### PR TITLE
fix: select placeholder is now a selectable option

### DIFF
--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -69,5 +69,27 @@ storiesOf('Form|Select', module)
           }}
         />
       </FinalForm>
+    );
+  })
+  .add('default option', () => {
+    const [value, setValue] = useState({ value: 'great', label: 'Great shit' });
+
+    return (
+      <Form>
+        <Select<SubjectOption>
+          id="subject"
+          label="Subject"
+          value={value}
+          placeholder="Please enter your subject"
+          optionForValue={(option: SubjectOption) => option.label}
+          options={[
+            { value: 'awesome', label: 'Awesome shit' },
+            { value: 'super', label: 'Super shit' },
+            { value: 'great', label: 'Great shit' },
+            { value: 'good', label: 'good shit' }
+          ]}
+          onChange={setValue}
+        />
+      </Form>
     );
   });

--- a/src/form/Select/Select.test.tsx
+++ b/src/form/Select/Select.test.tsx
@@ -38,7 +38,7 @@ describe('Component: Select', () => {
         placeholder="Please enter your subject"
         text={text}
         isOptionEnabled={isOptionEnabled}
-        optionForValue={(user: User) => user.email}
+        optionForValue={(user: User) => user?.email}
         options={[adminUser, coordinatorUser, userUser]}
         value={value}
         onChange={onChangeSpy}
@@ -164,7 +164,7 @@ describe('Component: Select', () => {
           // @ts-ignore
           const select = new Select({ options, onChange });
           select.props.value = adminUser;
-          select.props.optionForValue = (user: User) => user.email;
+          select.props.optionForValue = (user: User) => user?.email;
 
           jest.spyOn(select, 'setState').mockImplementation(() => undefined);
 
@@ -188,7 +188,7 @@ describe('Component: Select', () => {
           // @ts-ignore
           const select = new Select({ options, onChange });
           select.props.value = userUser;
-          select.props.optionForValue = (user: User) => user.email;
+          select.props.optionForValue = (user: User) => user?.email;
 
           jest.spyOn(select, 'setState').mockImplementation(() => undefined);
 
@@ -242,6 +242,9 @@ describe('Component: Select', () => {
       defaultOption.getElement().ref(option);
 
       expect(option.selected).toBe(true);
+
+      // @ts-ignore
+      expect(option.value).toBe(undefined);
     });
 
     it('should not select the placeholder as the default value when value is not an empty string', () => {
@@ -299,9 +302,6 @@ describe('Component: Select', () => {
         const options = select.find('option');
         expect(options.length).toBe(4);
 
-        // Default option should be disabled
-        expect(options.at(0).props().disabled).toBe(true);
-
         // Other options should be enabled
         expect(options.at(1).props().disabled).toBe(false);
         expect(options.at(2).props().disabled).toBe(false);
@@ -318,9 +318,6 @@ describe('Component: Select', () => {
 
         const options = select.find('option');
         expect(options.length).toBe(4);
-
-        // Default option should be disabled
-        expect(options.at(0).props().disabled).toBe(true);
 
         // Other options should be enabled
         expect(options.at(1).props().disabled).toBe(true);
@@ -347,14 +344,14 @@ describe('Component: Select', () => {
       select.setProps({ value: undefined });
 
       rsInput = select.find('Input');
-      expect(rsInput.props().value).toBe(-1);
+      expect(rsInput.props().value).toBe(undefined);
     });
 
     test('becomes filled', () => {
       setup({ value: undefined, isOptionEnabled: undefined });
 
       let rsInput = select.find('Input');
-      expect(rsInput.props().value).toBe(-1);
+      expect(rsInput.props().value).toBe(undefined);
 
       select.setProps({ value: coordinatorUser });
 

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { FormGroup, Label, Input as RSInput } from 'reactstrap';
-import { get, constant, isArray } from 'lodash';
+import { get, constant } from 'lodash';
 import { InputType } from 'reactstrap/lib/Input';
 import { Page } from '@42.nl/spring-connect';
 
@@ -114,7 +114,7 @@ export default class Select<T> extends Component<Props<T>, State<T>> {
 
     const { options } = props;
 
-    if (isArray(options)) {
+    if (Array.isArray(options)) {
       this.state = {
         options,
         loading: false
@@ -130,7 +130,7 @@ export default class Select<T> extends Component<Props<T>, State<T>> {
   async componentDidMount() {
     const options = this.props.options;
 
-    if (isArray(options) === false) {
+    if (Array.isArray(options) === false) {
       const fetcher = options as OptionsFetcher<T>;
 
       const page: Page<T> = await fetcher();
@@ -221,12 +221,19 @@ export default class Select<T> extends Component<Props<T>, State<T>> {
       className: value === undefined ? 'showing-placeholder' : ''
     };
 
-    // @ts-ignore
-    const indexOfValue = options.findIndex(option => option === value);
+    const indexOfValue =
+      value !== undefined
+        ? options.findIndex(
+            option => optionForValue(option) === optionForValue(value)
+          )
+        : undefined;
 
     return (
-      <RSInput value={indexOfValue} {...inputProps}>
-        <option disabled ref={option => this.selectDefaultOption(option)}>
+      <RSInput
+        value={indexOfValue === -1 ? undefined : indexOfValue}
+        {...inputProps}
+      >
+        <option ref={option => this.selectDefaultOption(option)}>
           {placeholder}
         </option>
 

--- a/src/form/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/form/Select/__snapshots__/Select.test.tsx.snap
@@ -31,9 +31,7 @@ exports[`Component: Select ui with value: Component: Select => ui => with value 
     valid={false}
     value={0}
   >
-    <option
-      disabled={true}
-    >
+    <option>
       Please enter your subject
     </option>
     <option

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -790,7 +790,6 @@ exports[`Component: ValuePicker single should render a \`Select\` component when
           onChange={[Function]}
           placeholder="Select your best friend"
           type="select"
-          value={-1}
         >
           <select
             className="showing-placeholder form-control"
@@ -798,11 +797,8 @@ exports[`Component: ValuePicker single should render a \`Select\` component when
             onBlur={[MockFunction]}
             onChange={[Function]}
             placeholder="Select your best friend"
-            value={-1}
           >
-            <option
-              disabled={true}
-            >
+            <option>
               Select your best friend
             </option>
             <option


### PR DESCRIPTION
In the previous version of `Select` the placeholder was a non-selectable
option which in turn shows the first item in the options as selected,
even though it is not selected. This is resolved by making the
placeholder a selectable option.

~Additionally this change contains a fix for object equality when passing
a value to `Select`. This is done by using `Lodash.isEqual` instead of
trying to do equal comparison.~

Fixes #137.