### PR TITLE
Pager component, Button improvements, and translation docs.

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,140 @@
+---
+layout: default
+title: Translations
+description: 'Translations within @42.nl/ui.'
+permalink: /translations
+nav_order: 4
+---
+
+## Translations
+
+Within the `@42.nl/ui` we support translating every text that the
+library renders. By default however every text has a `fallback` text
+which is in english. This way there is always a text for the user
+to see.
+
+There are two ways to `translate` or `override` these default text.
+
+### Overriding
+
+All components provide a `text` property containing all text which
+the component renders. For example:
+
+```ts
+<Pager
+  page={page}
+  onChange={action('page changed')}
+  text={{ next: 'Volgende', previous: 'Vorige' }}
+/>
+```
+
+Here we use the `text` property to override the `next` and `previous`
+text on the `Pager` component. When you override a text it should
+be translated already.
+
+### Translating
+
+Another option would be to provide your own `translator` function.
+All texts are by default translated before they are rendered, by
+default the `fallback` language is rendered.
+
+Here is an example on how to configure the `translator`:
+
+```ts
+import { setTranslator } from '@42.nl/ui';
+
+/**
+ * Translation provider is given a key and data and is expected
+ * to return a translated string.
+ */
+setTranslator(({ key, data }) => {
+  /*
+    All translations are given a `key` which is a string, and
+    data which is an object containing extra keys.
+
+    The data object will often contain things like the label for
+    an error message, or an amount of things.
+  */
+
+  return // translated string here...
+};
+
+```
+
+Here is a JSON notation containing all keys and default translations:
+
+```json
+{
+  "AsyncContent": {
+    "LOADING": {
+      "TITLE": "Loading..."
+    },
+    "ERROR": {
+      "TITLE": "Oops something went wrong!"
+    }
+  },
+  "ConfirmButton": {
+    "MODAL_HEADER": "Confirmation",
+    "CANCEL": "Cancel",
+    "CONFIRM": "Confirm"
+  },
+  "MoreOrLess": {
+    "LESS": "Show less",
+    "MORE": "Show {{amount}} more"
+  },
+  "DateRangePicker": {
+    "DATE_RANGE_ERROR": "The {{from}} must be before the {{to}}"
+  },
+  "ImageUpload": {
+    "CHANGE": "Change",
+    "REMOVE": "Remove",
+    "CANCEL": "Cancel",
+    "DONE": "Done",
+    "REQUIRED": "{{label}} is required",
+    "SIZE_TOO_LARGE": "{{label}} image is to large. Max size is {{maxSizeDisplay}} MB image size is {{fileSize}} MB"
+  },
+  "EmptyModal": {
+    "NO_RESULTS": {
+      "TITLE": "No results",
+      "SUBTITLE": "No results were found please try again with a different query."
+    },
+    "EMPTY": {
+      "TITLE": "No results",
+      "SUBTITLE": "There is nothing here yet, the collection is empty."
+    }
+  },
+  "ModalPicker": {
+    "SEARCH": "Search...",
+    "CANCEL": "Cancel",
+    "SELECT": "Select"
+  },
+  "Select": {
+    "LOADING": "Loading..."
+  },
+  "FileInput": {
+    "REQUIRED": "{{label}} is required",
+    "SIZE_TOO_LARGE": "{{label}} file is to large. Max size is {{maxSizeDisplay}} MB file size is {{fileSize}} MB"
+  },
+  "JarbFinalForm": {
+    "VALIDATION": {
+      "REQUIRED": "{{label}} is required",
+      "MINIMUM_LENGTH": "{{label}} must be bigger than {{validationError.reasons.minimumLength}} characters",
+      "MAXIMUM_LENGTH": "{{label}} must be smaller than {{reasons.maximumLength}} characters",
+      "MIN_VALUE": "{{label}} must be more than {{reasons.minValue}}",
+      "MAX_VALUE": "{{label}} must be less than {{reasons.maxValue}}",
+      "NUMBER": "{{label}} is not a number",
+      "NUMBER_FRACTION": "{{label}} is not a number. Number may have {{reasons.fractionLength}} digits behind the comma"
+    }
+  },
+  "FormError": {
+    "UNKNOWN_ERROR": "Something is wrong"
+  },
+  "Pager": {
+    "NEXT": "Next",
+    "PREVIOUS": "Previous"
+  }
+}
+```
+
+The JSON is nested to make it more readable. But a key you might
+be given is `Pager.NEXT` or `JarbFinalForm.VALIDATION.REQUIRED`.

--- a/src/core/Button/Button.scss
+++ b/src/core/Button/Button.scss
@@ -17,12 +17,21 @@
       vertical-align: middle;
       font-size: 1rem;
       margin-bottom: 2px;
+      margin-right: 5px;
+
+      &-right {
+        float: right;
+        margin-top: 3px;
+        margin-right: 0px;
+        margin-left: 5px;
+      }
     }
 
     .spinner {
       position: relative;
       top: -2px;
       left: -5px;
+      margin-left: 5px;
     }
   }
 

