### PR TITLE
Improvement: `AsyncContent` now shows retry button on failure.

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -70,7 +70,8 @@ Here is a JSON notation containing all keys and default translations:
       "TITLE": "Loading..."
     },
     "ERROR": {
-      "TITLE": "Oops something went wrong!"
+      "TITLE": "Oops something went wrong!",
+      "RETRY": "Retry"
     }
   },
   "ConfirmButton": {

--- a/src/core/AsyncContent/AsyncContent.stories.tsx
+++ b/src/core/AsyncContent/AsyncContent.stories.tsx
@@ -13,7 +13,11 @@ function loadData() {
 }
 
 function rejectData() {
-  return Promise.reject('could not load');
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject('could not load');
+    }, 1000);
+  });
 }
 
 function loadingData() {
@@ -46,12 +50,48 @@ storiesOf('core|AsyncContent', module)
     );
   })
 
+  .add('when error with custom text', () => {
+    const state = useAsync(rejectData);
+
+    return (
+      <div className="text-center">
+        <AsyncContent state={state} text={{ error: "I’m sorry Dave, I’m afraid I can’t do that" }}>
+          {(data: { user: string }) => <h2>Hi, {data.user}</h2>}
+        </AsyncContent>
+      </div>
+    );
+  })
+
+  .add('when error with no retry button', () => {
+    const state = useAsync(rejectData);
+
+    return (
+      <div className="text-center">
+        <AsyncContent state={state} showRetryButton={false}>
+          {(data: { user: string }) => <h2>Hi, {data.user}</h2>}
+        </AsyncContent>
+      </div>
+    );
+  })
+
   .add('when loading', () => {
     const state = useAsync(loadingData);
 
     return (
       <div className="text-center">
         <AsyncContent state={state}>
+          {(data: { user: string }) => <h2>Hi, {data.user}</h2>}
+        </AsyncContent>
+      </div>
+    );
+  })
+
+  .add('when loading with custom title', () => {
+    const state = useAsync(loadingData);
+
+    return (
+      <div className="text-center">
+        <AsyncContent state={state} text={{ loading: "Loading Jeffrey" }}>
           {(data: { user: string }) => <h2>Hi, {data.user}</h2>}
         </AsyncContent>
       </div>

--- a/src/core/AsyncContent/AsyncContent.test.tsx
+++ b/src/core/AsyncContent/AsyncContent.test.tsx
@@ -4,18 +4,29 @@ import toJson from 'enzyme-to-json';
 
 import AsyncContent from './AsyncContent';
 
+type State = {
+  isLoading: boolean;
+  isFulfilled?: boolean;
+  data?: string;
+  error?: string;
+  reload: () => void;
+};
+
 describe('Component: AsyncContent', () => {
-  function setup(state: {
-    isLoading: boolean;
-    isFulfilled?: boolean;
-    data?: string;
-    error?: string;
+  function setup({
+    state,
+    showRetryButton = undefined
+  }: {
+    state: State;
+    showRetryButton?: boolean;
   }) {
     jest.spyOn(console, 'error');
 
     const asyncContent = shallow(
       // @ts-ignore
-      <AsyncContent state={state}>{data => <h2>{data}</h2>}</AsyncContent>
+      <AsyncContent state={state} showRetryButton={showRetryButton}>
+        {data => <h2>{data}</h2>}
+      </AsyncContent>
     );
 
     return { asyncContent };
@@ -23,10 +34,11 @@ describe('Component: AsyncContent', () => {
 
   test('when loading', () => {
     const state = {
-      isLoading: true
+      isLoading: true,
+      reload: () => undefined
     };
 
-    const { asyncContent } = setup(state);
+    const { asyncContent } = setup({ state });
     expect(toJson(asyncContent)).toMatchSnapshot();
     expect(console.error).toHaveBeenCalledTimes(0);
   });
@@ -35,27 +47,71 @@ describe('Component: AsyncContent', () => {
     const state = {
       isLoading: false,
       isFulfilled: true,
-      data: 'importantos data'
+      data: 'importantos data',
+      reload: () => undefined
     };
 
-    const { asyncContent } = setup(state);
+    const { asyncContent } = setup({ state });
 
     expect(toJson(asyncContent)).toMatchSnapshot();
     expect(console.error).toHaveBeenCalledTimes(0);
   });
 
-  test('when rejected', () => {
-    jest.spyOn(console, 'error');
-    const state = {
-      isLoading: false,
-      isFulfilled: false,
-      error: 'something error'
-    };
+  describe('when rejected', () => {
+    test('with retry button', () => {
+      const reloadSpy = jest.fn();
 
-    const { asyncContent } = setup(state);
+      jest.spyOn(console, 'error');
+      const state = {
+        isLoading: false,
+        isFulfilled: false,
+        error: 'something error',
+        reload: reloadSpy
+      };
 
-    expect(toJson(asyncContent)).toMatchSnapshot();
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith('something error');
+      const { asyncContent } = setup({ state, showRetryButton: true });
+
+      expect(toJson(asyncContent)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith('something error');
+
+      asyncContent.find('Button').simulate('click');
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('without retry button', () => {
+      jest.spyOn(console, 'error');
+      const state = {
+        isLoading: false,
+        isFulfilled: false,
+        error: 'something error',
+        reload: () => undefined
+      };
+
+      const { asyncContent } = setup({ state, showRetryButton: false });
+
+      expect(toJson(asyncContent)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith('something error');
+    });
+
+    test('should not render when showRetryButton is undefined', () => {
+      const reloadSpy = jest.fn();
+
+      jest.spyOn(console, 'error');
+      const state = {
+        isLoading: false,
+        isFulfilled: false,
+        error: 'something error',
+        reload: reloadSpy
+      };
+
+      const { asyncContent } = setup({ state });
+
+      expect(toJson(asyncContent)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith('something error');
+    });
   });
 });

--- a/src/core/AsyncContent/AsyncContent.tsx
+++ b/src/core/AsyncContent/AsyncContent.tsx
@@ -3,13 +3,36 @@ import { AsyncState } from 'react-async';
 
 import ContentState from '../ContentState/ContentState';
 import { t } from '../../utilities/translation/translation';
+import Button from '../Button/Button';
 
 interface Text {
-  title?: string;
+  /**
+   * Error text to show when an error occurred.
+   */
+  error?: string;
+
+  /**
+   * Loading text to show when a request is being fetched.
+   */
+  loading?: string;
+
+  /**
+   * Text to show within the `retry` button.
+   */
+  retry?: string;
 }
 
 type Props<T> = {
+  /**
+   * Render function which takes the `data` from the `useAsync`'s
+   * `state` when the promise is fulfilled, and expects a you
+   * to render content.
+   */
   children: (data: T) => React.ReactNode;
+
+  /**
+   * Result from calling `useAsync` from `react-async`.
+   */
   state: AsyncState<T>;
 
   /**
@@ -17,10 +40,36 @@ type Props<T> = {
    * This text should already be translated.
    */
   text?: Text;
+
+  /**
+   * Optionally whether or not to show a retry button when the
+   * error state occurs. Defaults to `true`.
+   *
+   * @default true
+   */
+  showRetryButton?: boolean;
 };
 
+/**
+ * AsyncContent is a component which can be used to render the
+ * result of a call to `useAsync` from `react-async`.
+ *
+ * It has the following behaviors:
+ *
+ * 1. When the state is loading it shows a `ContentState` in the `loading` mode.
+ *
+ * 2. When an error occurs it shows a `ContentState` in the `error` mode.
+ *    By default it will then show a `Retry` button allowing the user
+ *    to try again.
+ *
+ * 3. When the state has loaded successfully it will render the `children`
+ *    render function and it provides the `state.data` for you to render.
+ *
+ * With these behaviors you ensure that you always handle the error and
+ * loading state when using `useAsync`.
+ */
 export default function AsyncContent<T>(props: Props<T>) {
-  const { state, text = {} } = props;
+  const { state, text = {}, showRetryButton = true } = props;
 
   if (state.isLoading) {
     return (
@@ -29,7 +78,7 @@ export default function AsyncContent<T>(props: Props<T>) {
         title={t({
           key: 'AsyncContent.LOADING.TITLE',
           fallback: 'Loading...',
-          overrideText: text.title
+          overrideText: text.loading
         })}
       />
     );
@@ -44,9 +93,19 @@ export default function AsyncContent<T>(props: Props<T>) {
           title={t({
             key: 'AsyncContent.ERROR.TITLE',
             fallback: 'Oops something went wrong!',
-            overrideText: text.title
+            overrideText: text.error
           })}
-        />
+        >
+          {showRetryButton ? (
+            <Button icon="refresh" onClick={() => state.reload()}>
+              {t({
+                key: 'AsyncContent.ERROR.RETRY',
+                fallback: 'Retry',
+                overrideText: text.retry
+              })}
+            </Button>
+          ) : null}
+        </ContentState>
       );
     }
   }

--- a/src/core/AsyncContent/__snapshots__/AsyncContent.test.tsx.snap
+++ b/src/core/AsyncContent/__snapshots__/AsyncContent.test.tsx.snap
@@ -15,7 +15,35 @@ exports[`Component: AsyncContent when loading 1`] = `
 />
 `;
 
-exports[`Component: AsyncContent when rejected 1`] = `
+exports[`Component: AsyncContent when rejected should not render when showRetryButton is undefined 1`] = `
+<ContentState
+  mode="error"
+  title="Oops something went wrong!"
+>
+  <Button
+    icon="refresh"
+    onClick={[Function]}
+  >
+    Retry
+  </Button>
+</ContentState>
+`;
+
+exports[`Component: AsyncContent when rejected with retry button 1`] = `
+<ContentState
+  mode="error"
+  title="Oops something went wrong!"
+>
+  <Button
+    icon="refresh"
+    onClick={[Function]}
+  >
+    Retry
+  </Button>
+</ContentState>
+`;
+
+exports[`Component: AsyncContent when rejected without retry button 1`] = `
 <ContentState
   mode="error"
   title="Oops something went wrong!"


### PR DESCRIPTION
When the `retry` button is `clicked` a call to `useAsync` return value
`reload` is called. By default this functionality is enabled but can
be disabled by setting `showRetryButton` to `false`.

Added better jsdoc documentation as well.

Also the title for the `loading` and `error` state can now be overridden
by the user.

Closes: #68