### PR TITLE
feat: Added SearchInput component.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.js": {
-    "bundled": 101143,
-    "minified": 48129,
-    "gzipped": 11458
+    "bundled": 132535,
+    "minified": 57976,
+    "gzipped": 14017
   },
   "dist/index.es.js": {
-    "bundled": 96339,
-    "minified": 43500,
-    "gzipped": 11182,
+    "bundled": 126899,
+    "minified": 52521,
+    "gzipped": 13677,
     "treeshaked": {
       "rollup": {
-        "code": 33394,
-        "import_statements": 1064
+        "code": 33710,
+        "import_statements": 1125
       },
       "webpack": {
-        "code": 37048
+        "code": 37403
       }
     }
   }

--- a/src/core/SearchInput/SearchInput.stories.tsx
+++ b/src/core/SearchInput/SearchInput.stories.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import SearchInput from './SearchInput';
+import { Card } from 'reactstrap';
+
+storiesOf('core|SearchInput', module)
+  .addParameters({ component: SearchInput })
+  .add('default', () => {
+    const [query, setQuery] = useState('');
+
+    return (
+      <Card body>
+        <p>You searched for: {query}</p>
+        <SearchInput value={query} onChange={setQuery} />
+      </Card>
+    );
+  })
+  .add('without icon', () => {
+    const [query, setQuery] = useState('');
+
+    return (
+      <Card body>
+        <p>You searched for: {query}</p>
+        <SearchInput value={query} onChange={setQuery} showIcon={false} />
+      </Card>
+    );
+  })
+  .add('with custom debounce', () => {
+    const [query, setQuery] = useState('');
+
+    return (
+      <Card body>
+        <p>You searched for: {query}</p>
+        <SearchInput value={query} onChange={setQuery} debounce={1000} />
+      </Card>
+    );
+  })
+  .add('with custom debounce settings', () => {
+    const [query, setQuery] = useState('');
+
+    return (
+      <Card body>
+        <p>You searched for: {query}</p>
+        <SearchInput
+          value={query}
+          onChange={setQuery}
+          debounce={1000}
+          debounceSettings={{ leading: true, trailing: true }}
+        />
+      </Card>
+    );
+  });

