### PR TITLE
Improvement: add @42.nl/jarb-final-form to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "@42.nl/jarb-final-form": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@42.nl/jarb-final-form/-/jarb-final-form-1.0.0.tgz",
-      "integrity": "sha512-T11AWHrroEU7C7UdbrSd+oe8Glp/ZOV3ReevcW0IMWIjscacvTWXtUyeUgaf5hPHWvD2inFQSb+3AOTPu/CgLg=="
+      "integrity": "sha512-T11AWHrroEU7C7UdbrSd+oe8Glp/ZOV3ReevcW0IMWIjscacvTWXtUyeUgaf5hPHWvD2inFQSb+3AOTPu/CgLg==",
+      "dev": true
     },
     "@42.nl/react-error-store": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "version": "jekyll build && npm run storybook:build"
   },
   "dependencies": {
-    "@42.nl/jarb-final-form": "1.0.0",
     "bootstrap": "4.3.1",
     "material-design-icons": "3.0.1",
     "moment": "2.24.0",
@@ -54,6 +53,7 @@
     "classnames": "^2.2.6",
     "@42.nl/spring-connect": "^4.0.0",
     "@42.nl/react-error-store": "^1.0.1",
+    "@42.nl/jarb-final-form": "^1.0.0",
     "reactstrap": "^8.0.1",
     "lodash": "^4.17.15",
     "react-router-dom": "^5.1.0"
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@42.nl/spring-connect": "4.0.0",
     "@42.nl/react-error-store": "1.0.1",
+    "@42.nl/jarb-final-form": "1.0.0",
     "@babel/plugin-transform-modules-commonjs": "7.6.0",
     "@storybook/addon-actions": "5.2.1",
     "@storybook/addon-docs": "5.2.1",


### PR DESCRIPTION
Probably an oversight from making all of the other packages peer dependencies but forgetting this one. Has been corrected.