### PR TITLE
improvement: `withJarb` will now throw errors when detecting wrong pr…

### DIFF
--- a/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
+++ b/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HoC: withJarb should throw an error when detecting illegal props 1`] = `
+"
+        withJarb: illegal props detected on \\"JarbInput\\".
+        
+        The following illegal props were detected: 'onChange' and 'value'.
+        
+        This happens when providing one or multiple of the following 
+        managed props: 'onChange', 'onBlur', 'onFocus', 'value', 'color', 'valid' or 'error' manually. 
+        
+        You should never provide these props manually instead you should
+        trust that \\"withJarb\\" will manage these props for you.
+
+        Remove the following illegal props: 'onChange' and 'value'.
+      "
+`;
+
 exports[`HoC: withJarb ui: withJarb => ui => formError 1`] = `
 <Fragment>
   <FormFeedback

--- a/src/form/withJarb/withJarb.test.tsx
+++ b/src/form/withJarb/withJarb.test.tsx
@@ -35,7 +35,7 @@ describe('HoC: withJarb', () => {
         label="First name"
         placeholder="Please enter your first name"
         // Should pass `passedFieldProps`
-        initialValue="beheer@42.nl" 
+        initialValue="beheer@42.nl"
         format={() => 'yolo'}
         formatOnBlur={false}
         parse={() => 'oloy'}
@@ -61,6 +61,13 @@ describe('HoC: withJarb', () => {
     expect(toJson(jarbFieldParent)).toMatchSnapshot('withJarb => ui');
     expect(toJson(jarbField)).toMatchSnapshot('withJarb => ui => jarbField');
     expect(toJson(formError)).toMatchSnapshot('withJarb => ui => formError');
+  });
+
+  it('should throw an error when detecting illegal props', () => {
+    expect(() =>
+      // @ts-ignore
+      shallow(<JarbInput value="test" onChange={() => undefined} />)
+    ).toThrowErrorMatchingSnapshot();
   });
 
   describe('events', () => {


### PR DESCRIPTION
…ops.

Before this commit when the user accidentally used one of the props
that `withJarb` managed for you. The form element would no longer work.

Unfortunately I cannot get `TypeScript` to understand that there is
a set of all props, from JarbField and from the props of the wrapped
component. And that it should strip away the managed props. I've tried
for 2 days and I cannot get this to work.

So now we simply throw errors when seeing that the user has provided
managed properties. A very detailed error message instructs the user
to trust `withJarb` and to remove those properties.

Closes: #228