### PR TITLE
Bugfix: enable bypassing of translation by providing a string

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,9 +10,9 @@ defaults:
     values:
       image: true
 links:
-  - icon: 'https://unpkg.com/simple-icons@latest/icons/github.svg'
-    name: 'View on Github'
+  - name: 'View on Github'
+    icon: 'https://unpkg.com/simple-icons@latest/icons/github.svg'
     href: 'https://github.com/42BV/ui'
-  - icon: 'https://unpkg.com/simple-icons@latest/icons/storybook.svg'
-    name: 'Storybook'
-    href: 'https://42bv.github.io/storybook'
+  - name: 'Storybook'
+    icon: 'https://unpkg.com/simple-icons@latest/icons/storybook.svg'
+    href: 'https://42bv.github.io/ui/storybook'

--- a/src/core/AsyncContent/AsyncContent.tsx
+++ b/src/core/AsyncContent/AsyncContent.tsx
@@ -27,7 +27,7 @@ export default function AsyncContent<T>(props: Props<T>) {
       <ContentState
         mode="loading"
         title={t({
-          key: 'ContentState.LOADING.TITLE',
+          key: 'AsyncContent.LOADING.TITLE',
           fallback: 'Loading...',
           overrideText: text.title
         })}
@@ -42,7 +42,7 @@ export default function AsyncContent<T>(props: Props<T>) {
         <ContentState
           mode="error"
           title={t({
-            key: 'ContentState.ERROR.TITLE',
+            key: 'AsyncContent.ERROR.TITLE',
             fallback: 'Oops something went wrong!',
             overrideText: text.title
           })}

--- a/src/form/FileInput/FileInput.test.tsx
+++ b/src/form/FileInput/FileInput.test.tsx
@@ -162,6 +162,6 @@ test('limitFileSize', () => {
   expect(validator(largeFile, {})).toEqual({
     data: { fileSize: '1.5', label: 'cv', size: '1.0' },
     fallback: 'cv file is to large. Max size is 1.0 MB file size is 1.5 MB',
-    key: 'FileInput.SIZE_TO_LARGE'
+    key: 'FileInput.SIZE_TOO_LARGE'
   });
 });

--- a/src/form/FileInput/FileInput.tsx
+++ b/src/form/FileInput/FileInput.tsx
@@ -217,7 +217,7 @@ export function limitFileSize(size: number, label: string): FileValidator {
     const maxSizeDisplay = size.toFixed(1);
 
     return {
-      key: 'FileInput.SIZE_TO_LARGE',
+      key: 'FileInput.SIZE_TOO_LARGE',
       data: { label, size: maxSizeDisplay, fileSize },
       fallback: `${label} file is to large. Max size is ${maxSizeDisplay} MB file size is ${fileSize} MB`
     };

--- a/src/form/FormError/utils.test.ts
+++ b/src/form/FormError/utils.test.ts
@@ -38,13 +38,10 @@ describe('errorMessage', () => {
   });
 
   test('Error is a string', () => {
-    errorMessage('Serious error');
+    const error = errorMessage('Serious error');
 
-    expect(t).toHaveBeenCalledTimes(1);
-    expect(t).toHaveBeenCalledWith({
-      fallback: 'Serious error',
-      key: 'Serious error'
-    });
+    expect(t).toHaveBeenCalledTimes(0);
+    expect(error).toEqual('Serious error');
   });
 
   test('Error is a Translation', () => {

--- a/src/form/FormError/utils.ts
+++ b/src/form/FormError/utils.ts
@@ -20,8 +20,9 @@ export function keyForError(error: MetaError) {
 export function errorMessage(error: MetaError): string {
   const translator = getTranslator();
 
+  // We consider it translated already
   if (typeof error === 'string') {
-    return translator({ key: error, fallback: error });
+    return error;
   }
 
   if ((error as ValidationError).type === undefined) {

--- a/src/form/ImageUpload/ImageUpload.test.tsx
+++ b/src/form/ImageUpload/ImageUpload.test.tsx
@@ -436,6 +436,6 @@ test('limitImageSize', () => {
     data: { fileSize: '2.2', label: 'profile picture', size: '1.0' },
     fallback:
       'profile picture image is to large. Max size is 1.0 MB image size is 2.2 MB',
-    key: 'ImageUpload.SIZE_TO_LARGE'
+    key: 'ImageUpload.SIZE_TOO_LARGE'
   });
 });

--- a/src/form/ImageUpload/ImageUpload.tsx
+++ b/src/form/ImageUpload/ImageUpload.tsx
@@ -509,7 +509,7 @@ export function limitImageSize(size: number, label: string): ImageValidator {
     const maxSizeDisplay = size.toFixed(1);
 
     return {
-      key: 'ImageUpload.SIZE_TO_LARGE',
+      key: 'ImageUpload.SIZE_TOO_LARGE',
       data: { label, size: maxSizeDisplay, fileSize },
       fallback: `${label} image is to large. Max size is ${maxSizeDisplay} MB image size is ${fileSize} MB`
     };


### PR DESCRIPTION
Sometimes a translated string is already passed through to the `translate` function provided by `@42.nl/ui`, which in turn tries to translate the translated string.

Additional changes:
* Fixed the link to the storybook in the documentation page.
* Renamed some translation keys to have correct spelling.