### PR TITLE
fix: enabled `strictNullChecks` in tsconfig. Fixed crashing <Icon>.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 script:
   - npm i
   - npm run lint
+  - npm run tsc
   - jest --coverage --outputFile test-results.json --json
   - npx danger ci
   - rm -f test-results.json

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   ],
   "license": "SEE LICENSE IN LICENSE.MD",
   "scripts": {
+    "tsc": "tsc --version && tsc --noEmit",
     "clean": "rm -rf dist",
     "start": "npm run storybook",
     "test": "jest",
     "test:watch": "jest --watch --coverage",
-    "test-all": "npm run lint && jest --coverage",
+    "test-all": "npm run lint && npm run tsc && jest --coverage",
     "build": "npm run clean && rollup -c",
     "lint": "eslint src --ext js,jsx,ts,tsx --max-warnings=0",
     "storybook:build": "build-storybook -c storybook -o docs/storybook",

--- a/src/core/AsyncContent/AsyncContent.test.tsx
+++ b/src/core/AsyncContent/AsyncContent.test.tsx
@@ -25,7 +25,7 @@ describe('Component: AsyncContent', () => {
     const asyncContent = shallow(
       // @ts-ignore
       <AsyncContent state={state} showRetryButton={showRetryButton}>
-        {data => <h2>{data}</h2>}
+        {(data: string) => <h2>{data}</h2>}
       </AsyncContent>
     );
 

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -271,6 +271,7 @@ describe('Component: Button', () => {
 
           const event = new Event('click');
 
+          // @ts-ignore
           button
             .find('Button')
             .props()

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -53,6 +53,7 @@ export default function Icon({
   disabled
 }: Props) {
   const colorCssClass = color !== undefined ? `text-${color}` : undefined;
+
   const classes = classNames(
     'icon',
     className,
@@ -68,7 +69,7 @@ export default function Icon({
     <i
       id={id}
       onClick={event => {
-        if (!disabled) {
+        if (!disabled && onClick) {
           onClick(event);
         }
       }}

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -66,7 +66,7 @@ export function pagesFor(
   currentPage: number,
   totalPages: number
 ): (number | Dots)[] {
-  const content = [];
+  const content: (number | Dots)[] = [];
 
   if (currentPage > 1) {
     content.push(1);

--- a/src/core/ProgressStepper/ProgressStepper.tsx
+++ b/src/core/ProgressStepper/ProgressStepper.tsx
@@ -85,7 +85,11 @@ export default function ProgressStepper<T>(props: Props<T>) {
           <div key={title} className={classes}>
             <div
               className="step-item"
-              onClick={() => clickable && onClick(step, index)}
+              onClick={() => {
+                if (clickable && onClick) {
+                  onClick(step, index);
+                }
+              }}
             >
               <div className="step-circle">
                 <span>{index + 1}</span>

--- a/src/core/SearchInput/SearchInput.test.tsx
+++ b/src/core/SearchInput/SearchInput.test.tsx
@@ -14,7 +14,7 @@ describe('Component: SearchInput', () => {
     debounceSettings
   }: {
     debounce?: number;
-    showIcon: boolean;
+    showIcon?: boolean;
     debounceSettings?: lodash.DebounceSettings;
   }) {
     // @ts-ignore
@@ -61,6 +61,7 @@ describe('Component: SearchInput', () => {
     it('should debounce by 500 by default', () => {
       const { searchInput, onChangeSpy } = setup({ showIcon: true });
 
+      // @ts-ignore
       searchInput
         .find(Input)
         .props()
@@ -83,6 +84,7 @@ describe('Component: SearchInput', () => {
         debounce: 10
       });
 
+      // @ts-ignore
       searchInput
         .find(Input)
         .props()
@@ -105,6 +107,7 @@ describe('Component: SearchInput', () => {
         debounceSettings
       });
 
+      // @ts-ignore
       searchInput
         .find(Input)
         .props()
@@ -124,6 +127,7 @@ describe('Component: SearchInput', () => {
       it('should on "ENTER" press set the value immediately', () => {
         const { searchInput, onChangeSpy } = setup({ showIcon: true });
 
+        // @ts-ignore
         searchInput
           .find(Input)
           .props()
@@ -137,6 +141,7 @@ describe('Component: SearchInput', () => {
       it('should on letters other "ENTER" wait for the debounce', () => {
         const { searchInput, onChangeSpy } = setup({ showIcon: true });
 
+        // @ts-ignore
         searchInput
           .find(Input)
           .props()

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -21,7 +21,7 @@ const options: SubjectOption[] = range(0, 100).map(i => ({
 
 storiesOf('Form|CheckboxMultipleSelect', module)
   .add('defined options', () => {
-    const [value, setValue] = useState([]);
+    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
 
     return (
       <div>
@@ -41,7 +41,7 @@ storiesOf('Form|CheckboxMultipleSelect', module)
     );
   })
   .add('fetched options', () => {
-    const [value, setValue] = useState([]);
+    const [value, setValue] = useState<User[] | undefined>([]);
 
     return (
       <Form>

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
@@ -149,7 +149,7 @@ describe('Component: CheckboxMultipleSelect', () => {
 
   describe('events', () => {
     test('onChange', () => {
-      let value = undefined;
+      let value: User[] | undefined = undefined;
 
       setup({ value, isOptionEnabled: undefined });
 

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -32,7 +32,7 @@ interface Props<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T[] | null) => void;
+  onChange: (value: T[]) => void;
 
   /**
    * Optional callback for when the form element is blurred.

--- a/src/form/ImageUpload/ImageUpload.stories.tsx
+++ b/src/form/ImageUpload/ImageUpload.stories.tsx
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions';
 import ImageUpload, { JarbImageUpload, requireImage } from './ImageUpload';
 import { Form, FinalForm } from '../story-utils';
 
-storiesOf('Form|ImgUpload', module)
+storiesOf('Form|ImageUpload', module)
   .add('rect', () => {
     return (
       <Form>

--- a/src/form/ImageUpload/ImageUpload.test.tsx
+++ b/src/form/ImageUpload/ImageUpload.test.tsx
@@ -4,11 +4,16 @@ import toJson from 'enzyme-to-json';
 
 import * as imgUploadUtils from './utils';
 
-import ImgUpload, { requireImage, Crop, limitImageSize } from './ImageUpload';
+import ImageUpload, {
+  requireImage,
+  Crop,
+  limitImageSize,
+  Text
+} from './ImageUpload';
 
 import * as testUtils from '../../test/utils';
 
-describe('Component: ImgUpload', () => {
+describe('Component: ImageUpload', () => {
   let imgUpload: ShallowWrapper;
 
   let onChangeSpy: jest.Mock<any, any>;
@@ -16,10 +21,12 @@ describe('Component: ImgUpload', () => {
 
   function setup({
     value,
-    cropType
+    cropType,
+    text
   }: {
     value?: File | string;
     cropType: 'rect' | 'circle';
+    text?: Text;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -30,7 +37,7 @@ describe('Component: ImgUpload', () => {
         : { size: 250, type: 'circle' };
 
     imgUpload = shallow(
-      <ImgUpload
+      <ImageUpload
         id="image-uploader"
         label="Profile photo"
         crop={crop}
@@ -39,6 +46,7 @@ describe('Component: ImgUpload', () => {
         onBlur={onBlurSpy}
         error="Some error"
         color="success"
+        text={text}
       />
     );
   }
@@ -46,7 +54,7 @@ describe('Component: ImgUpload', () => {
   describe('componentDidMount', () => {
     it('should not show the image when the value is null', () => {
       // @ts-ignore
-      const imgUpload = new ImgUpload();
+      const imgUpload = new ImageUpload();
 
       imgUpload.props = { value: null };
       jest.spyOn(imgUpload, 'setState');
@@ -58,7 +66,7 @@ describe('Component: ImgUpload', () => {
 
     it('should not show the image when the value is empty string', () => {
       // @ts-ignore
-      const imgUpload = new ImgUpload();
+      const imgUpload = new ImageUpload();
 
       imgUpload.props = { value: '' };
       jest.spyOn(imgUpload, 'setState');
@@ -70,7 +78,7 @@ describe('Component: ImgUpload', () => {
 
     test('it should show the image when the value is a non empty string', () => {
       // @ts-ignore
-      const imgUpload = new ImgUpload();
+      const imgUpload = new ImageUpload();
 
       imgUpload.props = { value: 'maarten.png' };
       jest.spyOn(imgUpload, 'setState').mockImplementation(() => undefined);
@@ -92,27 +100,48 @@ describe('Component: ImgUpload', () => {
       imgUpload.setState({ imageSrc: 'maarten.png', mode: 'file-selected' });
 
       expect(toJson(imgUpload)).toMatchSnapshot(
-        'Component: ImgUpload => ui => file-selected as rect'
+        'Component: ImageUpload => ui => file-selected as rect'
       );
     });
 
     test('file-selected as circle', () => {
-      setup({ value: new File([''], 'maarten.png'), cropType: 'circle' });
+      setup({
+        value: new File([''], 'maarten.png'),
+        cropType: 'circle',
+        text: {
+          cancel: 'CANCEL',
+          change: 'CHANGE',
+          remove: 'REMOVE',
+          done: 'DONE'
+        }
+      });
 
       imgUpload.setState({ imageSrc: 'maarten.png', mode: 'file-selected' });
 
       expect(toJson(imgUpload)).toMatchSnapshot(
-        'Component: ImgUpload => ui => file-selected as circle'
+        'Component: ImageUpload => ui => file-selected as circle'
       );
     });
 
     test('edit as rect', () => {
-      setup({ value: undefined, cropType: 'rect' });
+      setup({
+        value: undefined,
+        cropType: 'rect',
+        text: {
+          cancel: 'CANCEL',
+          change: 'CHANGE',
+          remove: 'REMOVE',
+          done: 'DONE'
+        }
+      });
 
-      imgUpload.setState({ imageSrc: 'maarten.png', mode: 'edit' });
+      imgUpload.setState({
+        imageSrc: 'maarten.png',
+        mode: 'edit'
+      });
 
       expect(toJson(imgUpload)).toMatchSnapshot(
-        'Component: ImgUpload => ui => edit as rect'
+        'Component: ImageUpload => ui => edit as rect'
       );
     });
 
@@ -122,7 +151,7 @@ describe('Component: ImgUpload', () => {
       imgUpload.setState({ imageSrc: 'maarten.png', mode: 'edit' });
 
       expect(toJson(imgUpload)).toMatchSnapshot(
-        'Component: ImgUpload => ui => edit as circle'
+        'Component: ImageUpload => ui => edit as circle'
       );
     });
 
@@ -131,7 +160,7 @@ describe('Component: ImgUpload', () => {
       imgUpload.setState({ mode: 'no-file' });
 
       expect(toJson(imgUpload)).toMatchSnapshot(
-        'Component: ImgUpload => ui => no-file'
+        'Component: ImageUpload => ui => no-file'
       );
     });
   });

--- a/src/form/ImageUpload/ImageUpload.tsx
+++ b/src/form/ImageUpload/ImageUpload.tsx
@@ -17,12 +17,13 @@ import {
   calculateScale
 } from './utils';
 
-interface Text {
+export interface Text {
   cancel?: string;
   change?: string;
   remove?: string;
   done?: string;
 }
+
 interface CropRect {
   /**
    * Crop is a rectangle
@@ -149,10 +150,6 @@ interface State {
 const reader = new FileReader();
 
 export default class ImageUpload extends Component<Props, State> {
-  static defaultProps = {
-    text: {}
-  };
-
   state = {
     mode: Mode.NO_FILE,
     imageSrc: '',
@@ -369,7 +366,7 @@ export default class ImageUpload extends Component<Props, State> {
   }
 
   renderFileSelectedButtons() {
-    const { change, remove } = this.props.text;
+    const { text = {} } = this.props;
 
     return (
       <FormGroup className="text-center mt-1">
@@ -381,7 +378,7 @@ export default class ImageUpload extends Component<Props, State> {
           {t({
             key: 'ImageUpload.CHANGE',
             fallback: 'Change',
-            overrideText: change
+            overrideText: text.change
           })}
         </Button>
         <Button
@@ -393,7 +390,7 @@ export default class ImageUpload extends Component<Props, State> {
           {t({
             key: 'ImageUpload.REMOVE',
             fallback: 'Remove',
-            overrideText: remove
+            overrideText: text.remove
           })}
         </Button>
       </FormGroup>
@@ -401,7 +398,7 @@ export default class ImageUpload extends Component<Props, State> {
   }
 
   renderEditButtons() {
-    const { cancel, done } = this.props.text;
+    const { text = {} } = this.props;
 
     return (
       <FormGroup className="d-flex justify-content-center mt-1">
@@ -428,7 +425,7 @@ export default class ImageUpload extends Component<Props, State> {
           {t({
             key: 'ImageUpload.CANCEL',
             fallback: 'Cancel',
-            overrideText: cancel
+            overrideText: text.cancel
           })}
         </Button>
 
@@ -441,7 +438,7 @@ export default class ImageUpload extends Component<Props, State> {
           {t({
             key: 'ImageUpload.DONE',
             fallback: 'Done',
-            overrideText: done
+            overrideText: text.done
           })}
         </Button>
       </FormGroup>

--- a/src/form/ImageUpload/__snapshots__/ImageUpload.test.tsx.snap
+++ b/src/form/ImageUpload/__snapshots__/ImageUpload.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: ImgUpload ui edit as circle: Component: ImgUpload => ui => edit as circle 1`] = `
+exports[`Component: ImageUpload ui edit as circle: Component: ImageUpload => ui => edit as circle 1`] = `
 <div>
   <FormGroup
     className="img-upload"
@@ -76,7 +76,7 @@ exports[`Component: ImgUpload ui edit as circle: Component: ImgUpload => ui => e
 </div>
 `;
 
-exports[`Component: ImgUpload ui edit as rect: Component: ImgUpload => ui => edit as rect 1`] = `
+exports[`Component: ImageUpload ui edit as rect: Component: ImageUpload => ui => edit as rect 1`] = `
 <div>
   <FormGroup
     className="img-upload"
@@ -136,7 +136,7 @@ exports[`Component: ImgUpload ui edit as rect: Component: ImgUpload => ui => edi
         icon="cancel"
         onClick={[Function]}
       >
-        Cancel
+        CANCEL
       </Button>
       <Button
         className="ml-1"
@@ -144,7 +144,7 @@ exports[`Component: ImgUpload ui edit as rect: Component: ImgUpload => ui => edi
         icon="done"
         onClick={[Function]}
       >
-        Done
+        DONE
       </Button>
     </FormGroup>
     Some error
@@ -152,7 +152,7 @@ exports[`Component: ImgUpload ui edit as rect: Component: ImgUpload => ui => edi
 </div>
 `;
 
-exports[`Component: ImgUpload ui file-selected as circle: Component: ImgUpload => ui => file-selected as circle 1`] = `
+exports[`Component: ImageUpload ui file-selected as circle: Component: ImageUpload => ui => file-selected as circle 1`] = `
 <div>
   <FormGroup
     className="img-upload"
@@ -197,7 +197,7 @@ exports[`Component: ImgUpload ui file-selected as circle: Component: ImgUpload =
         icon="camera_roll"
         onClick={[Function]}
       >
-        Change
+        CHANGE
       </Button>
       <Button
         className="ml-1"
@@ -205,7 +205,7 @@ exports[`Component: ImgUpload ui file-selected as circle: Component: ImgUpload =
         icon="delete"
         onClick={[Function]}
       >
-        Remove
+        REMOVE
       </Button>
     </FormGroup>
     Some error
@@ -213,7 +213,7 @@ exports[`Component: ImgUpload ui file-selected as circle: Component: ImgUpload =
 </div>
 `;
 
-exports[`Component: ImgUpload ui file-selected as rect: Component: ImgUpload => ui => file-selected as rect 1`] = `
+exports[`Component: ImageUpload ui file-selected as rect: Component: ImageUpload => ui => file-selected as rect 1`] = `
 <div>
   <FormGroup
     className="img-upload"
@@ -274,7 +274,7 @@ exports[`Component: ImgUpload ui file-selected as rect: Component: ImgUpload => 
 </div>
 `;
 
-exports[`Component: ImgUpload ui no-file: Component: ImgUpload => ui => no-file 1`] = `
+exports[`Component: ImageUpload ui no-file: Component: ImageUpload => ui => no-file 1`] = `
 <div>
   <FormGroup
     className="img-upload"

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -13,7 +13,7 @@ import { FinalForm, Form } from '../../story-utils';
 
 storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
   .add('default', () => {
-    const [value, setValue] = useState([]);
+    const [value, setValue] = useState<User[] | undefined>([]);
 
     return (
       <Form>
@@ -33,7 +33,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
     );
   })
   .add('with extra add button', () => {
-    const [value, setValue] = useState([]);
+    const [value, setValue] = useState<User[] | undefined>([]);
 
     return (
       <Form>
@@ -66,7 +66,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
     );
   })
   .add('without search', () => {
-    const [value, setValue] = useState([]);
+    const [value, setValue] = useState<User[] | undefined>([]);
 
     return (
       <Form>

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -55,7 +55,7 @@ interface Props<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T[] | null) => void;
+  onChange: (value: T[]) => void;
 
   /**
    * Optional callback for when the form element is blurred.

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -9,7 +9,7 @@ import { User } from '../../../test/types';
 
 storiesOf('Form/ModalPicker/ModalPickerSingle', module)
   .add('basic', () => {
-    const [value, setValue] = useState(undefined);
+    const [value, setValue] = useState<User| undefined>(undefined);
 
     return (
       <Form>
@@ -29,7 +29,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
     );
   })
   .add('with extra add button', () => {
-    const [value, setValue] = useState(undefined);
+    const [value, setValue] = useState<User| undefined>(undefined);
 
     return (
       <Form>
@@ -62,7 +62,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
     );
   })
   .add('without search', () => {
-    const [value, setValue] = useState(undefined);
+    const [value, setValue] = useState<User| undefined | null>(undefined);
 
     return (
       <Form>

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -53,7 +53,7 @@ interface Props<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T | null) => void;
+  onChange: (value: T) => void;
 
   /**
    * Optional callback for when the form element is blurred.
@@ -85,7 +85,7 @@ interface Props<T> {
 export interface State<T> {
   isOpen: boolean;
   page: Page<T>;
-  selected?: T;
+  selected?: T | null;
   query: string;
   userHasSearched: boolean;
 }

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
@@ -60,7 +60,7 @@ describe('Component: TypeaheadMultiple', () => {
         asyncTypeahead.props().onChange([]);
 
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
-        expect(onChangeSpy).toHaveBeenCalledWith(null);
+        expect(onChangeSpy).toHaveBeenCalledWith(undefined);
         expect(onBlurSpy).toHaveBeenCalledTimes(1);
       });
 

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
@@ -38,7 +38,7 @@ interface Props<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T[] | null) => void;
+  onChange: (value: T[] | undefined) => void;
 
   /**
    * Optional callback for when the form element is blurred.
@@ -109,7 +109,7 @@ export default class TypeaheadMultiple<T> extends Component<
 
   onChange(values: TypeaheadOption<T>[]) {
     if (values.length === 0) {
-      this.props.onChange(null);
+      this.props.onChange(undefined);
     } else {
       this.props.onChange(values.map(option => option.value));
     }
@@ -191,6 +191,6 @@ export default class TypeaheadMultiple<T> extends Component<
 /**
  * Variant of the TypeaheadMultiple which can be used in a Jarb context.
  */
-export const JarbTypeaheadMultiple = withJarb<any[], any[] | null, Props<any>>(
+export const JarbTypeaheadMultiple = withJarb<any[], any[] | undefined, Props<any>>(
   TypeaheadMultiple
 );

--- a/src/form/Typeahead/single/TypeaheadSingle.test.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.test.tsx
@@ -60,7 +60,7 @@ describe('Component: TypeaheadSingle', () => {
         asyncTypeahead.props().onChange([]);
 
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
-        expect(onChangeSpy).toHaveBeenCalledWith(null);
+        expect(onChangeSpy).toHaveBeenCalledWith(undefined);
       });
 
       test('value selected', () => {
@@ -122,7 +122,7 @@ describe('Component: TypeaheadSingle', () => {
           });
 
           expect(onChangeSpy).toHaveBeenCalledTimes(1);
-          expect(onChangeSpy).toHaveBeenCalledWith(null);
+          expect(onChangeSpy).toHaveBeenCalledWith(undefined);
           done();
         } catch (error) {
           console.error(error);

--- a/src/form/Typeahead/single/TypeaheadSingle.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.tsx
@@ -44,7 +44,7 @@ interface Props<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T | null) => void;
+  onChange: (value: T | undefined) => void;
 
   /**
    * Callback for when the form element gets the focus.
@@ -107,7 +107,7 @@ export default class TypeaheadSingle<T> extends Component<Props<T>, State<T>> {
 
   onChange(values: TypeaheadOption<T>[]) {
     if (values.length === 0) {
-      this.props.onChange(null);
+      this.props.onChange(undefined);
     } else {
       const selectedOption = values[0];
 
@@ -141,7 +141,7 @@ export default class TypeaheadSingle<T> extends Component<Props<T>, State<T>> {
     if (selectedValue) {
       this.props.onChange(selectedValue.value);
     } else {
-      this.props.onChange(null);
+      this.props.onChange(undefined);
     }
   }
 
@@ -159,7 +159,7 @@ export default class TypeaheadSingle<T> extends Component<Props<T>, State<T>> {
       className = ''
     } = this.props;
 
-    const selected = [];
+    const selected: TypeaheadOption<T>[] = [];
     if (value) {
       const option = valueToTypeaheadOption(value, optionForValue);
       selected.push(option);

--- a/src/form/ValuePicker/ValuePicker.stories.tsx
+++ b/src/form/ValuePicker/ValuePicker.stories.tsx
@@ -35,7 +35,7 @@ const large = Promise.resolve(
 storiesOf('Form|ValuePicker/multiple', module)
   .addParameters({ component: ValuePicker })
   .add('basic', () => {
-    const [value, setValue] = useState([]);
+    const [value, setValue] = useState<User[] | undefined>(undefined);
 
     const [size, setSize] = useState('small');
 
@@ -97,7 +97,7 @@ storiesOf('Form|ValuePicker/multiple', module)
 storiesOf('Form|ValuePicker/single', module)
   .addParameters({ component: ValuePicker })
   .add('basic', () => {
-    const [value, setValue] = useState(undefined);
+    const [value, setValue] = useState<User | undefined>(undefined);
 
     const [size, setSize] = useState('small');
 

--- a/src/form/ValuePicker/ValuePicker.tsx
+++ b/src/form/ValuePicker/ValuePicker.tsx
@@ -89,7 +89,7 @@ interface SingleValuePicker<T> extends BaseValuePickerProps<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T | null) => void;
+  onChange: (value: T) => void;
 
   /**
    * The value that the form element currently has.
@@ -106,7 +106,7 @@ interface MultipleValuePicker<T> extends BaseValuePickerProps<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T[] | null) => void;
+  onChange: (value: T[]) => void;
 
   /**
    * The value that the form element currently has.

--- a/src/table/EpicTable/EpicTable.tsx
+++ b/src/table/EpicTable/EpicTable.tsx
@@ -147,7 +147,7 @@ export function EpicTable({
             </div>
           }
           center={
-            center.length > 0
+            center && center.length > 0
               ? center.map((section, index) => (
                   <Fragment key={index}>
                     <div className="d-flex justify-content-between">
@@ -167,11 +167,11 @@ export function EpicTable({
               : null
           }
           right={
-            hasRight && right.length > 0 ? (
+            hasRight && right && right.length > 0 ? (
               <div
                 className={containsActiveDetailRow || overlay ? '' : 'shadow'}
               >
-                {right.map((section, index) => (
+                {right && right.map((section, index) => (
                   <Fragment key={index}>
                     {section.header}
 

--- a/src/table/EpicTable/cells/EpicHeader/EpicResize/EpicResize.test.tsx
+++ b/src/table/EpicTable/cells/EpicHeader/EpicResize/EpicResize.test.tsx
@@ -30,6 +30,7 @@ describe('Component: EpicResize', () => {
         <EpicResize width={300} onResize={onResizeSpy} />
       );
 
+      // @ts-ignore
       epicResize
         .find('div')
         .props()
@@ -72,6 +73,7 @@ describe('Component: EpicResize', () => {
         <EpicResize width={300} onResize={onResizeSpy} />
       );
 
+      // @ts-ignore
       epicResize
         .find('div')
         .props()

--- a/src/table/EpicTable/helpers/FixedHeader/FixedHeader.tsx
+++ b/src/table/EpicTable/helpers/FixedHeader/FixedHeader.tsx
@@ -69,7 +69,7 @@ export function FixedHeader({
         <GooeyCenter
           left={<div className="shadow">{left[index].header}</div>}
           center={
-            center.length > 0 ? (
+            center && center.length > 0 ? (
               <div
                 ref={fixedCenterEl}
                 className="d-flex justify-content-between overflow-hidden"
@@ -80,7 +80,7 @@ export function FixedHeader({
             ) : null
           }
           right={
-            right.length > 0 ? (
+            right && right.length > 0 ? (
               <div className="shadow">{right[index].header}</div>
             ) : null
           }

--- a/src/table/EpicTable/helpers/FixedHeader/useClosestHeaderIndex.ts
+++ b/src/table/EpicTable/helpers/FixedHeader/useClosestHeaderIndex.ts
@@ -4,19 +4,18 @@
 // Therefore there are a ton of stories for e2e testing instead. So
 // that is why the EpicTable is ignored by istanbul.
 
-import { useEffect, useState, MutableRefObject } from 'react';
-import { last } from 'lodash';
+import { useEffect, useState, RefObject } from 'react';
 import { HeaderRef } from '../../types';
 
 /**
- * Calculates which header is rendered closest to the FixedHeader by 
+ * Calculates which header is rendered closest to the FixedHeader by
  * index
- * 
+ *
  * Used to determine which header the FixedHeader should take as
  * its appearance.
  */
 export function useClosestHeaderIndex(
-  fixedHeaderEl: MutableRefObject<HTMLDivElement>,
+  fixedHeaderEl: RefObject<HTMLDivElement>,
   headers: HeaderRef[]
 ) {
   const [index, setIndex] = useState(-1);
@@ -33,7 +32,11 @@ export function useClosestHeaderIndex(
         });
 
         if (headersAboveFakeHeader && headersAboveFakeHeader.length > 0) {
-          setIndex(last(headersAboveFakeHeader).index);
+          const lastIndex = headersAboveFakeHeader.length - 1;
+
+          setIndex(
+            headersAboveFakeHeader[lastIndex].index
+          );
         } else {
           setIndex(-1);
         }

--- a/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
+++ b/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
@@ -65,8 +65,8 @@ export function GooeyCenter({
   showScrollbar = true,
   onCenterWidthChanged
 }: Props) {
-  const wrapperEl = useRef(null);
-  const centerEl = useRef(null);
+  const wrapperEl = useRef<HTMLDivElement>(null);
+  const centerEl = useRef<HTMLDivElement>(null);
 
   const [centerWidth, setCenterWidth] = useState(0);
 
@@ -74,8 +74,8 @@ export function GooeyCenter({
     const calculateCenterWidth = debounce(() => {
       if (wrapperEl.current) {
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const [left, _, right] = wrapperEl.current.children;
+        const left = wrapperEl.current.children[0];
+        const right = wrapperEl.current.children[2];
 
         const rightWidth = right ? right.clientWidth : 0;
 

--- a/src/table/EpicTable/helpers/layout/layout.ts
+++ b/src/table/EpicTable/helpers/layout/layout.ts
@@ -4,7 +4,7 @@
 // Therefore there are a ton of stories for e2e testing instead. So
 // that is why the EpicTable is ignored by istanbul.
 
-import { Children, cloneElement, createElement } from 'react';
+import { Children, cloneElement, createElement, ReactElement } from 'react';
 import { isFragment } from 'react-is';
 
 import { EpicExpanderRow } from '../../rows/EpicExpanderRow/EpicExpanderRow';
@@ -169,13 +169,13 @@ export function epicTableLayout(
   hasRight: boolean
 ): EpicTableLayout {
   // Will contain all the first columns as sections.
-  const left = [];
+  const left: EpicTableLayoutSection[] = [];
 
   // Will contain the middle columns as sections.
-  const center = [];
+  const center: EpicTableLayoutSection[] = [];
 
   // Will contain all the last columns as sections.
-  const right = [];
+  const right: EpicTableLayoutSection[] = [];
 
   let leftSection: EpicTableLayoutSection = { header: [], contents: [] };
   let centerSection: EpicTableLayoutSection = { header: [], contents: [] };
@@ -185,13 +185,13 @@ export function epicTableLayout(
   // so it renders the shadows properly.
   let containsActiveDetailRow = false;
 
-  Children.forEach(getRows(children), (row, index) => {
-    if (row.type === EpicExpanderRow && rect) {
-      return handleExpanderRow(row);
+  Children.forEach(getRows(children), (row: ReactElement, index) => {
+    if (row.type === EpicExpanderRow && rect !== null) {
+      return handleExpanderRow(row, rect);
     }
 
-    if (row.type === EpicDetailRow && rect) {
-      return handleEpicDetailRow(row);
+    if (row.type === EpicDetailRow && rect !== null) {
+      return handleEpicDetailRow(row, rect);
     }
 
     handleEpicRow(row, index);
@@ -245,12 +245,12 @@ export function epicTableLayout(
     }
 
     // These will contain all non header cells
-    const leftRow = [];
-    const centerRow = [];
-    const rightRow = [];
+    const leftRow: ReactElement[] = [];
+    const centerRow: ReactElement[] = [];
+    const rightRow: ReactElement[] = [];
 
     // Put all cells in the correct bucket
-    Children.forEach(cells, (cell, cellIndex) => {
+    Children.forEach(cells, (cell: ReactElement, cellIndex) => {
       // The first cell should be bucketed on the left
       if (cellIndex === 0) {
         if (isHeader) {
@@ -290,7 +290,7 @@ export function epicTableLayout(
   }
 
   // Impure helper function for handling EpicDetailRow's
-  function handleEpicDetailRow(row: any) {
+  function handleEpicDetailRow(row: any, rect: DOMRect | ClientRect) {
     // Clone the element because we are injecting extra props.
     const clone = cloneElement(row, {
       width: rect.width - row.props.left,
@@ -315,7 +315,7 @@ export function epicTableLayout(
   }
 
   // Impure helper function for handling ExpanderRow's
-  function handleExpanderRow(row: any) {
+  function handleExpanderRow(row: any, rect: DOMRect | ClientRect) {
     // Clone the element because we are injecting extra props.
     const clone = cloneElement(row, { width: rect.width, key: 1337 });
 
@@ -346,12 +346,12 @@ export function epicTableLayout(
 // Function which gathers all Row's inside of the EpicTable.
 // Also unpacks fragments at one level deep to help the user map
 // over array's
-export function getRows(children: any) {
-  const rows = [];
+export function getRows(children: any): ReactElement[] {
+  const rows: ReactElement[] = [];
 
-  Children.forEach(children, child => {
+  Children.forEach(children, (child: ReactElement) => {
     if (isFragment(child)) {
-      child.props.children.forEach(row => {
+      child.props.children.forEach((row: ReactElement) => {
         rows.push(row);
       });
     } else {

--- a/src/table/EpicTable/helpers/useEpicTableRect.ts
+++ b/src/table/EpicTable/helpers/useEpicTableRect.ts
@@ -4,9 +4,9 @@
 // Therefore there are a ton of stories for e2e testing instead. So
 // that is why the EpicTable is ignored by istanbul.
 
-import { MutableRefObject, useState, useEffect } from "react";
+import { useState, useEffect, RefObject } from "react";
 
-export function useEpicTableRect(epicTableEl: MutableRefObject<HTMLDivElement>) {
+export function useEpicTableRect(epicTableEl: RefObject<HTMLDivElement>) {
   const [epicTableRect, setEpicTableRect] = useState<
     DOMRect | ClientRect | null
   >(null);

--- a/src/table/EpicTable/widgets/EpicDetail/EpicDetail.test.tsx
+++ b/src/table/EpicTable/widgets/EpicDetail/EpicDetail.test.tsx
@@ -34,6 +34,7 @@ describe('Component: EpicDetail', () => {
 
       const event = new MouseEvent('click');
 
+      // @ts-ignore
       epicDetail
         .find(Icon)
         .props()

--- a/src/table/EpicTable/widgets/EpicExpander/EpicExpander.test.tsx
+++ b/src/table/EpicTable/widgets/EpicExpander/EpicExpander.test.tsx
@@ -34,6 +34,7 @@ describe('Component: EpicExpander', () => {
     it('should open the expander when it is clicked when it is closed', () => {
       const { epicExpander, onChangeSpy } = setup({ open: false });
 
+      // @ts-ignore
       epicExpander
         .find(Button)
         .props()
@@ -47,6 +48,7 @@ describe('Component: EpicExpander', () => {
     it('should close the expander when it is clicked when it is open', () => {
       const { epicExpander, onChangeSpy } = setup({ open: true });
 
+      // @ts-ignore
       epicExpander
         .find(Button)
         .props()

--- a/src/table/EpicTable/widgets/EpicSelection/EpicSelection.test.tsx
+++ b/src/table/EpicTable/widgets/EpicSelection/EpicSelection.test.tsx
@@ -34,6 +34,7 @@ describe('Component: EpicSelection', () => {
     it('should call onChange with true when checkbox is clicked while not checked', () => {
       const { epicSelection, onChangeSpy } = setup({ checked: false });
 
+      // @ts-ignore
       epicSelection
         .find(Input)
         .props()
@@ -47,6 +48,7 @@ describe('Component: EpicSelection', () => {
     it('should call onChange with false when checkbox is clicked while checked', () => {
       const { epicSelection, onChangeSpy } = setup({ checked: true });
 
+      // @ts-ignore
       epicSelection
         .find(Input)
         .props()

--- a/src/table/EpicTable/widgets/EpicSort/EpicSort.test.tsx
+++ b/src/table/EpicTable/widgets/EpicSort/EpicSort.test.tsx
@@ -45,6 +45,7 @@ describe('Component: EpicSort', () => {
     it('should call onChange with true when checkbox is clicked while not checked', () => {
       const { epicSelection, onChangeSpy } = setup({ direction: 'DESC' });
 
+      // @ts-ignore
       epicSelection
         .find(Icon)
         .props()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "target": "es6",
     "sourceMap": true,
     "lib": ["es6", "dom"],
-    "jsx": "react"
+    "jsx": "react",
+    "strictNullChecks": true
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*"]


### PR DESCRIPTION
The `Icon` when no `onClick` prop was provided would crash when clicked.
This was caused because when `onClick` is not a function calling it
results in an error.

This is strange because TypeScript should have caught this error. When
`onClick` can be `undefined` or a `function` it should warn us when we
have not made sure that it is a function.

Turns out that when `strictNullChecks` is `false`, which is the default,
any destructuring makes that type a non-null. This is of course wrong!

So this commit enables the `strictNullChecks` compiler flag. Also adds a
`tsc` script which checks the entire code. This way it is easier to get
all TypeScript errors out of the way first, whether they are in a story
or in a test or in the source code.

Enabling this flag causes a lot of errors:

  1. Added @ts-ignore on tests which called `ShallowWrapper.find` and
     proceed as if there is always something found. If they find nothing
     the test will fail anyway.

  2. Typed the `EpicTable` since it now misses a lot of types. A number
     checks are now written to ensure non null.

  3. ValuePicker components no longer say they can emit `null` on `onChange`
     since they do not do that.

  4. TypeaheadMultiple and TypeaheadSingle emit `undefined` instead of `null`
     when the value is empty. This makes for an easier type because the `value`
     can always be `undefined` already.

  5. ImageUpload removed `defaultProps.text` as empty object construction
     which `TypeScript` does not understand now. Added tests for custom
     text to prove it still works.

  6. Added extra `onClick` exists check on `ProgressStepper`.

  7. Made explicit various variable definitions, so TypeScript compiles.

Tiny refactor: changed ImgUpload to ImageUpload in the test.

Fixes: #222