### PR TITLE
improvement: `EpicTable` is now striped like a zebra by default.

### DIFF
--- a/src/table/EpicTable/EpicTable.scss
+++ b/src/table/EpicTable/EpicTable.scss
@@ -1,6 +1,14 @@
 .epic-table {
   background-color: $gray-100;
 
+  &--striped {
+    .epic-table-cell--odd {
+      // Must be transparent otherwise the shadow of the left / right
+      // columns are negated.
+      background-color: rgba($gray-400, 0.3);
+    }
+  }
+
   &-container {
     position: relative;
   }

--- a/src/table/EpicTable/EpicTable.stories.tsx
+++ b/src/table/EpicTable/EpicTable.stories.tsx
@@ -669,6 +669,93 @@ storiesOf('table|EpicTable', module)
       </Card>
     );
   })
+  .add('no stipes', () => {
+    return (
+      <Card body>
+        <EpicTable striped={false}>
+          <EpicRow header>
+            <EpicHeader width={300} height={44}>
+              First name
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Last name
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Age
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Eye color
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Height
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Weight
+            </EpicHeader>
+            <EpicHeader width={200} height={44}>
+              Job title
+            </EpicHeader>
+            <EpicHeader width={300} height={44}>
+              Favorite movie
+            </EpicHeader>
+            <EpicHeader width={150} height={44}>
+              Favorite food
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Birth date
+            </EpicHeader>
+            <EpicHeader width={100} height={44}>
+              Sex
+            </EpicHeader>
+            <EpicHeader width={300} height={44}>
+              Actions
+            </EpicHeader>
+          </EpicRow>
+
+          {persons.map(person => (
+            <EpicRow key={person.id}>
+              <EpicCell width={300} height={44}>
+                {person.firstName}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.lastName}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.age}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.eyeColor}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.height}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.weight}
+              </EpicCell>
+              <EpicCell width={200} height={44}>
+                {person.jobTitle}
+              </EpicCell>
+              <EpicCell width={300} height={44}>
+                {person.favoriteMovie}
+              </EpicCell>
+              <EpicCell width={150} height={44}>
+                {person.favoriteFood}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.birthDate}
+              </EpicCell>
+              <EpicCell width={100} height={44}>
+                {person.sex}
+              </EpicCell>
+              <EpicCell width={300} height={44}>
+                <Button icon="delete" /> <Button icon="edit" />
+              </EpicCell>
+            </EpicRow>
+          ))}
+        </EpicTable>
+      </Card>
+    );
+  })
   .add('small example', () => {
     return (
       <Card body>
@@ -1156,7 +1243,7 @@ storiesOf('table|EpicTable', module)
 
     return (
       <Card body>
-        <EpicTable>
+        <EpicTable striped={false}>
           {letters.map(letter => (
             <Fragment key={letter}>
               <EpicRow header>

--- a/src/table/EpicTable/EpicTable.tsx
+++ b/src/table/EpicTable/EpicTable.tsx
@@ -122,7 +122,10 @@ export function EpicTable({
   const desiredWidthMet = totalDesiredCenterWidth < centerWidth;
 
   const classes = classNames('epic-table', {
-    'epic-table--striped': striped
+    'epic-table--striped': striped,
+    // Making it invisible when not fully calculated, prevents
+    // the content from instantly resizing and flickering.
+    invisible: centerWidth === 0
   });
 
   return (

--- a/src/table/EpicTable/EpicTable.tsx
+++ b/src/table/EpicTable/EpicTable.tsx
@@ -5,6 +5,7 @@
 // that is why the EpicTable is ignored by istanbul.
 
 import React, { useRef, Fragment, useState } from 'react';
+import classNames from 'classnames';
 
 import { FixedHeader } from './helpers/FixedHeader/FixedHeader';
 import { GooeyCenter } from './helpers/GooeyCenter/GooeyCenter';
@@ -35,7 +36,7 @@ interface Props {
   /**
    * Whether or not to render a fixed right column.
    *
-   * Defaults to true
+   * Defaults to true.
    */
   hasRight?: boolean;
 
@@ -45,6 +46,13 @@ interface Props {
    * error states.
    */
   overlay?: React.ReactNode;
+
+  /**
+   * Whether or not to add zebra stripes to the table.
+   *
+   * Defaults to true.
+   */
+  striped?: boolean;
 }
 
 /**
@@ -63,6 +71,7 @@ interface Props {
  *   7. Filtering per column.
  *   8. Resizing of columns.
  *   9. Multiple headers
+ *  10. Zebra stripes.
  *
  * See the stories in the documentation for detailed examples.
  *
@@ -79,7 +88,8 @@ export function EpicTable({
   children,
   minHeight = 600,
   hasRight = true,
-  overlay
+  overlay,
+  striped = true
 }: Props) {
   const epicTableEl = useRef<HTMLDivElement>(null);
 
@@ -111,12 +121,12 @@ export function EpicTable({
 
   const desiredWidthMet = totalDesiredCenterWidth < centerWidth;
 
+  const classes = classNames('epic-table', {
+    'epic-table--striped': striped
+  });
+
   return (
-    <div
-      ref={epicTableEl}
-      className="epic-table"
-      style={{ minHeight: minHeight }}
-    >
+    <div ref={epicTableEl} className={classes} style={{ minHeight: minHeight }}>
       <div
         className={`epic-table-container ${desiredWidthMet ? 'shadow' : ''}`}
       >

--- a/src/table/EpicTable/cells/EpicCell/EpicCell.tsx
+++ b/src/table/EpicTable/cells/EpicCell/EpicCell.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 interface Props {
   /**
@@ -17,14 +18,25 @@ interface Props {
   height: number;
 }
 
+// Props that will be injected by the EpicTable.
+interface InjectedProps {
+  odd: boolean;
+}
+
 /**
  * The EpicCell is used inside of a EpicRow to render content in.
  * It can be seen as the EpicTable's variant of the `<td>` element.
  */
-export function EpicCell({ children, width, height }: Props) {
+export function EpicCell({ children, width, height, ...rest }: Props) {
+  const { odd } = rest as InjectedProps;
+
+  const classes = classNames('epic-table-cell border-bottom p-1', {
+    'epic-table-cell--odd': odd
+  });
+
   return (
     <div
-      className="epic-table-cell border-bottom p-1"
+      className={classes}
       style={{
         minWidth: width,
         width,

--- a/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
+++ b/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
@@ -111,8 +111,10 @@ export function GooeyCenter({
   const centerWrapper = (
     <div
       ref={centerEl}
-      // Making it undefined when not fully calculated, prevents
+      // Making it invisible when not fully calculated, prevents
       // the content from instantly resizing and flickering.
+      // Also the width must be undefined for this to work.
+      className={centerWidth === 0 ? 'invisible' : ''}
       style={{ width: centerWidth !== 0 ? centerWidth : undefined }}
     >
       {center}

--- a/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
+++ b/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
@@ -99,7 +99,7 @@ export function GooeyCenter({
         window.removeEventListener('resize', calculateCenterWidth);
       };
     },
-    [setCenterWidth, onCenterWidthChanged]
+    [setCenterWidth, onCenterWidthChanged, left, center, right]
   );
 
   function handleScroll(this: OverlayScrollbars, event?: UIEvent) {

--- a/src/table/EpicTable/helpers/layout/layout.ts
+++ b/src/table/EpicTable/helpers/layout/layout.ts
@@ -218,7 +218,12 @@ export function epicTableLayout(
   // so it renders the shadows properly.
   let containsActiveDetailRow = false;
 
-  Children.forEach(getRows(children), (row: ReactElement, index) => {
+  // Increases whenever an epic-row is encounted, used to determine
+  // if the row is striped. Needs a separate counter because other
+  // rows can be mixed with epic-row's.
+  let epicRowNumber = 1;
+
+  Children.forEach(getRows(children), (row: ReactElement) => {
     if (row.type === EpicExpanderRow && rect !== null) {
       return handleExpanderRow(row, rect);
     }
@@ -227,7 +232,8 @@ export function epicTableLayout(
       return handleEpicDetailRow(row, rect);
     }
 
-    handleEpicRow(row, index);
+    handleEpicRow(row, epicRowNumber);
+    epicRowNumber += 1;
   });
 
   left.push(leftSection);
@@ -281,6 +287,7 @@ export function epicTableLayout(
       leftSection = { header: [], contents: [] };
       centerSection = { header: [], contents: [] };
       rightSection = { header: [], contents: [] };
+      epicRowNumber = 1;
     }
 
     // These will contain all non header cells
@@ -288,31 +295,38 @@ export function epicTableLayout(
     const centerRow: ReactElement[] = [];
     const rightRow: ReactElement[] = [];
 
+    const isRowOdd = index % 2 === 1;
+
     // Put all cells in the correct bucket
     Children.forEach(cells, (cell: ReactElement, cellIndex) => {
+      const left = cellIndex === 0;
+      const right = hasRight && cellIndex === lastCellInRowIndex;
+
+      const clone = cloneElement(cell, { odd: isRowOdd, key: cellIndex });
+
       // The first cell should be bucketed on the left
-      if (cellIndex === 0) {
+      if (left) {
         if (isHeader) {
-          leftSection.header.push(cell);
+          leftSection.header.push(clone);
         } else {
-          leftRow.push(cell);
+          leftRow.push(clone);
         }
       }
       // The last cell should be bucketed on the right, if there is a right
-      else if (hasRight && cellIndex === lastCellInRowIndex) {
+      else if (right) {
         if (isHeader) {
-          rightSection.header.push(cell);
+          rightSection.header.push(clone);
         } else {
-          rightRow.push(cell);
+          rightRow.push(clone);
         }
       }
       // All cells in the center (or when there is no right) should be
       // bucketed in the center.
       else {
         if (isHeader) {
-          centerSection.header.push(cell);
+          centerSection.header.push(clone);
         } else {
-          centerRow.push(cell);
+          centerRow.push(clone);
         }
       }
     });


### PR DESCRIPTION
The `EpicCell` now has an injected property called `odd`. When `odd` is
`true` the cell sets a CSS class called `epic-table-cell--odd` which set
a transparent blue background color.

The `odd` property is injected by the `EpicTableLayout` based on the
number of encountered `EpicRow`'s. Each section resets the count so each
sections starts fresh.

`GooeyCenter` now has to recalculate whenever the left, right and center
change, otherwise the zebra stripes will bleed through the right column
of the EpicTable.

Closes: #238