--- a/src/core/Button/Button.stories.tsx
+++ b/src/core/Button/Button.stories.tsx
@@ -123,6 +123,58 @@ storiesOf('core|buttons/Button', module)
           <hr />
         </Col>
         <Col xs={12}>
+          <h4>Button with icon right</h4>
+          <Button
+            icon="save"
+            iconPosition="right"
+            onClick={action('Button clicked')}
+            color="primary"
+          >
+            primary
+          </Button>
+          <Button
+            icon="save"
+            iconPosition="right"
+            onClick={action('Button clicked')}
+            color="secondary"
+          >
+            secondary
+          </Button>
+          <Button
+            icon="save"
+            iconPosition="right"
+            onClick={action('Button clicked')}
+            color="success"
+          >
+            success
+          </Button>
+          <Button
+            icon="save"
+            iconPosition="right"
+            onClick={action('Button clicked')}
+            color="info"
+          >
+            info
+          </Button>
+          <Button
+            icon="save"
+            iconPosition="right"
+            onClick={action('Button clicked')}
+            color="warning"
+          >
+            warning
+          </Button>
+          <Button
+            icon="save"
+            iconPosition="right"
+            onClick={action('Button clicked')}
+            color="danger"
+          >
+            danger
+          </Button>
+          <hr />
+        </Col>
+        <Col xs={12}>
           <h4>Button with icon in progress</h4>
           <Button
             icon="save"
@@ -329,6 +381,64 @@ storiesOf('core|buttons/Button', module)
           <Button
             onClick={action('Button clicked')}
             icon="save"
+            outline={true}
+            color="danger"
+          >
+            danger
+          </Button>
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Outline with icon right</h4>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            iconPosition="right"
+            outline={true}
+            color="primary"
+          >
+            primary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            iconPosition="right"
+            outline={true}
+            color="secondary"
+          >
+            secondary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            iconPosition="right"
+            outline={true}
+            color="success"
+          >
+            success
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            iconPosition="right"
+            outline={true}
+            color="info"
+          >
+            info
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            iconPosition="right"
+            outline={true}
+            color="warning"
+          >
+            warning
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            iconPosition="right"
             outline={true}
             color="danger"
           >

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -75,6 +75,16 @@ describe('Component: Button', () => {
 
           expect(toJson(button)).toMatchSnapshot();
         });
