### PR TITLE
bug: The `NavigationItem` no longer forces `exact links

### DIFF
--- a/src/core/NavigationItem/Navigation.stories.tsx
+++ b/src/core/NavigationItem/Navigation.stories.tsx
@@ -12,4 +12,40 @@ storiesOf('core|NavigationItem', module)
         <NavigationItem to="/dashboard" icon="dashboard" text="Dashboard" />
       </BrowserRouter>
     );
+  })
+  .add('with show boolean', () => {
+    return (
+      <BrowserRouter>
+        <NavigationItem
+          show={true}
+          to="/dashboard"
+          icon="dashboard"
+          text="Dashboard"
+        />
+      </BrowserRouter>
+    );
+  })
+  .add('with show as function', () => {
+    return (
+      <BrowserRouter>
+        <NavigationItem
+          show={() => true && true}
+          to="/dashboard"
+          icon="dashboard"
+          text="Dashboard"
+        />
+      </BrowserRouter>
+    );
+  })
+  .add('with exact is false', () => {
+    return (
+      <BrowserRouter>
+        <NavigationItem
+          to="/dashboard"
+          icon="dashboard"
+          text="Dashboard"
+          exact={false}
+        />
+      </BrowserRouter>
+    );
   });

--- a/src/core/NavigationItem/NavigationItem.test.tsx
+++ b/src/core/NavigationItem/NavigationItem.test.tsx
@@ -1,48 +1,77 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+
+import { NavLink } from 'reactstrap';
 
 import NavigationItem from './NavigationItem';
 
 describe('Component: NavigationItem', () => {
-  let navigationItem: ShallowWrapper;
-
-  function setup({ show = true }: { show?: (() => boolean) | boolean }) {
-    navigationItem = shallow(
+  function setup({
+    show = true,
+    exact
+  }: {
+    show?: (() => boolean) | boolean;
+    exact?: boolean;
+  }) {
+    const navigationItem = shallow(
       <NavigationItem
         to="/dashboard"
         icon="dashboard"
         text="Dashboard"
         show={show}
+        exact={exact}
       />
     );
+
+    return { navigationItem };
   }
 
   test('ui', () => {
-    setup({});
+    const { navigationItem } = setup({});
     expect(toJson(navigationItem)).toMatchSnapshot();
   });
 
-  test('should not render when show is false', () => {
-    setup({ show: false });
-    expect(navigationItem.isEmptyRender()).toBe(true);
+  describe('show behavior', () => {
+    it('should not render when show is false', () => {
+      const { navigationItem } = setup({ show: false });
+      expect(navigationItem.isEmptyRender()).toBe(true);
+    });
+
+    it('should render when predicate resolves to true', () => {
+      const { navigationItem } = setup({ show: () => 1 + 1 === 2 });
+      expect(navigationItem.isEmptyRender()).toBe(false);
+    });
+
+    it('should not render when predicate resolves to false', () => {
+      const { navigationItem } = setup({ show: () => 1 + 2 === 2 });
+      expect(navigationItem.isEmptyRender()).toBe(true);
+    });
+
+    it('should default show to true if it is not provided', () => {
+      const navigationItem = shallow(
+        <NavigationItem to="/dashboard" icon="dashboard" text="Dashboard" />
+      );
+
+      expect(navigationItem.isEmptyRender()).toBe(false);
+    });
   });
 
-  test('should render when predicate resolves to true', () => {
-    setup({ show: () => 1 + 1 === 2 });
-    expect(navigationItem.isEmptyRender()).toBe(false);
-  });
+  describe('exact behavior', () => {
+    it('should default to exact when exact is undefined', () => {
+      const { navigationItem } = setup({ exact: undefined });
 
-  test('should not render when predicate resolves to false', () => {
-    setup({ show: () => 1 + 2 === 2 });
-    expect(navigationItem.isEmptyRender()).toBe(true);
-  });
+      const exact = navigationItem.find(NavLink).props().exact;
 
-  test('should default show to true if it is not provided', () => {
-    const navigationItem = shallow(
-      <NavigationItem to="/dashboard" icon="dashboard" text="Dashboard" />
-    );
+      expect(exact).toBe(true);
+    });
 
-    expect(navigationItem.isEmptyRender()).toBe(false);
+    it('should be able to set exact to false', () => {
+      const { navigationItem } = setup({ exact: false });
+
+      const exact = navigationItem.find(NavLink).props().exact;
+
+      expect(exact).toBe(false);
+    });
   });
 });

--- a/src/core/NavigationItem/NavigationItem.tsx
+++ b/src/core/NavigationItem/NavigationItem.tsx
@@ -31,19 +31,37 @@ interface Props {
    * Predicate to determine if the link will be shown. Accepts either a boolean or a function that returns a boolean.
    */
   show?: (() => boolean) | boolean;
+
+  /**
+   * Optionally whether the route is an exact route.
+   * 
+   * Defaults to true.
+   */
+  exact?: boolean;
 }
 
 /**
- * The NavigationItem enables you to guard specific links by a predicate, for example by user role.
+ * The NavigationItem is a wrapper around the `react-router`'s 
+ * `NavLink`. See https://reacttraining.com/react-router/web/api/NavLink.
+ * It adds texts and icons around the `NavLink`.
+ * 
+ * The NavigationItem enables you to guard specific links by a predicate, 
+ * for example by user role.
  *
- * Use it when you want to keep certain navigation items hidden for specific user roles.
+ * Use it when you want to keep certain navigation items hidden 
+ * for specific user roles.
+ * 
+ * By default the `NavigationItem` will render an `exact` link. See:
+ * https://reacttraining.com/react-router/web/api/Route/exact-bool.
+ * But you can set it to `false` via the props.
  */
 export default function NavigationItem({
   to,
   icon,
   text,
   show = true,
-  className
+  className,
+  exact = true
 }: Props) {
   const shouldShow = typeof show === 'function' ? show : () => show;
 
@@ -53,7 +71,7 @@ export default function NavigationItem({
 
   return (
     <NavItem className={classNames('navigation-item', className)}>
-      <NavLink to={to} exact tag={RRNavLink} activeClassName="active">
+      <NavLink to={to} exact={exact} tag={RRNavLink} activeClassName="active">
         <Icon icon={icon} className="mr-3 align-bottom" />
         {text}
       </NavLink>


### PR DESCRIPTION
Sometimes we use nested routes in applications, which do no work
nicely with the default `exact` property. For example when a user navigates
to `users/10` and we have a master-detail view, the `NavigationItem` will
not apply active to the entry, as it has an `exact` property by default.

This commit makes the `exact` configurable by the user to bypass this
behavior.

Fixes #120