### PR TITLE
Bugfix/pager can go out of bounds

### DIFF
--- a/src/core/Button/Button.stories.tsx
+++ b/src/core/Button/Button.stories.tsx
@@ -78,6 +78,52 @@ storiesOf('core|buttons/Button', module)
           </Button>
           <hr />
         </Col>
+        <Col xs={12}>
+          <h4>Button disabled</h4>
+          <Button
+            onClick={action('Button clicked')}
+            color="primary"
+            disabled={true}
+          >
+            primary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="secondary"
+            disabled={true}
+          >
+            secondary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="success"
+            disabled={true}
+          >
+            success
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="info"
+            disabled={true}
+          >
+            info
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="warning"
+            disabled={true}
+          >
+            warning
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="danger"
+            disabled={true}
+          >
+            danger
+          </Button>
+          <hr />
+        </Col>
       </Row>
     );
   })
@@ -226,6 +272,53 @@ storiesOf('core|buttons/Button', module)
           </Button>
           <hr />
         </Col>
+        <Col xs={12}>
+          <h4>Button with icon disabled</h4>
+          <Button
+            icon="save"
+            onClick={action('Button clicked')}
+            color="primary"
+            disabled={true}
+          >
+            primary
+          </Button>
+          <Button
+            icon="save"
+            onClick={action('Button clicked')}
+            color="secondary"
+            disabled={true}
+          >
+            secondary
+          </Button>
+          <Button
+            icon="save"
+            onClick={action('Button clicked')}
+            color="success"
+            disabled={true}
+          >
+            success
+          </Button>
+          <Button
+            icon="save"
+            onClick={action('Button clicked')}
+            color="info"
+            disabled={true}
+          >
+            info
+          </Button>
+          <Button
+            icon="save"
+            onClick={action('Button clicked')}
+            color="warning"
+            disabled={true}
+          >
+            warning
+          </Button>
+          <Button icon="save" onClick={action('Button clicked')} color="danger">
+            danger
+          </Button>
+          <hr />
+        </Col>
       </Row>
     );
   })
@@ -325,6 +418,58 @@ storiesOf('core|buttons/Button', module)
             outline={true}
             inProgress={true}
             color="danger"
+          >
+            danger
+          </Button>
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Outline disabled</h4>
+          <Button
+            onClick={action('Button clicked')}
+            outline={true}
+            color="primary"
+            disabled={true}
+          >
+            primary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            outline={true}
+            color="secondary"
+            disabled={true}
+          >
+            secondary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            outline={true}
+            color="success"
+            disabled={true}
+          >
+            success
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            outline={true}
+            color="info"
+            disabled={true}
+          >
+            info
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            outline={true}
+            color="warning"
+            disabled={true}
+          >
+            warning
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            outline={true}
+            color="danger"
+            disabled={true}
           >
             danger
           </Button>
@@ -504,6 +649,63 @@ storiesOf('core|buttons/Button', module)
           </Button>
           <hr />
         </Col>
+        <Col xs={12}>
+          <h4>Outline with icon disabled</h4>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            outline={true}
+            color="primary"
+            disabled={true}
+          >
+            primary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            outline={true}
+            color="secondary"
+            disabled={true}
+          >
+            secondary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            outline={true}
+            color="success"
+            disabled={true}
+          >
+            success
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            outline={true}
+            color="info"
+          >
+            info
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            outline={true}
+            color="warning"
+            disabled={true}
+          >
+            warning
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            outline={true}
+            color="danger"
+            disabled={true}
+          >
+            danger
+          </Button>
+          <hr />
+        </Col>
       </Row>
     );
   })
@@ -578,6 +780,46 @@ storiesOf('core|buttons/Button', module)
             icon="save"
             inProgress={true}
             color="danger"