--- a/src/core/SearchInput/SearchInput.test.tsx
+++ b/src/core/SearchInput/SearchInput.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import lodash from 'lodash';
+
+import SearchInput from './SearchInput';
+import { Input } from 'reactstrap';
+
+describe('Component: SearchInput', () => {
+  function setup({
+    debounce,
+    showIcon,
+    debounceSettings
+  }: {
+    debounce?: number;
+    showIcon: boolean;
+    debounceSettings?: lodash.DebounceSettings;
+  }) {
+    // @ts-ignore
+    jest.spyOn(lodash, 'debounce').mockImplementation(fn => {
+      return fn;
+    });
+
+    const onChangeSpy = jest.fn();
+
+    const searchInput = shallow(
+      <SearchInput
+        value=""
+        debounce={debounce}
+        debounceSettings={debounceSettings}
+        onChange={onChangeSpy}
+        showIcon={showIcon}
+      />
+    );
+
+    return { searchInput, onChangeSpy };
+  }
+
+  describe('ui', () => {
+    test('with icon', () => {
+      const { searchInput } = setup({ showIcon: true });
+
+      expect(toJson(searchInput)).toMatchSnapshot();
+    });
+
+    test('with icon when undefined', () => {
+      const { searchInput } = setup({ showIcon: undefined });
+
+      expect(toJson(searchInput)).toMatchSnapshot();
+    });
+
+    test('without icon', () => {
+      const { searchInput } = setup({ showIcon: false });
+
+      expect(toJson(searchInput)).toMatchSnapshot();
+    });
+  });
+
+  describe('events', () => {
+    it('should debounce by 500 by default', () => {
+      const { searchInput, onChangeSpy } = setup({ showIcon: true });
+
+      searchInput
+        .find(Input)
+        .props()
+        // @ts-ignore
+        .onChange({ target: { value: 'Maarten' } });
+
+      expect(onChangeSpy).toBeCalledTimes(1);
+      expect(onChangeSpy).toBeCalledWith('Maarten');
+
+      expect(lodash.debounce).toBeCalledTimes(1);
+      // @ts-ignore
+      expect(lodash.debounce.mock.calls[0][1]).toBe(500);
+      // @ts-ignore
+      expect(lodash.debounce.mock.calls[0][2]).toBe(undefined);
+    });
+
+    it('should be able to debounce with a custom value', () => {
+      const { searchInput, onChangeSpy } = setup({
+        showIcon: true,
+        debounce: 10
+      });
+
+      searchInput
+        .find(Input)
+        .props()
+        // @ts-ignore
+        .onChange({ target: { value: 'Maarten' } });
+
+      expect(onChangeSpy).toBeCalledTimes(1);
+      expect(onChangeSpy).toBeCalledWith('Maarten');
+
+      expect(lodash.debounce).toBeCalledTimes(1);
+      // @ts-ignore
+      expect(lodash.debounce.mock.calls[0][1]).toBe(10);
+    });
+
+    it('should debounce with settings when settings are defined', () => {
+      const debounceSettings = { leading: true, trailing: false };
+
+      const { searchInput, onChangeSpy } = setup({
+        showIcon: true,
+        debounceSettings
+      });
+
+      searchInput
+        .find(Input)
+        .props()
+        // @ts-ignore
+        .onChange({ target: { value: 'M' } });
+
+      // Trailing will cause the first character to go through immediately
+      expect(onChangeSpy).toBeCalledTimes(1);
+      expect(onChangeSpy).toBeCalledWith('M');
+
+      expect(lodash.debounce).toBeCalledTimes(1);
+      // @ts-ignore
+      expect(lodash.debounce.mock.calls[0][2]).toBe(debounceSettings);
+    });
+
+    describe('onKeyUp behavior', () => {
+      it('should on "ENTER" press set the value immediately', () => {
+        const { searchInput, onChangeSpy } = setup({ showIcon: true });
+
+        searchInput
+          .find(Input)
+          .props()
+          // @ts-ignore
+          .onKeyUp({ key: 'Enter', currentTarget: { value: 'Maarten' } });
+
+        expect(onChangeSpy).toBeCalledTimes(1);
+        expect(onChangeSpy).toBeCalledWith('Maarten');
+      });
+
+      it('should on letters other "ENTER" wait for the debounce', () => {
+        const { searchInput, onChangeSpy } = setup({ showIcon: true });
+
+        searchInput
+          .find(Input)
+          .props()
+          // @ts-ignore
+          .onKeyUp({ key: 'a', currentTarget: { value: 'Maarten' } });
+
+        expect(onChangeSpy).toBeCalledTimes(0);
+      });
+    });
+  });
+});

--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -1,0 +1,104 @@
+import React, { useRef, KeyboardEvent } from 'react';
+import { debounce as lodashDebounce, DebounceSettings } from 'lodash';
+import { Input, InputProps, InputGroup, InputGroupAddon } from 'reactstrap';
+
+import { Icon } from '../Icon';
+
+type ModifiedInputProps = Omit<
+  InputProps,
+  // We are going to override onChange so it sends out strings.
+  | 'onChange'
+  // Value is only going to accept strings
+  | 'value'
+  // We want to remove the defaultValue because we are going to set it
+  // ourselves, we do not want the user to accidentaly use it.
+  | 'defaultValue'
+>;
+
+interface Props extends ModifiedInputProps {
+  /**
+   * Optionally the number of milliseconds to debounce the onChange.
+   *
+   * Defaults to 500 milliseconds.
+   */
+  debounce?: number;
+
+  /**
+   * Optionally the debounce settings. As defined by lodash
+   * https://lodash.com/docs/4.17.15#debounce.
+   */
+  debounceSettings?: DebounceSettings;
+
+  /**
+   * The value that the form element currently has.
+   */
+  value: string;
+
+  /**
+   * Called when the value changes after the debounce period.
+   */
+  onChange: (value: string) => void;
+
+  /**
+   * Whether or not to show a magnifying glass icon.
+   *
+   * Defaults to true.
+   */
+  showIcon?: boolean;
+}
+
+/**
+ * SearchInput is a component which shows an input field which has
+ * the onChange debounced by a number of milliseconds. Useful for
+ * when you want to run search queries on your back-end, and you
+ * don't want to spam the back-end for every keystroke.
+ *
+ * For the debounce logic it uses lodash.
+ */
+export default function SearchInput(props: Props) {
+  const {
+    debounce = 500,
+    debounceSettings,
+    value,
+    onChange,
+    showIcon = true,
+    ...rest
+  } = props;
+
+  const handleChange = useRef(
+    lodashDebounce(onChange, debounce, debounceSettings)
+  );
+
+  function handleKeyUp(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      onChange(event.currentTarget.value);
+    }
+  }
+
+  // We map value to defaultValue so this component is completely
+  // controlled by us. Otherwise the value of the <Input> will only
+  // update after the onChange. Which would never work because it is
+  // debounced.
+
+  const input = (
+    <Input
+      defaultValue={value}
+      onChange={event => handleChange.current(event.target.value)}
+      onKeyUp={handleKeyUp}
+      {...rest}
+    />
+  );
+
+  if (showIcon) {
+    return (
+      <InputGroup size={rest.size}>
+        <InputGroupAddon addonType="prepend">
+          <Icon icon="search" />
+        </InputGroupAddon>
+        {input}
+      </InputGroup>
+    );
+  } else {
+    return input;
+  }
+}

