### PR TITLE
Improvement: dumped down the FlashMessage component.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.js": {
-    "bundled": 91509,
-    "minified": 44396,
-    "gzipped": 10880
+    "bundled": 90516,
+    "minified": 44012,
+    "gzipped": 10735
   },
   "dist/index.es.js": {
-    "bundled": 87119,
-    "minified": 40177,
-    "gzipped": 10578,
+    "bundled": 86145,
+    "minified": 39812,
+    "gzipped": 10439,
     "treeshaked": {
       "rollup": {
-        "code": 30042,
-        "import_statements": 1052
+        "code": 30032,
+        "import_statements": 1016
       },
       "webpack": {
-        "code": 33448
+        "code": 33404
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,6 @@
         "lodash.set": "^4.3.2"
       }
     },
-    "@42.nl/react-flash-messages": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@42.nl/react-flash-messages/-/react-flash-messages-0.0.2.tgz",
-      "integrity": "sha512-y/rR7BIpTg7ckIX5zhIzbG5ChexKGoZfjrXDYgWGJSj0um2p3/sQep4FzA7VOKKLMm3hGRinZzBdCMGds5BYag=="
-    },
     "@42.nl/spring-connect": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@42.nl/spring-connect/-/spring-connect-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@42.nl/jarb-final-form": "1.0.0",
     "@42.nl/react-error-store": "1.0.1",
-    "@42.nl/react-flash-messages": "0.0.2",
     "@42.nl/spring-connect": "4.0.0",
     "bootstrap": "4.3.1",
     "classnames": "2.2.6",