+          />
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Icon disabled</h4>
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            color="primary"
+            disabled={true}
+          />
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            color="secondary"
+            disabled={true}
+          />
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            color="success"
+            disabled={true}
+          />
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            color="info"
+            disabled={true}
+          />
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            color="warning"
+            disabled={true}
+          />
+          <Button
+            onClick={action('Button clicked')}
+            icon="save"
+            color="danger"
+            disabled={true}
           />
           <hr />
         </Col>

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -12,7 +12,7 @@ describe('Component: Button', () => {
       describe('normal', () => {
         test('inProgress is true', () => {
           const button = shallow(
-            <Button onClick={jest.fn()} inProgress={true} size="md">
+            <Button onClick={jest.fn()} inProgress={true}>
               Save
             </Button>
           );
@@ -45,6 +45,46 @@ describe('Component: Button', () => {
         test('inProgress is false', () => {
           const button = shallow(
             <Button onClick={jest.fn()} inProgress={false} outline={true}>
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+      });
+
+      describe('disabled', () => {
+        test('is disabled', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} disabled={true}>
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('is enabled', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} disabled={false}>
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+      });
+
+      describe('size', () => {
+        test('use md by default', () => {
+          const button = shallow(<Button onClick={jest.fn()}>Save</Button>);
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('can override size', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} size="sm">
               Save
             </Button>
           );
@@ -121,20 +161,40 @@ describe('Component: Button', () => {
     });
 
     describe('icon', () => {
-      test('inProgress is true', () => {
-        const button = shallow(
-          <Button onClick={jest.fn()} inProgress={true} icon="save" />
-        );
+      describe('inProgress', () => {
+        test('inProgress is true', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} inProgress={true} icon="save" />
+          );
 
-        expect(toJson(button)).toMatchSnapshot();
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('inProgress is false', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} inProgress={false} icon="save" />
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
       });
 
-      test('inProgress is false', () => {
-        const button = shallow(
-          <Button onClick={jest.fn()} inProgress={false} icon="save" />
-        );
+      describe('disabled', () => {
+        test('is disabled', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} icon="save" disabled={true} />
+          );
 
-        expect(toJson(button)).toMatchSnapshot();
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('is enabled', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} icon="save" disabled={false} />
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
       });
     });
   });

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -41,6 +41,13 @@ interface BaseProps {
    * Useful for styling the component.
    */
   className?: string;
+
+  /**
+   * Optionally whether the button is disabled
+   *
+   * Defaults to `false`
+   */
+  disabled?: boolean;
 }
 
 interface WithIconAndText extends BaseProps {
@@ -64,7 +71,7 @@ interface WithIconAndText extends BaseProps {
   /**
    * Optionally the size of the button, defaults to md.
    *
-   * @default md
+   * Defaults to 'md'.
    */
   size?: 'sm' | 'md' | 'lg';
 }
@@ -90,7 +97,7 @@ interface WithText extends BaseProps {
   /**
    * Optionally the size of the button, defaults to md.
    *
-   * @default md
+   * Defaults to 'md'.
    */
   size?: 'sm' | 'md' | 'lg';
 }
@@ -128,6 +135,7 @@ export default function Button({
 
   const children = 'children' in props ? props.children : undefined;
   const icon = 'icon' in props ? props.icon : undefined;
+  const disabled = 'disabled' in props ? props.disabled : undefined;
 
   if (children !== undefined) {
     const outline = 'outline' in props ? props.outline : undefined;
@@ -145,7 +153,7 @@ export default function Button({
       <span className={`button ${className} ${color}`}>
         <RSButton
           onClick={handleOnClick}
-          disabled={inProgress}
+          disabled={inProgress || disabled}
           {...buttonProps}
         >
           {showSpinner ? (
@@ -168,7 +176,12 @@ export default function Button({
           // Color is empty string so we can override the color
           <Spinner size={24} color="" />
         ) : (
-          <Icon onClick={handleOnClick} icon={iconCast} color={color} />
+          <Icon
+            onClick={handleOnClick}
+            icon={iconCast}
+            color={color}
+            disabled={inProgress || disabled}
+          />
         )}
       </span>
     );

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -1,12 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: Button ui button normal inProgress is false 1`] = `
+exports[`Component: Button ui button disabled is disabled 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    disabled={true}
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</span>
+`;
+
+exports[`Component: Button ui button disabled is enabled 1`] = `
 <span
   className="button  primary"
 >
   <Button
     color="primary"
     disabled={false}
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</span>
+`;
+
+exports[`Component: Button ui button normal inProgress is false 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
     onClick={[Function]}
     size="md"
     tag="button"
@@ -44,7 +77,6 @@ exports[`Component: Button ui button outline inProgress is false 1`] = `
 >
   <Button
     color="primary"
-    disabled={false}
     onClick={[Function]}
     outline={true}
     size="md"
@@ -78,13 +110,44 @@ exports[`Component: Button ui button outline inProgress is true 1`] = `
 </span>
 `;
 
+exports[`Component: Button ui button size can override size 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="sm"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</span>
+`;
+
+exports[`Component: Button ui button size use md by default 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</span>
+`;
+
 exports[`Component: Button ui button with icon normal inProgress is false 1`] = `
 <span
   className="button  primary"
 >
   <Button
     color="primary"
-    disabled={false}
     onClick={[Function]}
     size="md"
     tag="button"
@@ -146,7 +209,6 @@ exports[`Component: Button ui button with icon outline inProgress is false 1`] =
 >
   <Button
     color="primary"
-    disabled={false}
     onClick={[Function]}
     outline={true}
     size="md"
@@ -184,7 +246,33 @@ exports[`Component: Button ui button with icon outline inProgress is true 1`] = 
 </span>
 `;
 
-exports[`Component: Button ui icon inProgress is false 1`] = `
+exports[`Component: Button ui icon disabled is disabled 1`] = `
+<span
+  className="button  primary"
+>
+  <Icon
+    color="primary"
+    disabled={true}
+    icon="save"
+    onClick={[Function]}
+  />
+</span>
+`;
+
+exports[`Component: Button ui icon disabled is enabled 1`] = `
+<span
+  className="button  primary"
+>
+  <Icon
+    color="primary"
+    disabled={false}
+    icon="save"
+    onClick={[Function]}
+  />
+</span>
+`;
+
+exports[`Component: Button ui icon inProgress inProgress is false 1`] = `
 <span
   className="button  primary"
 >
@@ -196,7 +284,7 @@ exports[`Component: Button ui icon inProgress is false 1`] = `
 </span>
 `;
 
-exports[`Component: Button ui icon inProgress is true 1`] = `
+exports[`Component: Button ui icon inProgress inProgress is true 1`] = `
 <span
   className="button  primary"
 >

--- a/src/core/Icon/Icon.scss
+++ b/src/core/Icon/Icon.scss
@@ -1,6 +1,12 @@
+.icon {
+  &--disabled {
+    opacity: 0.65;
+  }
+}
+
 /**
-* Make material-icons within Bootstrap great again!
-*/
+  * Make material-icons within Bootstrap great again!
+  */
 .input-group {
   &-append,
   &-prepend {

--- a/src/core/Icon/Icon.stories.tsx
+++ b/src/core/Icon/Icon.stories.tsx
@@ -28,7 +28,13 @@ storiesOf('core|Icons', module)
         <Icon icon="train" color="primary" />
         <Icon icon="wb_sunny" color="warning" />
         <Icon icon="drafts" />
+        <Icon icon="drafts" disabled={true} />
         <Icon icon="timer_3" onClick={action('timer clicked')} />
+        <Icon
+          icon="home"
+          disabled={true}
+          onClick={action('timer clicked')}
+        />
       </div>
     );
   });

--- a/src/core/Icon/Icon.test.tsx
+++ b/src/core/Icon/Icon.test.tsx
@@ -42,6 +42,18 @@ describe('Icon', () => {
       const icon = shallow(<Icon icon="alarm" onClick={undefined} />);
       expect(toJson(icon)).toMatchSnapshot('Icon => ui => is not clickable');
     });
+
+    test('is disabled', () => {
+      const icon = shallow(
+        <Icon icon="alarm" onClick={() => undefined} disabled={true} />
+      );
+      expect(toJson(icon)).toMatchSnapshot('Icon => ui => is disabled');
+    });
+
+    test('is enabled', () => {
+      const icon = shallow(<Icon icon="alarm" disabled={false} />);
+      expect(toJson(icon)).toMatchSnapshot('Icon => ui => is enabled');
+    });
   });
 
   describe('events', () => {
@@ -52,6 +64,28 @@ describe('Icon', () => {
       icon.find('i').simulate('click');
 
       expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call the "onClick" event when the icon is clicked and is explicitly enabled', () => {
+      const onClickSpy = jest.fn();
+
+      const icon = shallow(
+        <Icon icon="alarm" onClick={onClickSpy} disabled={false} />
+      );
+      icon.find('i').simulate('click');
+
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call the "onClick" event when the icon is clicked but is disabled', () => {
+      const onClickSpy = jest.fn();
+
+      const icon = shallow(
+        <Icon icon="alarm" onClick={onClickSpy} disabled={true} />
+      );
+      icon.find('i').simulate('click');
+
+      expect(onClickSpy).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -30,6 +30,13 @@ interface Props {
    * Optional onClick event for when the Icon is clicked.
    */
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+
+  /**
+   * Optionally whether the button is disabled
+   *
+   * Defaults to `false`
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -37,14 +44,36 @@ interface Props {
  *
  * Useful for making sure your icon is typesafe via TypeScript.
  */
-export default function Icon({ className, onClick, icon, id, color }: Props) {
+export default function Icon({
+  className,
+  onClick,
+  icon,
+  id,
+  color,
+  disabled
+}: Props) {
   const colorCssClass = color !== undefined ? `text-${color}` : undefined;
-  const classes = classNames(className, 'material-icons', colorCssClass, {
-    clickable: onClick
-  });
+  const classes = classNames(
+    'icon',
+    className,
+    'material-icons',
+    colorCssClass,
+    {
+      clickable: !disabled && onClick,
+      'icon--disabled': disabled
+    }
+  );
 
   return (
-    <i id={id} onClick={onClick} className={classes}>
+    <i
+      id={id}
+      onClick={event => {
+        if (!disabled) {
+          onClick(event);
+        }
+      }}
+      className={classes}
+    >
       {icon}
     </i>
   );

--- a/src/core/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Icon ui default: Icon => ui => default 1`] = `
 <i
-  className="material-icons"
+  className="icon material-icons"
+  onClick={[Function]}
 >
   alarm
 </i>
@@ -10,7 +11,25 @@ exports[`Icon ui default: Icon => ui => default 1`] = `
 
 exports[`Icon ui is clickable: Icon => ui => is clickable 1`] = `
 <i
-  className="material-icons clickable"
+  className="icon material-icons clickable"
+  onClick={[Function]}
+>
+  alarm
+</i>
+`;
+
+exports[`Icon ui is disabled: Icon => ui => is disabled 1`] = `
+<i
+  className="icon material-icons icon--disabled"
+  onClick={[Function]}
+>
+  alarm
+</i>
+`;
+
+exports[`Icon ui is enabled: Icon => ui => is enabled 1`] = `
+<i
+  className="icon material-icons"
   onClick={[Function]}
 >
   alarm
@@ -19,7 +38,8 @@ exports[`Icon ui is clickable: Icon => ui => is clickable 1`] = `
 
 exports[`Icon ui is not clickable: Icon => ui => is not clickable 1`] = `
 <i
-  className="material-icons"
+  className="icon material-icons"
+  onClick={[Function]}
 >
   alarm
 </i>
@@ -27,7 +47,8 @@ exports[`Icon ui is not clickable: Icon => ui => is not clickable 1`] = `
 
 exports[`Icon ui with className: Icon => ui => with className 1`] = `
 <i
-  className="text-danger material-icons"
+  className="icon text-danger material-icons"
+  onClick={[Function]}
 >
   alarm
 </i>
@@ -35,8 +56,9 @@ exports[`Icon ui with className: Icon => ui => with className 1`] = `
 
 exports[`Icon ui with color: Icon => ui => with color 1`] = `
 <i
-  className="material-icons text-danger"
+  className="icon material-icons text-danger"
   id="1337"
+  onClick={[Function]}
 >
   alarm
 </i>
@@ -44,8 +66,9 @@ exports[`Icon ui with color: Icon => ui => with color 1`] = `
 
 exports[`Icon ui with id: Icon => ui => with id 1`] = `
 <i
-  className="material-icons"
+  className="icon material-icons"
   id="1337"
+  onClick={[Function]}
 >
   alarm
 </i>

--- a/src/core/Pager/Pager.stories.tsx
+++ b/src/core/Pager/Pager.stories.tsx
@@ -1,26 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 
 import Pager from './Pager';
+import { pageOf } from '../../test/utils';
 
 storiesOf('core|Pager', module)
   .addParameters({ component: Pager })
   .add('default', () => {
-    const page = {
-      content: [1, 2, 3],
-      last: false,
-      totalElements: 100,
-      totalPages: 10,
-      size: 10,
-      number: 5,
-      first: false,
-      numberOfElements: 10
-    };
+    const [pageNumber, setPageNumber] = useState(1);
+
+    const page = pageOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], pageNumber, 2);
 
     return (
       <div className="text-center">
-        <Pager page={page} onChange={action('page changed')} />
+        <h2>You are on page {pageNumber}</h2>
+
+        <Pager page={page} onChange={setPageNumber} />
       </div>
     );
   });

--- a/src/core/Pager/Pager.test.tsx
+++ b/src/core/Pager/Pager.test.tsx
@@ -51,6 +51,22 @@ describe('Component: Pager', () => {
         'Component: Pager => normal'
       );
     });
+
+    test('first', () => {
+      setup({ number: 1, totalPages: 10 });
+
+      expect(toJson(pager)).toMatchSnapshot(
+        'Component: Pager => first'
+      );
+    });
+
+    test('last', () => {
+      setup({ number: 10, totalPages: 10 });
+
+      expect(toJson(pager)).toMatchSnapshot(
+        'Component: Pager => last'
+      );
+    });
   });
 
   describe('events', () => {

--- a/src/core/Pager/Pager.tsx
+++ b/src/core/Pager/Pager.tsx
@@ -75,6 +75,7 @@ export default function Pager<T>({
         className="mr-1"
         outline
         icon="arrow_back"
+        disabled={first}
         onClick={() => onChange(page.number - 1)}
       >
         {t({
@@ -89,6 +90,7 @@ export default function Pager<T>({
         className="pager-next"
         icon="arrow_forward"
         iconPosition="right"
+        disabled={last}
         onClick={() => onChange(page.number + 1)}
       >
         {t({

--- a/src/core/Pager/__snapshots__/Pager.test.tsx.snap
+++ b/src/core/Pager/__snapshots__/Pager.test.tsx.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: Pager ui normal: Component: Pager => normal 1`] = `
+exports[`Component: Pager ui first: Component: Pager => first 1`] = `
 <div
   className="pager"
 >
   <Button
     className="mr-1"
+    disabled={true}
     icon="arrow_back"
     onClick={[Function]}
     outline={true}
@@ -14,6 +15,59 @@ exports[`Component: Pager ui normal: Component: Pager => normal 1`] = `
   </Button>
   <Button
     className="pager-next"
+    disabled={false}
+    icon="arrow_forward"
+    iconPosition="right"
+    onClick={[Function]}
+    outline={true}
+  >
+    Next
+  </Button>
+</div>
+`;
+
+exports[`Component: Pager ui last: Component: Pager => last 1`] = `
+<div
+  className="pager"
+>
+  <Button
+    className="mr-1"
+    disabled={false}
+    icon="arrow_back"
+    onClick={[Function]}
+    outline={true}
+  >
+    Previous
+  </Button>
+  <Button
+    className="pager-next"
+    disabled={true}
+    icon="arrow_forward"
+    iconPosition="right"
+    onClick={[Function]}
+    outline={true}
+  >
+    Next
+  </Button>
+</div>
+`;
+
+exports[`Component: Pager ui normal: Component: Pager => normal 1`] = `
+<div
+  className="pager"
+>
+  <Button
+    className="mr-1"
+    disabled={false}
+    icon="arrow_back"
+    onClick={[Function]}
+    outline={true}
+  >
+    Previous
+  </Button>
+  <Button
+    className="pager-next"
+    disabled={false}
     icon="arrow_forward"
     iconPosition="right"
     onClick={[Function]}

--- a/src/form/Select/Select.test.tsx
+++ b/src/form/Select/Select.test.tsx
@@ -87,6 +87,19 @@ describe('Component: Select', () => {
 
       expect(rsInput.props().className).toBe('showing-placeholder');
     });
+
+    test('when value is not in options select nothing', () => {
+      setup({ value: {
+        id: -1,
+        email: 'none',
+        active: false,
+        roles: [],
+      }, isOptionEnabled: undefined });
+
+      const rsInput = select.find('Input');
+
+      expect(rsInput.props().value).toBe(undefined);
+    });
   });
 
   describe('constructor', () => {


### PR DESCRIPTION
The bounds of the `Pager` are now constricted by adding a `disabled`
property on the buttons. When `first` is `true` the `previous` button
is disabled. When `last` is true the `next` button is disabled.
    
Since `Button` did not support `disabled` I've added support for it.
The same goes for the `Icon` which now also supports `disabled`.
    
Also fixed a missing unit test for the `Select` component. There was not
test for when the `value` was not longer in the list of `options`.
    