--- a/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: SearchInput ui with icon 1`] = `
+<InputGroup
+  tag="div"
+>
+  <InputGroupAddon
+    addonType="prepend"
+    tag="div"
+  >
+    <Icon
+      icon="search"
+    />
+  </InputGroupAddon>
+  <Input
+    defaultValue=""
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    type="text"
+  />
+</InputGroup>
+`;
+
+exports[`Component: SearchInput ui with icon when undefined 1`] = `
+<InputGroup
+  tag="div"
+>
+  <InputGroupAddon
+    addonType="prepend"
+    tag="div"
+  >
+    <Icon
+      icon="search"
+    />
+  </InputGroupAddon>
+  <Input
+    defaultValue=""
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    type="text"
+  />
+</InputGroup>
+`;
+
+exports[`Component: SearchInput ui without icon 1`] = `
+<Input
+  defaultValue=""
+  onChange={[Function]}
+  onKeyUp={[Function]}
+  type="text"
+/>
+`;

--- a/src/form/ModalPicker/ModalPicker.test.tsx
+++ b/src/form/ModalPicker/ModalPicker.test.tsx
@@ -47,6 +47,7 @@ describe('Component: ModalPicker', () => {
         closeModal={closeModalSpy}
         modalSaved={modalSavedSpy}
         saveButtonEnabled={true}
+        query=""
         canSearch={canSearch}
         addButton={addButton}
       >
@@ -138,15 +139,15 @@ describe('Component: ModalPicker', () => {
       expect(modalSavedSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should call search when the user hits "enter" in the search box', () => {
+    it('should call search stops typing', () => {
       setup({ showAddButton: false, canSearch: true });
 
       // @ts-ignore
       modalPicker
-        .find('Input')
+        .find('SearchInput')
         .props()
         // @ts-ignore
-        .onChange({ target: { value: 'Maarten' } });
+        .onChange('Maarten');
 
       expect(fetchDataSpy).toHaveBeenCalledTimes(1);
       expect(fetchDataSpy).toHaveBeenCalledWith('Maarten');

--- a/src/form/ModalPicker/ModalPicker.tsx
+++ b/src/form/ModalPicker/ModalPicker.tsx
@@ -8,14 +8,11 @@ import {
   Button,
   Row,
   Col,
-  Input,
-  InputGroup,
-  InputGroupAddon
 } from 'reactstrap';
 
 import Pagination from '../../core/Pagination/Pagination';
-import Icon from '../../core/Icon/Icon';
 import { t } from '../../utilities/translation/translation';
+import SearchInput from '../../core/SearchInput/SearchInput';
 
 interface Text {
   placeholder?: string;
@@ -44,6 +41,11 @@ interface Props {
    * Here the component using the ModalPicker must render in the options.
    */
   children: React.ReactNode;
+
+  /**
+   * The value to show in the search input.
+   */
+  query: string;
 
   /**
    * Whether or not to show the search input.
@@ -103,6 +105,7 @@ export default function ModalPicker(props: Props) {
     isOpen,
     page,
     children,
+    query,
     canSearch,
     fetchOptions,
     pageChanged,
@@ -122,20 +125,16 @@ export default function ModalPicker(props: Props) {
         {canSearch ? (
           <Row>
             <Col>
-              <InputGroup>
-                <InputGroupAddon addonType="prepend">
-                  <Icon icon="search" />
-                </InputGroupAddon>
-                <Input
-                  id="search"
-                  placeholder={t({
-                    overrideText: text.placeholder,
-                    key: 'ModalPicker.SEARCH',
-                    fallback: 'Search...'
-                  })}
-                  onChange={event => fetchOptions(event.target.value)}
-                />
-              </InputGroup>
+              <SearchInput
+                id="search"
+                value={query}
+                placeholder={t({
+                  overrideText: text.placeholder,
+                  key: 'ModalPicker.SEARCH',
+                  fallback: 'Search...'
+                })}
+                onChange={value => fetchOptions(value)}
+              ></SearchInput>
             </Col>
           </Row>
         ) : null}

--- a/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
+++ b/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
@@ -55,24 +55,12 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
           ]
         }
       >
-        <InputGroup
-          tag="div"
-        >
-          <InputGroupAddon
-            addonType="prepend"
-            tag="div"
-          >
-            <Icon
-              icon="search"
-            />
-          </InputGroupAddon>
-          <Input
-            id="search"
-            onChange={[Function]}
-            placeholder="Search..."
-            type="text"
-          />
-        </InputGroup>
+        <SearchInput
+          id="search"
+          onChange={[Function]}
+          placeholder="Search..."
+          value=""
+        />
       </Col>
     </Row>
     <h1>

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -14,8 +14,6 @@ import {
 import { User } from '../../../test/types';
 import * as testUtils from '../../../test/utils';
 
-import lodash from 'lodash';
-
 describe('Component: ModalPickerMultiple', () => {
   let modalPickerMultiple: ShallowWrapper;
 
@@ -259,13 +257,7 @@ describe('Component: ModalPickerMultiple', () => {
       });
     });
 
-    it('should when the user searches it should perform the search on typing', () => {
-      // @ts-ignore
-      jest.spyOn(lodash, 'debounce').mockImplementation((fn, delay) => {
-        expect(delay).toBe(500);
-        return fn;
-      });
-
+    it('should fetch options when the user searches', () => {
       setup({
         value: undefined,
         showAddButton: false

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FormGroup, Label, Input } from 'reactstrap';
-import { debounce, isArray } from 'lodash';
 import { emptyPage, Page } from '@42.nl/spring-connect';
 import { Button, Row, Col } from 'reactstrap';
 
@@ -118,11 +117,6 @@ export default class ModalPickerMultiple<T> extends React.Component<
     userHasSearched: false
   };
 
-  constructor(props: Props<T>) {
-    super(props);
-    this.debouncedSearch = debounce(this.debouncedSearch, 500);
-  }
-
   componentDidMount() {
     this.loadPage(1);
   }
@@ -144,7 +138,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
     // Otherwise the selection will be the same as the value, which
     // causes values to be commited and the cancel button will not
     // do anything.
-    const selected = isArray(this.props.value) ? [...this.props.value] : [];
+    const selected = Array.isArray(this.props.value) ? [...this.props.value] : [];
 
     this.setState({ selected, isOpen: true, query: '' }, () => {
       this.loadPage(1);
@@ -172,7 +166,9 @@ export default class ModalPickerMultiple<T> extends React.Component<
   }
 
   fetchOptions(query: string) {
-    this.debouncedSearch(query);
+    this.setState({ query }, () => {
+      this.loadPage(1);
+    });
   }
 
   async loadPage(pageNumber: number) {
@@ -182,12 +178,6 @@ export default class ModalPickerMultiple<T> extends React.Component<
     const page: Page<T> = await this.props.fetchOptions(query, pageNumber, 10);
 
     this.setState({ page });
-  }
-
-  debouncedSearch(query: string) {
-    this.setState({ query }, () => {
-      this.loadPage(1);
-    });
   }
 
   async addButtonClicked(callback: AddButtonCallback<T>) {
@@ -214,7 +204,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
     return (
       <FormGroup className={className} color={color}>
         <Label for={id}>{label}</Label>
-        
+
         <div>
           {this.renderTagsInMoreOrLess(value)}
           <Button color="primary" onClick={() => this.openModal()}>
@@ -230,7 +220,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
 
   renderModal() {
     const { placeholder, addButton, canSearch = true } = this.props;
-    const { page, isOpen, selected } = this.state;
+    const { page, isOpen, selected, query } = this.state;
 
     const addButtonOptions = addButton
       ? {
@@ -243,6 +233,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
 
     return (
       <ModalPicker
+        query={query}
         placeholder={placeholder}
         isOpen={isOpen}
         page={page}

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
+    query=""
     saveButtonEnabled={true}
   >
     <Row

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { emptyPage } from '@42.nl/spring-connect';
-import lodash from 'lodash';
 
 import ModalPickerSingle, { State } from './ModalPickerSingle';
 import { User } from '../../../test/types';
@@ -171,13 +170,7 @@ describe('Component: ModalPickerSingle', () => {
       }
     });
 
-    it('should when the user searches it should perform the search on key up', () => {
-      // @ts-ignore
-      jest.spyOn(lodash, 'debounce').mockImplementation((fn, delay) => {
-        expect(delay).toBe(500);
-        return fn;
-      });
-
+    it('should fetch options when the user searches', () => {
       setup({
         value: undefined,
         showAddButton: false

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FormGroup, Label, Input } from 'reactstrap';
-import { debounce } from 'lodash';
 import { emptyPage, Page } from '@42.nl/spring-connect';
 import { Button, Row, Col } from 'reactstrap';
 
@@ -116,11 +115,6 @@ export default class ModalPickerSingle<T> extends React.Component<
     userHasSearched: false
   };
 
-  constructor(props: Props<T>) {
-    super(props);
-    this.debouncedSearch = debounce(this.debouncedSearch, 500);
-  }
-
   componentDidMount() {
     this.loadPage(1);
   }
@@ -156,7 +150,9 @@ export default class ModalPickerSingle<T> extends React.Component<
   }
 
   fetchOptions(query: string) {
-    this.debouncedSearch(query);
+    this.setState({ query }, () => {
+      this.loadPage(1);
+    });
   }
 
   async loadPage(pageNumber: number) {
@@ -167,12 +163,6 @@ export default class ModalPickerSingle<T> extends React.Component<
     const page: Page<T> = await this.props.fetchOptions(query, pageNumber, 10);
 
     this.setState({ page });
-  }
-
-  debouncedSearch(query: string) {
-    this.setState({ query }, () => {
-      this.loadPage(1);
-    });
   }
 
   async addButtonClicked(callback: AddButtonCallback<T>) {
@@ -225,7 +215,7 @@ export default class ModalPickerSingle<T> extends React.Component<
 
   renderModal() {
     const { placeholder, addButton, canSearch = true } = this.props;
-    const { page, selected, isOpen } = this.state;
+    const { page, selected, isOpen, query } = this.state;
 
     const addButtonOptions = addButton
       ? {
@@ -238,6 +228,7 @@ export default class ModalPickerSingle<T> extends React.Component<
 
     return (
       <ModalPicker
+        query={query}
         placeholder={placeholder}
         isOpen={isOpen}
         page={page}

--- a/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
+++ b/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
+    query=""
     saveButtonEnabled={false}
   >
     <Row

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -398,6 +398,7 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
           }
           pageChanged={[Function]}
           placeholder="Select your best friend"
+          query=""
           saveButtonEnabled={true}
         >
           <Modal
@@ -629,6 +630,7 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
           }
           pageChanged={[Function]}
           placeholder="Select your best friend"
+          query=""
           saveButtonEnabled={false}
         >
           <Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export { default as Spinner } from './core/Spinner/Spinner';
 export { default as SubmitButton } from './core/SubmitButton/SubmitButton';
 export { default as Tag } from './core/Tag/Tag';
 export { default as AsyncContent } from './core/AsyncContent/AsyncContent';
+export { default as SearchInput } from './core/SearchInput/SearchInput';
 
 // Form
 export { default as Input, JarbInput } from './form/Input/Input';

--- a/src/main.scss
+++ b/src/main.scss
@@ -56,6 +56,7 @@ body {
 
 .form-control:focus {
   box-shadow: none !important;
+  border-color: $gray-400 !important;
 }
 
 .radio,


### PR DESCRIPTION
The `SearchInput` component is a small wrapper around the `reactstrap`
`Input` component which debounces the `onChange` by `500` milliseconds
by default. It uses `lodash`'s `debounce` under the hood.

Features:

  1. When the user presses enter the `SearchInput` will skip the debounce
     and set the value straight away.

  2. The icon which is a magnifying class can be toggled on or of.

  3. The debounce timeout can also be set to a custom value.

  4. The debounce settings which lodash accepts can also be set for
     maximum configurability.

The modal pickers now use the `SearchInput` instead of debouncing the
inputs themselves.

Also had to set the border color in `.form-control:focus` to a gray
to prevent it from becoming blue for the `SearchInput`.

Closes #191