### PR TITLE
improvement: SearchInput's value can now be manipulated from the outs…

### DIFF
--- a/src/core/SearchInput/SearchInput.stories.tsx
+++ b/src/core/SearchInput/SearchInput.stories.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import SearchInput from './SearchInput';
+
 import { Card } from 'reactstrap';
+import { Select, Button } from '../..';
 
 storiesOf('core|SearchInput', module)
   .addParameters({ component: SearchInput })
@@ -48,6 +50,42 @@ storiesOf('core|SearchInput', module)
           debounce={1000}
           debounceSettings={{ leading: true, trailing: true }}
         />
+      </Card>
+    );
+  })
+  .add('with external value', () => {
+    const [query, setQuery] = useState('');
+
+    return (
+      <Card body>
+        <p>You searched for: {query}</p>
+
+        <SearchInput value={query} onChange={setQuery} debounce={1000}>
+          {(searchInput, { setValue }) => (
+            <>
+              {searchInput}
+
+              <Button className="mt-3" onClick={() => setValue('')}>
+                Clear query
+              </Button>
+
+              <Select
+                className="mt-2"
+                id="predefined-query"
+                label="Predefined queries"
+                value={query}
+                placeholder="Please select a predefined query"
+                optionForValue={option => option}
+                options={['Maarten', 'Jeffrey']}
+                onChange={value => {
+                  if (value) {
+                    setValue(value);
+                  }
+                }}
+              />
+            </>
+          )}
+        </SearchInput>
       </Card>
     );
   });

--- a/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Component: SearchInput ui with icon 1`] = `
 <InputGroup
+  className=""
   tag="div"
 >
   <InputGroupAddon
@@ -13,7 +14,13 @@ exports[`Component: SearchInput ui with icon 1`] = `
     />
   </InputGroupAddon>
   <Input
+    className=""
     defaultValue=""
+    innerRef={
+      Object {
+        "current": null,
+      }
+    }
     onChange={[Function]}
     onKeyUp={[Function]}
     type="text"
@@ -23,6 +30,7 @@ exports[`Component: SearchInput ui with icon 1`] = `
 
 exports[`Component: SearchInput ui with icon when undefined 1`] = `
 <InputGroup
+  className=""
   tag="div"
 >
   <InputGroupAddon
@@ -34,7 +42,13 @@ exports[`Component: SearchInput ui with icon when undefined 1`] = `
     />
   </InputGroupAddon>
   <Input
+    className=""
     defaultValue=""
+    innerRef={
+      Object {
+        "current": null,
+      }
+    }
     onChange={[Function]}
     onKeyUp={[Function]}
     type="text"
@@ -44,7 +58,13 @@ exports[`Component: SearchInput ui with icon when undefined 1`] = `
 
 exports[`Component: SearchInput ui without icon 1`] = `
 <Input
+  className=""
   defaultValue=""
+  innerRef={
+    Object {
+      "current": null,
+    }
+  }
   onChange={[Function]}
   onKeyUp={[Function]}
   type="text"


### PR DESCRIPTION
…ide.

The `SearchInput` is debounced and therefore must use an uncontrolled
input. Otherwise the value of the input cannot be debounced.

This causes a problem however, when ever the `value` prop of the
`SearchInput` changed due to external changes. For example: a button
which clears the `SearchInput`. The new value would not appear in the
input element, due to it being uncontrolled.

This commit adds a new children prop to the `SearchInput`. The children
is expected to be a function of type:

```ts
(searchInput: React.ReactNode, api: SearchInputApi) => React.ReactNode;
``

It should take the searchInput rendered by the `SearchInput` and display
it somewhere in the return of the children function. It can the use the
`api` which contains a function called `setValue` to change the actual
value of the `SearchInput`.

The `setValue` will cancel the debounce, update the `<input>`'s actual
value through the ref, and it will call `props.onChange` with the actual
value.

Closes: #219