### PR TITLE
Feature: Button's onClick is now optional.

### DIFF
--- a/packages/core/Button/CHANGELOG.md
+++ b/packages/core/Button/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 30/07/2019
+
+### Changed
+
+- `onClick` is now optional to enable scenarios where `<form onSubmit>` is defined.
+
 ## [0.0.1] - 23/07/2019
 
 ### Added

--- a/packages/core/Button/package.json
+++ b/packages/core/Button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/ui-core-button",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "lib/Button.js",
   "private": false,

--- a/packages/core/Button/src/Button.tsx
+++ b/packages/core/Button/src/Button.tsx
@@ -22,9 +22,9 @@ interface BaseProps {
   color?: Color;
 
   /**
-   * Callback for what needs to happen when the button is clicked.
+   *  Optional callback for what needs to happen when the button is clicked.
    */
-  onClick: (event: React.MouseEvent<HTMLElement>) => any;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => any;
 
   /**
    * Whether or not the action you are performing is currenlty in
@@ -114,6 +114,11 @@ export default function Button({
   const showSpinner = useShowSpinner(!!inProgress);
 
   function handleOnClick(event: React.MouseEvent<HTMLElement>) {
+    if (!onClick) {
+      return;
+    }
+
+
     if (!inProgress) {
       onClick(event);
     }

--- a/packages/core/Button/test/Button.test.tsx
+++ b/packages/core/Button/test/Button.test.tsx
@@ -133,24 +133,32 @@ describe('Component: Button', () => {
     let onClickSpy: jest.Mock<any, any>;
 
     describe('onClick', () => {
-      function setup({ inProgress }: { inProgress: boolean }) {
+      function setup({
+        inProgress,
+        hasOnClick
+      }: {
+        inProgress: boolean;
+        hasOnClick: boolean;
+      }) {
         onClickSpy = jest.fn();
 
         jest
           .spyOn({ useShowSpinner }, 'useShowSpinner')
           .mockReturnValue(inProgress);
 
-        button = shallow(
-          <Button onClick={onClickSpy} inProgress={inProgress}>
-            Save
-          </Button>
-        );
+        const props = {
+          onClick: hasOnClick ? onClickSpy : undefined,
+          inProgress
+        };
+
+        button = shallow(<Button {...props}>Save</Button>);
       }
 
       describe('button', () => {
         it('should call the onClick callback when inProgress is false', () => {
           setup({
-            inProgress: false
+            inProgress: false,
+            hasOnClick: true
           });
 
           const event = new Event('click');
@@ -168,7 +176,26 @@ describe('Component: Button', () => {
 
         it('should not call the onClick callback when inProgress is true and ignore the click', () => {
           setup({
-            inProgress: true
+            inProgress: true,
+            hasOnClick: true
+          });
+
+          const event = new Event('click');
+
+          // @ts-ignore
+          button
+            .find('Button')
+            .props()
+            // @ts-ignore
+            .onClick(event);
+
+          expect(onClickSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('should not call the onClick callback when onClick is undefined', () => {
+          setup({
+            inProgress: false,
+            hasOnClick: false
           });
 
           const event = new Event('click');

--- a/packages/core/ConfirmButton/package.json
+++ b/packages/core/ConfirmButton/package.json
@@ -14,7 +14,7 @@
     "lib/*"
   ],
   "dependencies": {
-    "@42.nl/ui-core-button": "0.0.1",
+    "@42.nl/ui-core-button": "0.0.2",
     "@42.nl/ui-core-icon": "0.0.1",
     "@42.nl/ui-types": "0.0.1",
     "classnames": "2.2.6"

--- a/packages/core/SubmitButton/package.json
+++ b/packages/core/SubmitButton/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@42.nl/ui-core-icon": "0.0.1",
-    "@42.nl/ui-core-button": "0.0.1",
+    "@42.nl/ui-core-button": "0.0.2",
     "classnames": "2.2.6"
   },
   "peerDependencies": {

--- a/packages/core/SubmitButton/src/SubmitButton.tsx
+++ b/packages/core/SubmitButton/src/SubmitButton.tsx
@@ -18,9 +18,9 @@ export interface Props {
   size?: 'lg' | 'sm' | 'md';
 
   /**
-   * Callback for what needs to happen when the button is clicked.
+   * Optional callback for what needs to happen when the button is clicked.
    */
-  onClick: (event: React.MouseEvent<HTMLElement>) => any;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => any;
 
   /**
    * The text of the button.

--- a/packages/core/_bundle/package.json
+++ b/packages/core/_bundle/package.json
@@ -24,7 +24,7 @@
     "@42.nl/ui-core-spinner": "0.0.1",
     "@42.nl/ui-core-more-or-less": "0.0.1",
     "@42.nl/ui-core-navigation-item": "0.0.1",
-    "@42.nl/ui-core-button": "0.0.1",
+    "@42.nl/ui-core-button": "0.0.2",
     "@42.nl/ui-core-confirm-button": "0.0.1",
     "@42.nl/ui-core-submit-button": "0.0.1",
     "@42.nl/ui-core-pagination": "0.0.1",


### PR DESCRIPTION
The reason for this is sometimes you do not want an onClick. The
`SubmitButton` for example is of type 'submit'. This means that you
can submit via the `<form onSubmit>` instead.

Closes #8