--- a/src/core/FlashMessage/FlashMessage.scss
+++ b/src/core/FlashMessage/FlashMessage.scss
@@ -1,14 +1,7 @@
-.flash-messages {
-  position: fixed;
-  height: 3.125rem;
-  left: 50%;
-  top: 1rem;
-  z-index: 9000;
-  transform: translateX(-50%);
-  @include media-breakpoint-down(sm) {
-    min-width: 90%;
-  }
-
+.flash-message {
+  position: relative;
+  margin-top: 1rem;
+  
   .close {
     position: relative;
     left: 74px;

--- a/src/core/FlashMessage/FlashMessage.stories.tsx
+++ b/src/core/FlashMessage/FlashMessage.stories.tsx
@@ -1,79 +1,26 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import FlashMessage from './FlashMessage';
-import { Button } from 'reactstrap';
-
-import {
-  addInfo,
-  addError,
-  addWarning,
-  addApocalypse,
-  addSuccess
-} from '@42.nl/react-flash-messages';
 
 storiesOf('core|FlashMessage', module)
   .addParameters({ component: FlashMessage })
   .add('default', () => {
     return (
-      <Fragment>
-        <FlashMessage />
-
-        <Button
-          onClick={() =>
-            addSuccess({
-              text: 'Success',
-              onClick: () => action('Success clicked')
-            })
-          }
-        >
+      <>
+        <FlashMessage color="success" onClose={action('success closed')}>
           Success
-        </Button>
-
-        <Button
-          onClick={() =>
-            addInfo({
-              text: 'Info',
-              onClick: () => action('Info clicked')
-            })
-          }
-        >
-          Info
-        </Button>
-
-        <Button
-          onClick={() =>
-            addError({
-              text: 'Error',
-              onClick: () => action('Error clicked')
-            })
-          }
-        >
-          Error
-        </Button>
-
-        <Button
-          onClick={() =>
-            addWarning({
-              text: 'Warning',
-              onClick: () => action('Warning clicked')
-            })
-          }
-        >
+        </FlashMessage>
+        <FlashMessage color="danger" onClose={action('danger closed')}>
           Warning
-        </Button>
-
-        <Button
-          onClick={() =>
-            addApocalypse({
-              text: 'Apocalypse',
-              onClick: () => action('Apocalypse clicked')
-            })
-          }
-        >
-          Apocalypse
-        </Button>
-      </Fragment>
+        </FlashMessage>
+        <FlashMessage color="warning" onClose={action('warning closed')}>
+          Warning
+        </FlashMessage>
+        <FlashMessage color="info" onClose={action('info closed')}>
+          Info
+        </FlashMessage>
+      </>
     );
   });

--- a/src/core/FlashMessage/FlashMessage.test.tsx
+++ b/src/core/FlashMessage/FlashMessage.test.tsx
@@ -1,107 +1,37 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import * as reactFlashMessages from '@42.nl/react-flash-messages';
 import FlashMessage from './FlashMessage';
 
 describe('Component: FlashMessage', () => {
-  let flashMessage: ShallowWrapper;
-
-  function setup({
-    messages
-  }: {
-    messages: reactFlashMessages.FlashMessageConfig<any>[];
-  }) {
-    reactFlashMessages.flashMessageService.clearFlashMessages();
-    messages.forEach(m => reactFlashMessages.addFlashMessage(m));
-    jest.spyOn(reactFlashMessages, 'removeFlashMessage');
-    flashMessage = shallow(<FlashMessage />);
-  }
-
-  test('ui', () => {
-    setup({
-      messages: [
-        {
-          type: 'INFO',
-          text: 'Epic info',
-          onClick: jest.fn(),
-          duration: 5000,
-          data: { age: 15 }
-        }
-      ]
+  describe('ui', () => {
+    test('normal', () => {
+      const flashMessage = shallow(
+        <FlashMessage color="danger">Danger commander</FlashMessage>
+      );
+  
+      expect(toJson(flashMessage)).toMatchSnapshot();
     });
-    expect(toJson(flashMessage)).toMatchSnapshot(
-      'Component: FlashMessage => ui'
-    );
-  });
 
-  test('empty messages array', () => {
-    setup({ messages: [] });
-    expect(toJson(flashMessage)).toMatchSnapshot(
-      'Component: FlashMessage => empty messages array'
-    );
-  });
-
-  test('message types', () => {
-    setup({
-      messages: [
-        {
-          type: 'INFO',
-          text: 'text',
-          onClick: jest.fn(),
-          duration: 5000,
-          data: { age: 1 }
-        },
-        {
-          type: 'SUCCESS',
-          text: 'text',
-          onClick: jest.fn(),
-          duration: 5000,
-          data: { age: 1 }
-        },
-        {
-          type: 'WARNING',
-          text: 'text',
-          onClick: jest.fn(),
-          duration: 5000,
-          data: { age: 1 }
-        },
-        {
-          type: 'ERROR',
-          text: 'text',
-          onClick: jest.fn(),
-          duration: 5000,
-          data: { age: 1 }
-        },
-        {
-          type: 'APOCALYPSE',
-          text: 'text',
-          onClick: jest.fn(),
-          duration: 5000,
-          data: { age: 1 }
-        }
-      ]
+    test('with extra css class', () => {
+      const flashMessage = shallow(
+        <FlashMessage className="extra-css-class" color="danger">Danger commander</FlashMessage>
+      );
+  
+      expect(flashMessage.find('.extra-css-class').exists()).toBe(true);
     });
-    expect(toJson(flashMessage)).toMatchSnapshot(
-      'Component: FlashMessage => message types'
+  })
+
+  test('onClose', () => {
+    const onCloseSpy = jest.fn();
+
+    const flashMessage = shallow(
+      <FlashMessage onClose={onCloseSpy}>
+        Warning commander
+      </FlashMessage>
     );
-  });
-
-  test('onFlashMessageClick', () => {
-    const onClickSpy = jest.fn();
-
-    const message = {
-      id: 42,
-      type: 'INFO',
-      text: 'Epic info',
-      onClick: onClickSpy,
-      duration: 5000,
-      data: { age: 15 }
-    };
-
-    setup({ messages: [message] });
 
     flashMessage
       .find('Alert')
@@ -109,10 +39,6 @@ describe('Component: FlashMessage', () => {
       // @ts-ignore
       .toggle();
 
-    expect(onClickSpy).toHaveBeenCalledTimes(1);
-    expect(onClickSpy).toHaveBeenCalledWith(message);
-
-    expect(reactFlashMessages.removeFlashMessage).toHaveBeenCalledTimes(1);
-    expect(reactFlashMessages.removeFlashMessage).toHaveBeenCalledWith(message);
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/FlashMessage/FlashMessage.tsx
+++ b/src/core/FlashMessage/FlashMessage.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Alert } from 'reactstrap';
 import classNames from 'classnames';
-import {
-  removeFlashMessage,
-  FlashMessage as FlashMessageShape,
-  useFlashMessages
-} from '@42.nl/react-flash-messages';
+
+import { Color } from '../types';
 
 interface Props {
   /**
@@ -13,63 +10,38 @@ interface Props {
    * Useful for styling the component.
    */
   className?: string;
+
+  /**
+   * Optional callback for what needs to happen when the flash-message is closed.
+   */
+  onClose?: () => void;
+
+  /**
+   * Optionally the color of the button.
+   */
+  color?: Color;
+
+   /**
+   * The text of the flash message.
+   */
+  children: React.ReactNode;
 }
 
 /**
- * FlashMessage is a graphical implementation for https://github.com/42BV/react-flash-messages.
+ * A FlashMessage is a message you want to show to the user briefly.
  *
  * Use it when you want to globally show a notification / message.
  */
-export default function FlashMessage({ className }: Props) {
-  const flashMessages = useFlashMessages();
-
-  if (flashMessages.length === 0) {
-    return null;
-  }
-
-  /**
-   * Remove FlashMessage upon clicking.
-   *
-   * @param flashMessage
-   */
-  function onFlashMessageClick(flashMessage: FlashMessageShape<any>) {
-    flashMessage.onClick();
-    removeFlashMessage(flashMessage);
-  }
-
+export default function FlashMessage({ className, onClose, color, children }: Props) {
   return (
-    <div className={classNames('flash-messages', className)}>
-      {flashMessages.map((flashMessage: FlashMessageShape<any>) => (
-        <Alert
-          color={messageColorByType(flashMessage.type)}
-          key={flashMessage.id}
-          open={true}
-          toggle={() => onFlashMessageClick(flashMessage)}
-        >
-          {flashMessage.text}
-        </Alert>
-      ))}
+    <div className={classNames('flash-message', className)}>
+      <Alert
+        color={color}
+        open={true}
+        toggle={onClose}
+      >
+        {children}
+      </Alert>
     </div>
   );
-}
-
-/**
- * Assign bootstrap colors to specific FlashMessage types.
- *
- * @param {string} type
- * @returns {string}
- */
-function messageColorByType(type: string): string {
-  switch (type) {
-    case 'SUCCESS':
-      return 'success';
-    case 'WARNING':
-      return 'warning';
-    case 'ERROR':
-    case 'APOCALYPSE':
-      return 'danger';
-    case 'INFO':
-    default:
-      return 'info';
-  }
 }

--- a/src/core/FlashMessage/__snapshots__/FlashMessage.test.tsx.snap
+++ b/src/core/FlashMessage/__snapshots__/FlashMessage.test.tsx.snap
@@ -1,116 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: FlashMessage empty messages array: Component: FlashMessage => empty messages array 1`] = `""`;
-
-exports[`Component: FlashMessage message types: Component: FlashMessage => message types 1`] = `
+exports[`Component: FlashMessage ui normal 1`] = `
 <div
-  className="flash-messages"
+  className="flash-message"
 >
-  <Alert
-    closeAriaLabel="Close"
-    color="info"
-    fade={true}
-    isOpen={true}
-    key="2"
-    open={true}
-    tag="div"
-    toggle={[Function]}
-    transition={
-      Object {
-        "appear": true,
-        "baseClass": "fade",
-        "baseClassActive": "show",
-        "enter": true,
-        "exit": true,
-        "in": true,
-        "mountOnEnter": false,
-        "onEnter": [Function],
-        "onEntered": [Function],
-        "onEntering": [Function],
-        "onExit": [Function],
-        "onExited": [Function],
-        "onExiting": [Function],
-        "tag": "div",
-        "timeout": 150,
-        "unmountOnExit": true,
-      }
-    }
-  >
-    text
-  </Alert>
-  <Alert
-    closeAriaLabel="Close"
-    color="success"
-    fade={true}
-    isOpen={true}
-    key="3"
-    open={true}
-    tag="div"
-    toggle={[Function]}
-    transition={
-      Object {
-        "appear": true,
-        "baseClass": "fade",
-        "baseClassActive": "show",
-        "enter": true,
-        "exit": true,
-        "in": true,
-        "mountOnEnter": false,
-        "onEnter": [Function],
-        "onEntered": [Function],
-        "onEntering": [Function],
-        "onExit": [Function],
-        "onExited": [Function],
-        "onExiting": [Function],
-        "tag": "div",
-        "timeout": 150,
-        "unmountOnExit": true,
-      }
-    }
-  >
-    text
-  </Alert>
-  <Alert
-    closeAriaLabel="Close"
-    color="warning"
-    fade={true}
-    isOpen={true}
-    key="4"
-    open={true}
-    tag="div"
-    toggle={[Function]}
-    transition={
-      Object {
-        "appear": true,
-        "baseClass": "fade",
-        "baseClassActive": "show",
-        "enter": true,
-        "exit": true,
-        "in": true,
-        "mountOnEnter": false,
-        "onEnter": [Function],
-        "onEntered": [Function],
-        "onEntering": [Function],
-        "onExit": [Function],
-        "onExited": [Function],
-        "onExiting": [Function],
-        "tag": "div",
-        "timeout": 150,
-        "unmountOnExit": true,
-      }
-    }
-  >
-    text
-  </Alert>
   <Alert
     closeAriaLabel="Close"
     color="danger"
     fade={true}
     isOpen={true}
-    key="5"
     open={true}
     tag="div"
-    toggle={[Function]}
     transition={
       Object {
         "appear": true,
@@ -132,78 +32,7 @@ exports[`Component: FlashMessage message types: Component: FlashMessage => messa
       }
     }
   >
-    text
-  </Alert>
-  <Alert
-    closeAriaLabel="Close"
-    color="danger"
-    fade={true}
-    isOpen={true}
-    key="6"
-    open={true}
-    tag="div"
-    toggle={[Function]}
-    transition={
-      Object {
-        "appear": true,
-        "baseClass": "fade",
-        "baseClassActive": "show",
-        "enter": true,
-        "exit": true,
-        "in": true,
-        "mountOnEnter": false,
-        "onEnter": [Function],
-        "onEntered": [Function],
-        "onEntering": [Function],
-        "onExit": [Function],
-        "onExited": [Function],
-        "onExiting": [Function],
-        "tag": "div",
-        "timeout": 150,
-        "unmountOnExit": true,
-      }
-    }
-  >
-    text
-  </Alert>
-</div>
-`;
-
-exports[`Component: FlashMessage ui: Component: FlashMessage => ui 1`] = `
-<div
-  className="flash-messages"
->
-  <Alert
-    closeAriaLabel="Close"
-    color="info"
-    fade={true}
-    isOpen={true}
-    key="1"
-    open={true}
-    tag="div"
-    toggle={[Function]}
-    transition={
-      Object {
-        "appear": true,
-        "baseClass": "fade",
-        "baseClassActive": "show",
-        "enter": true,
-        "exit": true,
-        "in": true,
-        "mountOnEnter": false,
-        "onEnter": [Function],
-        "onEntered": [Function],
-        "onEntering": [Function],
-        "onExit": [Function],
-        "onExited": [Function],
-        "onExiting": [Function],
-        "tag": "div",
-        "timeout": 150,
-        "unmountOnExit": true,
-      }
-    }
-  >
-    Epic info
+    Danger commander
   </Alert>
 </div>
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,6 @@ export { default as FormError } from './form/FormError/FormError';
 // Utilities
 export { t } from './utilities/translation/translation';
 export { setTranslator } from './utilities/translation/translator';
+
+// Types
+export { Color } from './core/types';


### PR DESCRIPTION
Before the `FlashMessage` component used the `@42.nl/react-flash-messages`
library to render and close the flash messages. This is to much knowledge
of the way flash messages work. Now the flash message is simply a UI
component which does not know anything about `@42.nl/react-flash-messages`.

The styling has also been changed: it now renders in the full width of
the given container, and it now longer renders on a fixed position.
This is done because the `FlashMessage` no longer knows were it is
rendered anymore.

Users of `@42.nl/ui` should now implement their own flash message engine
or simply use: ``@42.nl/react-flash-messages`.

Also exposed `Color` in the default export.

Closes #78