+
+        test('with icon on the right', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} icon="save" iconPosition="right">
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
       });
 
       describe('outline', () => {

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -7,6 +7,8 @@ import useShowSpinner from './useShowSpinner';
 
 import { Color } from '../types';
 
+export type IconPosition = 'left' | 'right';
+
 interface BaseProps {
   /**
    * Optionally the type of button it is, defaults to 'button'.
@@ -46,6 +48,8 @@ interface WithIconAndText extends BaseProps {
    * Optionally the Icon you want to use.
    */
   icon: IconType;
+
+  iconPosition?: IconPosition;
 
   /**
    * Optionally the text of the button.
@@ -128,6 +132,7 @@ export default function Button({
   if (children !== undefined) {
     const outline = 'outline' in props ? props.outline : undefined;
     const size = 'size' in props ? props.size : 'md';
+    const iconPosition = 'iconPosition' in props ? props.iconPosition : 'left';
 
     const buttonProps = {
       type,
@@ -146,7 +151,7 @@ export default function Button({
           {showSpinner ? (
             <Spinner size={16} color={outline ? '' : 'white'} />
           ) : icon !== undefined ? (
-            <Icon icon={icon} />
+            <Icon icon={icon} className={`material-icons-${iconPosition}`} />
           ) : null}
           {children}
         </RSButton>

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`Component: Button ui button with icon normal inProgress is false 1`] = 
     type="button"
   >
     <Icon
+      className="material-icons-left"
       icon="save"
     />
     Save
@@ -119,6 +120,26 @@ exports[`Component: Button ui button with icon normal inProgress is true 1`] = `
 </span>
 `;
 
+exports[`Component: Button ui button with icon normal with icon on the right 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    <Icon
+      className="material-icons-right"
+      icon="save"
+    />
+    Save
+  </Button>
+</span>
+`;
+
 exports[`Component: Button ui button with icon outline inProgress is false 1`] = `
 <span
   className="button  primary"
@@ -133,6 +154,7 @@ exports[`Component: Button ui button with icon outline inProgress is false 1`] =
     type="button"
   >
     <Icon
+      className="material-icons-left"
       icon="save"
     />
     Save

--- a/src/core/Pager/Pager.stories.tsx
+++ b/src/core/Pager/Pager.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import Pager from './Pager';
+
+storiesOf('core|Pager', module)
+  .addParameters({ component: Pager })
+  .add('default', () => {
+    const page = {
+      content: [1, 2, 3],
+      last: false,
+      totalElements: 100,
+      totalPages: 10,
+      size: 10,
+      number: 5,
+      first: false,
+      numberOfElements: 10
+    };
+
+    return (
+      <div className="text-center">
+        <Pager page={page} onChange={action('page changed')} />
+      </div>
+    );
+  });

--- a/src/core/Pager/Pager.test.tsx
+++ b/src/core/Pager/Pager.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { Page } from '@42.nl/spring-connect';
+
+import Pager from './Pager';
+
+describe('Component: Pager', () => {
+  let pager: ShallowWrapper;
+  let onChangeSpy: jest.Mock<any, any>;
+
+  function setup({
+    number,
+    totalPages
+  }: {
+    number: number;
+    totalPages: number;
+  }) {
+    const page: Page<any> = {
+      content: [],
+      last: number === totalPages,
+      totalElements: 100,
+      totalPages,
+      size: 10,
+      number,
+      first: number === 1,
+      numberOfElements: 10
+    };
+
+    onChangeSpy = jest.fn();
+
+    const props = {
+      page,
+      onChange: onChangeSpy
+    };
+
+    pager = shallow(<Pager {...props} />);
+  }
+
+  describe('ui', () => {
+    test('empty', () => {
+      setup({ number: 1, totalPages: 1 });
+
+      expect(pager.isEmptyRender()).toBe(true);
+    });
+
+    test('normal', () => {
+      setup({ number: 5, totalPages: 10 });
+
+      expect(toJson(pager)).toMatchSnapshot(
+        'Component: Pager => normal'
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('should call onChange when previous or next button is clicked', () => {
+      setup({ number: 5, totalPages: 10 });
+
+      const buttons = pager.find('Button');
+
+      const next = buttons.at(0);
+      const previous = buttons.at(1);
+
+      next.simulate('click');
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+      expect(onChangeSpy).toHaveBeenCalledWith(4);
+
+      previous.simulate('click');
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(2);
+      expect(onChangeSpy).toHaveBeenCalledWith(6);
+    });
+  });
+});
+

--- a/src/core/Pager/Pager.tsx
+++ b/src/core/Pager/Pager.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Page } from '@42.nl/spring-connect';
+import classNames from 'classnames';
+
+import { t } from '../../utilities/translation/translation';
+import Button from '../Button/Button';
+
+interface Text {
+  /**
+   * The text to show as the next button's text, defaults to "Next"
+   *
+   * @default Cancel
+   */
+  next?: string;
+
+  /**
+   * The text to show as the previous button's text, defaults to "Previous"
+   *
+   * @default OK
+   */
+  previous?: string;
+
+  /**
+   * Optionally customized text to use within the component.
+   */
+  text?: Text;
+}
+
+interface Props<T> {
+  /**
+   * Represents Spring's page abstraction.
+   */
+  page: Page<T>;
+
+  /**
+   * Called when navigation to a certain page number.
+   */
+  onChange: (pageNumber: number) => void;
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
+
+  /**
+   * Optionally customized text to use within the component.
+   */
+  text?: Text;
+}
+
+/**
+ * The Pager component shows a small variant of bootstraps pagination,
+ * it only shows a previous and next button.
+ *
+ * It supports working with a `Page` from `@42.nl/spring-connect`.
+ */
+export default function Pager<T>({
+  page,
+  onChange,
+  className,
+  text = {}
+}: Props<T>) {
+  const { first, last } = page;
+  const { next, previous } = text;
+
+  // Don't bother to render if there is nothing to paginate.
+  if (first && last) {
+    return null;
+  }
+
+  return (
+    <div className={classNames('pager', className)}>
+      <Button
+        className="mr-1"
+        outline
+        icon="arrow_back"
+        onClick={() => onChange(page.number - 1)}
+      >
+        {t({
+          overrideText: previous,
+          key: 'Pager.PREVIOUS',
+          fallback: 'Previous'
+        })}
+      </Button>
+
+      <Button
+        outline
+        className="pager-next"
+        icon="arrow_forward"
+        iconPosition="right"
+        onClick={() => onChange(page.number + 1)}
+      >
+        {t({
+          overrideText: next,
+          key: 'Pager.NEXT',
+          fallback: 'Next'
+        })}
+      </Button>
+    </div>
+  );
+}

--- a/src/core/Pager/__snapshots__/Pager.test.tsx.snap
+++ b/src/core/Pager/__snapshots__/Pager.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: Pager ui normal: Component: Pager => normal 1`] = `
+<div
+  className="pager"
+>
+  <Button
+    className="mr-1"
+    icon="arrow_back"
+    onClick={[Function]}
+    outline={true}
+  >
+    Previous
+  </Button>
+  <Button
+    className="pager-next"
+    icon="arrow_forward"
+    iconPosition="right"
+    onClick={[Function]}
+    outline={true}
+  >
+    Next
+  </Button>
+</div>
+`;


### PR DESCRIPTION
### Pager
Feature: Added `Pager` component.
    
 The Pager component shows a small variant of bootstraps pagination,
 it only shows a previous and next button.
    
It supports working with a `Page` from `@42.nl/spring-connect`.

### Button
Improvement: Button now support placing the icon on the right.
    
Also fixed the spacing between the text and the icon in the button.
