### PR TITLE
improvement: EpicTable is now flat when no horizontal scrollbar is shown

### DIFF
--- a/src/table/EpicTable/EpicTable.stories.tsx
+++ b/src/table/EpicTable/EpicTable.stories.tsx
@@ -669,6 +669,69 @@ storiesOf('table|EpicTable', module)
       </Card>
     );
   })
+  .add('small example', () => {
+    return (
+      <Card body>
+        <EpicTable>
+          <EpicRow header>
+            <EpicHeader width={300} height={44}>
+              First name
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Last name
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Age
+            </EpicHeader>
+            <EpicHeader width={300} height={44}>
+              Actions
+            </EpicHeader>
+          </EpicRow>
+
+          {persons.map(person => (
+            <EpicRow key={person.id}>
+              <EpicCell width={300} height={44}>
+                {person.firstName}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.lastName}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.age}
+              </EpicCell>
+              <EpicCell width={300} height={44}>
+                <Button icon="delete" /> <Button icon="edit" />
+              </EpicCell>
+            </EpicRow>
+          ))}
+        </EpicTable>
+      </Card>
+    );
+  })
+  .add('no header', () => {
+    return (
+      <Card body>
+        <EpicTable>
+          {persons.map(person => (
+            <EpicRow key={person.id}>
+              <EpicCell width={300} height={44}>
+                {person.firstName}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.lastName}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.age}
+              </EpicCell>
+              <EpicCell width={300} height={44}>
+                <Button icon="delete" /> <Button icon="edit" />
+              </EpicCell>
+            </EpicRow>
+          ))}
+        </EpicTable>
+      </Card>
+    );
+  })
   .add('no right', () => {
     return (
       <Card body>

--- a/src/table/EpicTable/EpicTable.tsx
+++ b/src/table/EpicTable/EpicTable.tsx
@@ -63,15 +63,15 @@ interface Props {
  *   7. Filtering per column.
  *   8. Resizing of columns.
  *   9. Multiple headers
- * 
+ *
  * See the stories in the documentation for detailed examples.
- * 
+ *
  * That said there are a couple of rules:
- * 
+ *
  *   1. Do not render anything inside of the EpicTable which is not
  *      one of the row's. The EpicTable will not understand those and
  *      it will error.
- * 
+ *
  *   2. The EpicTable can contain fragments, and will unpack those, but
  *      only one level deep. Those fragments should contain only row's.
  */
@@ -101,7 +101,15 @@ export function EpicTable({
 
   const layout = epicTableLayout(children, epicTableRect, hasRight);
 
-  const { center, right, left, containsActiveDetailRow } = layout;
+  const {
+    center,
+    right,
+    left,
+    containsActiveDetailRow,
+    totalDesiredCenterWidth
+  } = layout;
+
+  const desiredWidthMet = totalDesiredCenterWidth < centerWidth;
 
   return (
     <div
@@ -109,7 +117,9 @@ export function EpicTable({
       className="epic-table"
       style={{ minHeight: minHeight }}
     >
-      <div className="epic-table-container">
+      <div
+        className={`epic-table-container ${desiredWidthMet ? 'shadow' : ''}`}
+      >
         {overlay && epicTableRect ? (
           <div
             className="epic-table-overlay shadow"
@@ -134,7 +144,10 @@ export function EpicTable({
           onCenterWidthChanged={setCenterWidth}
           onScroll={setLeftScroll}
           left={
-            <div className={overlay ? '' : 'shadow'} style={{ minHeight }}>
+            <div
+              className={desiredWidthMet || overlay ? '' : 'shadow'}
+              style={{ minHeight }}
+            >
               {left.map((section, index) => (
                 <Fragment key={index}>
                   <div ref={ref => registerHeader(ref, index)}>
@@ -169,15 +182,20 @@ export function EpicTable({
           right={
             hasRight && right && right.length > 0 ? (
               <div
-                className={containsActiveDetailRow || overlay ? '' : 'shadow'}
+                className={
+                  desiredWidthMet || containsActiveDetailRow || overlay
+                    ? ''
+                    : 'shadow'
+                }
               >
-                {right && right.map((section, index) => (
-                  <Fragment key={index}>
-                    {section.header}
+                {right &&
+                  right.map((section, index) => (
+                    <Fragment key={index}>
+                      {section.header}
 
-                    {section.contents}
-                  </Fragment>
-                ))}
+                      {section.contents}
+                    </Fragment>
+                  ))}
               </div>
             ) : null
           }

--- a/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
+++ b/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
@@ -53,8 +53,8 @@ type Props = {
  *
  * The center gets a horizontal scrollbar for when the content
  * is to large to fit in the center.
- * 
- * GooeyCenter is not meant for consumers of the library and is 
+ *
+ * GooeyCenter is not meant for consumers of the library and is
  * a private component.
  */
 export function GooeyCenter({
@@ -70,35 +70,37 @@ export function GooeyCenter({
 
   const [centerWidth, setCenterWidth] = useState(0);
 
-  useEffect(function trackCenterWidthBasedOnResize() {
-    const calculateCenterWidth = debounce(() => {
-      if (wrapperEl.current) {
+  useEffect(
+    function trackCenterWidthBasedOnResize() {
+      const calculateCenterWidth = debounce(() => {
+        if (wrapperEl.current) {
+          const left = wrapperEl.current.children[0];
+          const right = wrapperEl.current.children[2];
 
-        const left = wrapperEl.current.children[0];
-        const right = wrapperEl.current.children[2];
+          const rightWidth = right ? right.clientWidth : 0;
 
-        const rightWidth = right ? right.clientWidth : 0;
+          const centerWidth =
+            wrapperEl.current.clientWidth - left.clientWidth - rightWidth;
 
-        const centerWidth =
-          wrapperEl.current.clientWidth - left.clientWidth - rightWidth;
+          setCenterWidth(centerWidth);
 
-        setCenterWidth(centerWidth);
-
-        if (onCenterWidthChanged) {
-          onCenterWidthChanged(centerWidth);
+          if (onCenterWidthChanged) {
+            onCenterWidthChanged(centerWidth);
+          }
         }
-      }
-    }, 200);
+      }, 200);
 
-    window.addEventListener('resize', calculateCenterWidth);
+      window.addEventListener('resize', calculateCenterWidth);
 
-    // Calculate at least once on startup
-    calculateCenterWidth();
+      // Calculate at least once on startup
+      calculateCenterWidth();
 
-    return () => {
-      window.removeEventListener('resize', calculateCenterWidth);
-    };
-  }, [setCenterWidth, onCenterWidthChanged]);
+      return () => {
+        window.removeEventListener('resize', calculateCenterWidth);
+      };
+    },
+    [setCenterWidth, onCenterWidthChanged]
+  );
 
   function handleScroll(this: OverlayScrollbars, event?: UIEvent) {
     if (onScroll && event) {
@@ -123,6 +125,7 @@ export function GooeyCenter({
 
       {center && showScrollbar ? (
         <OverlayScrollbarsComponent
+          className="w-100"
           options={{
             scrollbars: {
               visibility: 'visible'


### PR DESCRIPTION
Multiple people are taken aback by the shadows produced on a very small
table. This is because they do not see that the center can be scrolled
in this case. So when a table is small enough not to need a horizontal
scrollbar it should not render the shadows and instead be more flat.

The technical solution is to calculate the total desired width of the
center as given by the user. When the desired width can be met, there is
no need for a horizontal scrollbar. In that case we do not render shadows
around the left and right column, but only around the container.

Also the `GooeyCenter` now renders at 100% width to prevent width
flickering.

Closes #230