### PR TITLE
feat: improve Breadcrumbs functionality

### DIFF
--- a/packages/core/Breadcrumbs/example/Breadcrumbs.stories.tsx
+++ b/packages/core/Breadcrumbs/example/Breadcrumbs.stories.tsx
@@ -11,7 +11,8 @@ storiesOf('core|Breadcrumbs', module)
       <Breadcrumbs
         items={[
           { name: 'Dashboard', url: '/dashboard' },
-          { name: 'Users', url: '/users' }
+          { name: 'Users', url: '/users' },
+          { name: 'Library', active: true }
         ]}
       />
     </BrowserRouter>

--- a/packages/core/Breadcrumbs/package.json
+++ b/packages/core/Breadcrumbs/package.json
@@ -16,7 +16,8 @@
     "lib/*"
   ],
   "dependencies": {
-    "@42.nl/ui-core-styling": "1.0.0"
+    "@42.nl/ui-core-styling": "1.0.0",
+    "classnames": "2.2.6"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/core/Breadcrumbs/src/Breadcrumbs.scss
+++ b/packages/core/Breadcrumbs/src/Breadcrumbs.scss
@@ -18,9 +18,16 @@
 
   .breadcrumb {
     margin-right: $spacer;
-    background: white;
+    background: transparent;
     border-bottom: none;
     margin-bottom: 0;
+
+    .active {
+      span {
+        padding: 0.5rem 1rem;
+        display: inline-block;
+      }
+    }
 
     .breadcrumb-item + .breadcrumb-item {
       &::before {

--- a/packages/core/Breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/core/Breadcrumbs/src/Breadcrumbs.tsx
@@ -1,14 +1,47 @@
 import React from 'react';
 import { Breadcrumb as RBreadcrumb, BreadcrumbItem, NavLink } from 'reactstrap';
 import { NavLink as RRNavLink } from 'react-router-dom';
+import classNames from 'classnames';
+
+interface InactiveItem {
+  /**
+   * Url to navigate to the page.
+   */
+  url: string;
+
+  /**
+   * Name of the link that will get displayed.
+   */
+  name: string;
+}
+
+interface ActiveItem {
+  /**
+   * Name associated with the link.
+   */
+  name: string;
+
+  /**
+   * Determines wether a Breadcrumb item is active,
+   * in this case an url is not required.
+   */
+  active: boolean;
+}
+
+export type ItemProps = InactiveItem | ActiveItem;
 
 interface BreadcrumbsProps {
   /**
    * Collection of breadcrumbs you would like to show.
    *
-   * @default []
    */
-  items: { url: string; name: string }[];
+  items: ItemProps[];
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
 }
 
 /**
@@ -16,16 +49,24 @@ interface BreadcrumbsProps {
  *
  * Use it when you want to provide the user an easy way to navigate back to a specific page.
  */
-export default function Breadcrumbs({ items = [] }: BreadcrumbsProps) {
+export default function Breadcrumbs({ items, className }: BreadcrumbsProps) {
   return (
-    <div className="breadcrumb-wrapper">
+    <div className={classNames('breadcrumb-wrapper', className)}>
       <RBreadcrumb className="ml-auto">
-        {items.map(({ url, name }, index) => {
+        {items.map(item => {
+          const active = 'active' in item;
+          const name = item.name;
+          const url = 'url' in item ? item.url : undefined;
+
           return (
-            <BreadcrumbItem key={index}>
-              <NavLink to={url} exact tag={RRNavLink}>
-                {name}
-              </NavLink>
+            <BreadcrumbItem key={name} active={active}>
+              {active ? (
+                <span>{name}</span>
+              ) : (
+                <NavLink to={url} exact tag={RRNavLink}>
+                  {name}
+                </NavLink>
+              )}
             </BreadcrumbItem>
           );
         })}

--- a/packages/core/Breadcrumbs/test/Breadcrumbs.test.tsx
+++ b/packages/core/Breadcrumbs/test/Breadcrumbs.test.tsx
@@ -2,29 +2,34 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import Breadcrumbs from '../src/Breadcrumbs';
+import Breadcrumbs, { ItemProps } from '../src/Breadcrumbs';
 
 describe('Component: Breadcrumbs', () => {
   let breadcrumbs: ShallowWrapper;
 
-  function setup({ items }: { items?: { url: string; name: string }[] }) {
+  function setup({ items }: { items?: ItemProps[] }) {
     breadcrumbs = shallow(<Breadcrumbs items={items} />);
   }
 
   describe('ui', () => {
     test('default', () => {
-      setup({});
+      setup({ items: [{ name: 'Dashboard', url: '/dashboard' }] });
 
       expect(toJson(breadcrumbs)).toMatchSnapshot(
         'Component: Breadcrumbs => ui => default'
       );
     });
 
-    test('with items', () => {
-      setup({ items: [{ name: 'Dashboard', url: '/dashboard' }] });
+    test('with active', () => {
+      setup({
+        items: [
+          { name: 'Dashboard', url: '/dashboard' },
+          { name: 'Library', active: true }
+        ]
+      });
 
       expect(toJson(breadcrumbs)).toMatchSnapshot(
-        'Component: Breadcrumbs => ui => with items'
+        'Component: Breadcrumbs => ui => with active'
       );
     });
   });

--- a/packages/core/Breadcrumbs/test/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/core/Breadcrumbs/test/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -9,11 +9,25 @@ exports[`Component: Breadcrumbs ui default: Component: Breadcrumbs => ui => defa
     className="ml-auto"
     listTag="ol"
     tag="nav"
-  />
+  >
+    <BreadcrumbItem
+      active={false}
+      key="Dashboard"
+      tag="li"
+    >
+      <NavLink
+        exact={true}
+        tag={[Function]}
+        to="/dashboard"
+      >
+        Dashboard
+      </NavLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
 </div>
 `;
 
-exports[`Component: Breadcrumbs ui with items: Component: Breadcrumbs => ui => with items 1`] = `
+exports[`Component: Breadcrumbs ui with active: Component: Breadcrumbs => ui => with active 1`] = `
 <div
   className="breadcrumb-wrapper"
 >
@@ -24,7 +38,8 @@ exports[`Component: Breadcrumbs ui with items: Component: Breadcrumbs => ui => w
     tag="nav"
   >
     <BreadcrumbItem
-      key="0"
+      active={false}
+      key="Dashboard"
       tag="li"
     >
       <NavLink
@@ -34,6 +49,15 @@ exports[`Component: Breadcrumbs ui with items: Component: Breadcrumbs => ui => w
       >
         Dashboard
       </NavLink>
+    </BreadcrumbItem>
+    <BreadcrumbItem
+      active={true}
+      key="Library"
+      tag="li"
+    >
+      <span>
+        Library
+      </span>
     </BreadcrumbItem>
   </Breadcrumb>
 </div>


### PR DESCRIPTION
Previous version of Breadcrumbs did not accept an active item. By adding
the `InactiveItem` and `ActiveItem` distinction it now accepts `active`
accordingly.