### PR TITLE
improvement: all ValuePickers support custom `isOptionEqual` checks now.

### DIFF
--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState} from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { range } from 'lodash';
 
@@ -6,7 +6,7 @@ import CheckboxMultipleSelect, {
   JarbCheckboxMultipleSelect
 } from './CheckboxMultipleSelect';
 import { FinalForm, Form } from '../story-utils';
-import { pageOfUsers } from '../../test/fixtures';
+import { pageOfUsers, userUser } from '../../test/fixtures';
 import { User } from '../../test/types';
 
 interface SubjectOption {
@@ -51,6 +51,24 @@ storiesOf('Form|CheckboxMultipleSelect', module)
           placeholder="Please select your subjects"
           optionForValue={(user: User) => user.email}
           options={() => Promise.resolve(pageOfUsers)}
+          value={value}
+          onChange={setValue}
+        />
+      </Form>
+    );
+  })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<User[] | undefined>([userUser]);
+
+    return (
+      <Form>
+        <CheckboxMultipleSelect
+          id="subject"
+          label="Subject"
+          placeholder="Please select your subjects"
+          optionForValue={(user: User) => user.email}
+          options={() => Promise.resolve(pageOfUsers)}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={value}
           onChange={setValue}
         />

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
@@ -10,7 +10,7 @@ import {
   userUser,
   pageOfUsers
 } from '../../test/fixtures';
-import { OptionEnabledCallback } from '../types';
+import { OptionEnabledCallback } from '../option';
 
 describe('Component: CheckboxMultipleSelect', () => {
   let checkboxMultipleSelect: ShallowWrapper;
@@ -58,13 +58,18 @@ describe('Component: CheckboxMultipleSelect', () => {
 
     describe('loading', () => {
       test('with custom text', () => {
-        setup({ value: [adminUser], text: { loadingMessage: 'Custom loading' } });
+        setup({
+          value: [adminUser],
+          text: { loadingMessage: 'Custom loading' }
+        });
 
         // @ts-ignore
         checkboxMultipleSelect.setState({ loading: true });
 
         expect(checkboxMultipleSelect.find('Spinner').exists()).toBe(true);
-        expect(checkboxMultipleSelect.find('span').text()).toBe('Custom loading');
+        expect(checkboxMultipleSelect.find('span').text()).toBe(
+          'Custom loading'
+        );
       });
 
       test('with default text', () => {
@@ -82,16 +87,26 @@ describe('Component: CheckboxMultipleSelect', () => {
   describe('constructor', () => {
     test('when options is an array use that options and set loading to false', () => {
       // @ts-ignore
-      const checkboxMultipleSelect = new CheckboxMultipleSelect({ options: [adminUser] });
+      const checkboxMultipleSelect = new CheckboxMultipleSelect({
+        options: [adminUser]
+      });
 
-      expect(checkboxMultipleSelect.state).toEqual({ loading: false, options: [adminUser] });
+      expect(checkboxMultipleSelect.state).toEqual({
+        loading: false,
+        options: [adminUser]
+      });
     });
 
     test('when options is a function set options to empty and loading to true', () => {
       // @ts-ignore
-      const checkboxMultipleSelect = new CheckboxMultipleSelect({ options: jest.fn() });
+      const checkboxMultipleSelect = new CheckboxMultipleSelect({
+        options: jest.fn()
+      });
 
-      expect(checkboxMultipleSelect.state).toEqual({ loading: true, options: [] });
+      expect(checkboxMultipleSelect.state).toEqual({
+        loading: true,
+        options: []
+      });
     });
   });
 
@@ -105,7 +120,9 @@ describe('Component: CheckboxMultipleSelect', () => {
         onChange
       });
 
-      jest.spyOn(checkboxMultipleSelect, 'setState').mockImplementation(() => undefined);
+      jest
+        .spyOn(checkboxMultipleSelect, 'setState')
+        .mockImplementation(() => undefined);
 
       try {
         await checkboxMultipleSelect.componentDidMount();
@@ -126,9 +143,14 @@ describe('Component: CheckboxMultipleSelect', () => {
       const options = () => Promise.resolve(pageOfUsers);
 
       // @ts-ignore
-      const checkboxMultipleSelect = new CheckboxMultipleSelect({ options, onChange });
+      const checkboxMultipleSelect = new CheckboxMultipleSelect({
+        options,
+        onChange
+      });
 
-      jest.spyOn(checkboxMultipleSelect, 'setState').mockImplementation(() => undefined);
+      jest
+        .spyOn(checkboxMultipleSelect, 'setState')
+        .mockImplementation(() => undefined);
 
       try {
         await checkboxMultipleSelect.componentDidMount();
@@ -160,14 +182,14 @@ describe('Component: CheckboxMultipleSelect', () => {
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy).toHaveBeenCalledWith([adminUser]);
-      
-      // Check that selected is a copy of value 
+
+      // Check that selected is a copy of value
       expect(onChangeSpy.mock.calls[0][0]).not.toBe(value);
 
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
 
       // Manually set the value since it is external
-      value = [adminUser]
+      value = [adminUser];
       checkboxMultipleSelect.setProps({ value });
 
       // Now lets click on the coordinator it should be added
@@ -178,14 +200,14 @@ describe('Component: CheckboxMultipleSelect', () => {
 
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy).toHaveBeenCalledWith([adminUser, coordinatorUser]);
-      
-      // Check that selected is a copy of value 
+
+      // Check that selected is a copy of value
       expect(onChangeSpy.mock.calls[1][0]).not.toBe(value);
 
       expect(onBlurSpy).toHaveBeenCalledTimes(2);
 
       // Manually set the value since it is external
-      value = [adminUser, coordinatorUser]
+      value = [adminUser, coordinatorUser];
       checkboxMultipleSelect.setProps({ value });
 
       // Now lets click on the admin again it should be removed
@@ -196,8 +218,8 @@ describe('Component: CheckboxMultipleSelect', () => {
 
       expect(onChangeSpy).toHaveBeenCalledTimes(3);
       expect(onChangeSpy).toHaveBeenCalledWith([coordinatorUser]);
-      
-      // Check that selected is a copy of value 
+
+      // Check that selected is a copy of value
       expect(onChangeSpy.mock.calls[2][0]).not.toBe(value);
 
       expect(onBlurSpy).toHaveBeenCalledTimes(3);

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -6,7 +6,14 @@ import { Page } from '@42.nl/spring-connect';
 
 import withJarb from '../withJarb/withJarb';
 import Spinner from '../../core/Spinner/Spinner';
-import { Color, OptionsFetcher, OptionEnabledCallback } from '../types';
+import { Color } from '../types';
+import {
+  OptionsFetcher,
+  OptionEnabledCallback,
+  OptionForValue,
+  OptionEqual,
+  isOptionSelected
+} from '../option';
 import { t } from '../../utilities/translation/translation';
 import { doBlur } from '../utils';
 
@@ -49,7 +56,16 @@ interface Props<T> {
    * Callback to convert an value of type T to an option to show
    * to the user.
    */
-  optionForValue: (value: T) => string;
+  optionForValue: OptionForValue<T>;
+
+  /**
+   * Optional callback which is used to determine if two options
+   * of type T are equal.
+   *
+   * When `isOptionEqual` is not defined the outcome of `optionForValue`
+   * is used to test equality.
+   */
+  isOptionEqual?: OptionEqual<T>;
 
   /**
    * Optional callback which is called for every option to determine
@@ -197,7 +213,7 @@ export default class CheckboxMultipleSelect<T> extends Component<
   }
 
   renderCheckboxes() {
-    const { optionForValue, value } = this.props;
+    const { optionForValue, value, isOptionEqual } = this.props;
 
     const { options } = this.state;
 
@@ -213,7 +229,12 @@ export default class CheckboxMultipleSelect<T> extends Component<
               {options.map((option, index) => {
                 const label = optionForValue(option);
 
-                const isChecked = !!(value && value.some(v => option === v));
+                const isChecked = isOptionSelected({
+                  option,
+                  optionForValue,
+                  isOptionEqual,
+                  value
+                });
 
                 return (
                   <FormGroup check key={label}>

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -98,6 +98,27 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
       </Form>
     );
   })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<User[] | undefined>([userUser]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple<User>
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          fetchOptions={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+          }
+          optionForValue={(user: User) => user.email}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
+          value={value}
+          onChange={setValue}
+        />
+      </Form>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -9,7 +9,7 @@ import { User } from '../../../test/types';
 
 storiesOf('Form/ModalPicker/ModalPickerSingle', module)
   .add('basic', () => {
-    const [value, setValue] = useState<User| undefined>(undefined);
+    const [value, setValue] = useState<User | undefined>(undefined);
 
     return (
       <Form>
@@ -29,7 +29,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
     );
   })
   .add('with extra add button', () => {
-    const [value, setValue] = useState<User| undefined>(undefined);
+    const [value, setValue] = useState<User | undefined>(undefined);
 
     return (
       <Form>
@@ -62,7 +62,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
     );
   })
   .add('without search', () => {
-    const [value, setValue] = useState<User| undefined | null>(undefined);
+    const [value, setValue] = useState<User | undefined | null>(undefined);
 
     return (
       <Form>
@@ -74,6 +74,27 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
             Promise.resolve(pageWithContentAndExactSize([userUser]))
+          }
+          value={value}
+          onChange={setValue}
+        />
+      </Form>
+    );
+  })
+  .add('custom optionIsEqual', () => {
+    const [value, setValue] = useState<User | undefined>(userUser);
+
+    return (
+      <Form>
+        <ModalPickerSingle
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          optionForValue={(user: User) => user.email}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
+          fetchOptions={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
           }
           value={value}
           onChange={setValue}

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -8,7 +8,13 @@ import EmptyModal from '../EmptyModal';
 
 import { AddButtonCallback, AddButtonOptions } from '../types';
 import withJarb from '../../withJarb/withJarb';
-import { Color, OptionForValue, FetchOptionsCallback } from '../../types';
+import { Color } from '../../types';
+import {
+  OptionEqual,
+  OptionForValue,
+  FetchOptionsCallback,
+  isOptionSelected
+} from '../../option';
 
 interface Props<T> {
   /**
@@ -43,6 +49,15 @@ interface Props<T> {
    * before.
    */
   addButton?: AddButtonOptions<T>;
+
+  /**
+   * Optional callback which is used to determine if two options
+   * of type T are equal.
+   *
+   * When `isOptionEqual` is not defined the outcome of `optionForValue`
+   * is used to test equality.
+   */
+  isOptionEqual?: OptionEqual<T>;
 
   /**
    * Callback to convert an value of type T to an option to show
@@ -255,23 +270,26 @@ export default class ModalPickerSingle<T> extends React.Component<
       return <EmptyModal userHasSearched={this.state.userHasSearched} />;
     }
 
-    const { optionForValue } = this.props;
+    const { optionForValue, isOptionEqual } = this.props;
 
-    return page.content.map((value: T) => {
-      const label = optionForValue(value);
+    return page.content.map((option: T) => {
+      const label = optionForValue(option);
 
-      const isChecked =
-        // @ts-ignore
-        selected !== undefined && optionForValue(selected) === label;
+      const isChecked = isOptionSelected({
+        option,
+        optionForValue,
+        isOptionEqual,
+        value: selected
+      });
 
       return (
-        <FormGroup key={optionForValue(value)} check>
+        <FormGroup key={label} check>
           <Label check>
             <Input
               type="radio"
               name={label}
               checked={isChecked}
-              onChange={() => this.itemClicked(value)}
+              onChange={() => this.itemClicked(option)}
             />
             {label}
           </Label>

--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 
 import Select, { JarbSelect } from './Select';
 import { FinalForm, Form } from '../story-utils';
-import { pageOfUsers } from '../../test/fixtures';
+import { pageOfUsers, userUser } from '../../test/fixtures';
 import { User } from '../../test/types';
 
 interface SubjectOption {
@@ -42,6 +42,22 @@ storiesOf('Form|Select', module)
           placeholder="Please enter your subject"
           optionForValue={(user: User) => user.email}
           options={() => Promise.resolve(pageOfUsers)}
+          onChange={value => action(`You entered ${value}`)}
+        />
+      </Form>
+    );
+  })
+  .add('custom isOptionEqual', () => {
+    return (
+      <Form>
+        <Select
+          id="subject"
+          label="Subject"
+          placeholder="Please enter your subject"
+          value={userUser}
+          optionForValue={(user: User) => user.email}
+          options={() => Promise.resolve(pageOfUsers)}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
           onChange={value => action(`You entered ${value}`)}
         />
       </Form>

--- a/src/form/Select/Select.test.tsx
+++ b/src/form/Select/Select.test.tsx
@@ -10,7 +10,7 @@ import {
   userUser,
   pageOfUsers
 } from '../../test/fixtures';
-import { OptionEnabledCallback } from '../types';
+import { OptionEnabledCallback } from '../option';
 import { pageWithContent } from '../../test/utils';
 
 describe('Component: Select', () => {
@@ -89,12 +89,15 @@ describe('Component: Select', () => {
     });
 
     test('when value is not in options select nothing', () => {
-      setup({ value: {
-        id: -1,
-        email: 'none',
-        active: false,
-        roles: [],
-      }, isOptionEnabled: undefined });
+      setup({
+        value: {
+          id: -1,
+          email: 'none',
+          active: false,
+          roles: []
+        },
+        isOptionEnabled: undefined
+      });
 
       const rsInput = select.find('Input');
 

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -6,13 +6,15 @@ import { Page } from '@42.nl/spring-connect';
 
 import withJarb from '../withJarb/withJarb';
 import Spinner from '../../core/Spinner/Spinner';
+import { Color } from '../types';
+import { t } from '../../utilities/translation/translation';
 import {
-  Color,
+  OptionEqual,
   OptionForValue,
   OptionEnabledCallback,
-  OptionsFetcher
-} from '../types';
-import { t } from '../../utilities/translation/translation';
+  OptionsFetcher,
+  isOptionSelected
+} from '../option';
 
 export interface Text {
   /**
@@ -53,6 +55,15 @@ interface Props<T> {
    * to the user.
    */
   optionForValue: OptionForValue<T>;
+
+  /**
+   * Optional callback which is used to determine if two options
+   * of type T are equal.
+   *
+   * When `isOptionEqual` is not defined the outcome of `optionForValue`
+   * is used to test equality.
+   */
+  isOptionEqual?: OptionEqual<T>;
 
   /**
    * Optional callback which is called for every option to determine
@@ -201,7 +212,8 @@ export default class Select<T> extends Component<Props<T>, State<T>> {
       valid,
       onBlur,
       onChange,
-      optionForValue
+      optionForValue,
+      isOptionEqual
     } = this.props;
 
     const { options } = this.state;
@@ -223,8 +235,8 @@ export default class Select<T> extends Component<Props<T>, State<T>> {
 
     const indexOfValue =
       value !== undefined
-        ? options.findIndex(
-            option => optionForValue(option) === optionForValue(value)
+        ? options.findIndex(option =>
+            isOptionSelected({ option, optionForValue, isOptionEqual, value })
           )
         : undefined;
 

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
@@ -5,7 +5,8 @@ import { FetchOptionsCallback, TypeaheadOption } from '../types';
 import withJarb from '../../withJarb/withJarb';
 import { doBlur } from '../../utils';
 import { valueToTypeaheadOption } from '../utils';
-import { Color, OptionForValue } from '../../types';
+import { Color } from '../../types';
+import { OptionForValue } from '../../option';
 import classNames from 'classnames';
 
 interface Props<T> {
@@ -191,6 +192,8 @@ export default class TypeaheadMultiple<T> extends Component<
 /**
  * Variant of the TypeaheadMultiple which can be used in a Jarb context.
  */
-export const JarbTypeaheadMultiple = withJarb<any[], any[] | undefined, Props<any>>(
-  TypeaheadMultiple
-);
+export const JarbTypeaheadMultiple = withJarb<
+  any[],
+  any[] | undefined,
+  Props<any>
+>(TypeaheadMultiple);

--- a/src/form/Typeahead/single/TypeaheadSingle.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.tsx
@@ -6,7 +6,8 @@ import { TypeaheadOption, FetchOptionsCallback } from '../types';
 import withJarb from '../../withJarb/withJarb';
 import { doBlur } from '../../utils';
 import { valueToTypeaheadOption } from '../utils';
-import { Color, OptionForValue } from '../../types';
+import { Color } from '../../types';
+import { OptionForValue } from '../../option';
 import classNames from 'classnames';
 
 interface Props<T> {

--- a/src/form/ValuePicker/ValuePicker.stories.tsx
+++ b/src/form/ValuePicker/ValuePicker.stories.tsx
@@ -63,6 +63,36 @@ storiesOf('Form|ValuePicker/multiple', module)
       </Form>
     );
   })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<User[] | undefined>([userUser]);
+
+    const [size, setSize] = useState('small');
+
+    const promise = size === 'small' ? small : large;
+
+    return (
+      <Form>
+        <ValuePicker<User>
+          multiple={true}
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          fetchOptions={() => promise}
+          optionForValue={(user: User) => user.email}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
+          value={value}
+          onChange={setValue}
+        />
+
+        <p>Use these buttons to trigger a morph</p>
+        <Button className="mx-2" onClick={() => setSize('small')}>
+          Small
+        </Button>
+        <Button onClick={() => setSize('large')}>Large</Button>
+      </Form>
+    );
+  })
   .add('jarb', () => {
     const [size, setSize] = useState('small');
 
@@ -113,6 +143,36 @@ storiesOf('Form|ValuePicker/single', module)
           canSearch={true}
           fetchOptions={() => promise}
           optionForValue={(user: User) => user.email}
+          value={value}
+          onChange={setValue}
+        />
+
+        <p>Use these buttons to trigger a morph</p>
+        <Button className="mx-2" onClick={() => setSize('small')}>
+          Small
+        </Button>
+        <Button onClick={() => setSize('large')}>Large</Button>
+      </Form>
+    );
+  })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<User | undefined>(userUser);
+
+    const [size, setSize] = useState('small');
+
+    const promise = size === 'small' ? small : large;
+
+    return (
+      <Form>
+        <ValuePicker<User>
+          multiple={false}
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          fetchOptions={() => promise}
+          optionForValue={(user: User) => user.email}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={value}
           onChange={setValue}
         />

--- a/src/form/ValuePicker/ValuePicker.test.tsx
+++ b/src/form/ValuePicker/ValuePicker.test.tsx
@@ -4,7 +4,7 @@ import toJson from 'enzyme-to-json';
 import { Page } from '@42.nl/spring-connect';
 
 import ValuePicker from './ValuePicker';
-import { FetchOptionsCallback } from '../types';
+import { FetchOptionsCallback } from '../option';
 
 import { User } from '../../test/types';
 import * as testUtils from '../../test/utils';

--- a/src/form/ValuePicker/ValuePicker.tsx
+++ b/src/form/ValuePicker/ValuePicker.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Color, FetchOptionsCallback } from '../types';
+import { Color } from '../types';
+import { FetchOptionsCallback, OptionForValue, OptionEqual } from '../option';
 import withJarb from '../withJarb/withJarb';
 
 import ModalPickerMultiple from '../ModalPicker/multiple/ModalPickerMultiple';
@@ -50,7 +51,16 @@ interface BaseValuePickerProps<T> {
    * Callback to convert an value of type T to an option to show
    * to the user.
    */
-  optionForValue: (value: T) => string;
+  optionForValue: OptionForValue<T>;
+
+  /**
+   * Optional callback which is used to determine if two options
+   * of type T are equal.
+   *
+   * When `isOptionEqual` is not defined the outcome of `optionForValue`
+   * is used to test equality.
+   */
+  isOptionEqual?: OptionEqual<T>;
 
   /**
    * Optional callback for when the form element is blurred.
@@ -116,21 +126,20 @@ interface MultipleValuePicker<T> extends BaseValuePickerProps<T> {
 
 type Props<T> = SingleValuePicker<T> | MultipleValuePicker<T>;
 
-
 /**
- * 
+ *
  * The `ValuePicker` component is an abstraction which automatically
  * selects the best component to use when the user has to select a value
  * from a pre-defined list.
- * 
+ *
  * This is the decision matrix:
- * 
+ *
  * ```
  * | multiple | items <= 10             | items > 10
  * | true     | CheckboxMultipleSelect  | ModalPickerMultiple
  * | false    | Select                  | ModalPickerSingle
  * ```
- * 
+ *
  * `ValuePicker` starts in a booting state in which a spinner is shown.
  * During the booting state it will call `FetchOptionsCallback` and ask
  * for a `Page` of size `1` so it can get the `totalElements`.

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -372,7 +372,7 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": false,
                   "email": "coordinator@42.nl",
-                  "id": 1337,
+                  "id": 777,
                   "roles": Array [
                     "ADMIN",
                     "USER",
@@ -604,7 +604,7 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": false,
                   "email": "coordinator@42.nl",
-                  "id": 1337,
+                  "id": 777,
                   "roles": Array [
                     "ADMIN",
                     "USER",

--- a/src/form/option.test.tsx
+++ b/src/form/option.test.tsx
@@ -1,0 +1,185 @@
+import { isOptionSelected } from './option';
+
+type Boat = {
+  id: number;
+  name: string;
+};
+
+describe('Util: isOptionSelected', () => {
+  function setup() {
+    const speedBoat: Boat = {
+      id: 1,
+      name: 'Speedy'
+    };
+
+    const tugBoat: Boat = {
+      id: 2,
+      name: 'Tugger'
+    };
+
+    // anotherTugBoat is also named tugger just like tugBoat but
+    // has a different id
+    const anotherTugBoat: Boat = {
+      id: 3,
+      name: 'Tugger'
+    };
+
+    // Is the same as speedBoat but another instance with a different name
+    const speedBoatCopy: Boat = {
+      id: 1,
+      name: 'Speedie'
+    };
+
+    const optionForValue = (boat: Boat) => boat.name;
+    const isOptionEqual = (a: Boat, b: Boat) => a.id === b.id;
+
+    return {
+      optionForValue,
+      isOptionEqual,
+      speedBoat,
+      tugBoat,
+      anotherTugBoat,
+      speedBoatCopy
+    };
+  }
+
+  it('should when the value is undefined return false', () => {
+    const { optionForValue, speedBoat } = setup();
+
+    expect(
+      isOptionSelected({ value: undefined, option: speedBoat, optionForValue })
+    ).toBe(false);
+  });
+
+  describe('when value is an array', () => {
+    describe('when "isOptionEqual" is defined', () => {
+      it('should consider a value selected when the "isOptionEqual" returns true for one item in the array', () => {
+        const {
+          optionForValue,
+          isOptionEqual,
+          speedBoat,
+          speedBoatCopy
+        } = setup();
+
+        expect(
+          isOptionSelected({
+            value: [speedBoatCopy],
+            option: speedBoat,
+            optionForValue,
+            isOptionEqual
+          })
+        ).toBe(true);
+      });
+
+      it('should not consider a value selected when "isOptionEqual" returns false for every item in the array', () => {
+        const {
+          optionForValue,
+          isOptionEqual,
+          tugBoat,
+          anotherTugBoat
+        } = setup();
+
+        expect(
+          isOptionSelected({
+            value: [tugBoat],
+            option: anotherTugBoat,
+            optionForValue,
+            isOptionEqual
+          })
+        ).toBe(false);
+      });
+    });
+
+    describe('when "isOptionEqual" is not defined', () => {
+      it('should consider a value selected when "optionForValue" returns the same string for one item in the array', () => {
+        const { optionForValue, tugBoat, anotherTugBoat } = setup();
+
+        expect(
+          isOptionSelected({
+            value: [tugBoat],
+            option: anotherTugBoat,
+            optionForValue
+          })
+        ).toBe(true);
+      });
+
+      it('should not consider a value selected when "optionForValue" does not return the same string for at least one item in the array', () => {
+        const { optionForValue, speedBoat, speedBoatCopy } = setup();
+
+        expect(
+          isOptionSelected({
+            value: [speedBoatCopy],
+            option: speedBoat,
+            optionForValue
+          })
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe('when value is a primitive', () => {
+    describe('when "isOptionEqual" is defined', () => {
+      it('should consider a value selected when the "isOptionEqual" returns true', () => {
+        const {
+          optionForValue,
+          isOptionEqual,
+          speedBoat,
+          speedBoatCopy
+        } = setup();
+
+        expect(
+          isOptionSelected({
+            value: speedBoatCopy,
+            option: speedBoat,
+            optionForValue,
+            isOptionEqual
+          })
+        ).toBe(true);
+      });
+
+      it('should not consider a value selected when "isOptionEqual" returns false', () => {
+        const {
+          optionForValue,
+          isOptionEqual,
+          tugBoat,
+          anotherTugBoat
+        } = setup();
+
+        expect(
+          isOptionSelected({
+            value: tugBoat,
+            option: anotherTugBoat,
+            optionForValue,
+            isOptionEqual
+          })
+        ).toBe(false);
+      });
+    });
+
+    describe('when "isOptionEqual" is not defined', () => {
+      it('should consider a value selected when "optionForValue" returns the same string', () => {
+        const { optionForValue, tugBoat, anotherTugBoat } = setup();
+
+        expect(
+          isOptionSelected({
+            value: tugBoat,
+            option: anotherTugBoat,
+            optionForValue
+          })
+        ).toBe(true);
+      });
+
+      it('should not consider a value selected when "optionForValue" does not return the same string', () => {
+        const { optionForValue, speedBoat, speedBoatCopy } = setup();
+
+        expect(
+          isOptionSelected({
+            value: speedBoatCopy,
+            option: speedBoat,
+            optionForValue
+          })
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/src/form/option.ts
+++ b/src/form/option.ts
@@ -1,0 +1,78 @@
+import { Page } from '@42.nl/spring-connect';
+
+/**
+ * Callback to determine the label for a given value of type T.
+ * Aka the text the user sees when selecting a value.
+ */
+export type OptionForValue<T> = (value: T) => string;
+
+export type OptionEqual<T> = (a: T, b: T) => boolean;
+
+/**
+ * Callback to determine if the option is currently enabled.
+ */
+export type OptionEnabledCallback<T> = (option: T) => boolean;
+
+/**
+ * Callback which should return a Page of options which can
+ * be selected by the user.
+ */
+export type OptionsFetcher<T> = () => Promise<Page<T>>;
+
+/**
+ * Callback which should return a Page of options which can
+ * be selected by the user.
+ *
+ * It is given three parameters:
+ *
+ * 1. `query` A string you must use to filter the number of options.
+ * Used for searches.
+ *
+ * 2. `page` A number telling you which page you must load. Used
+ * to limit the total number of elements by asking for a small slice
+ * each time.
+ *
+ * 3. `size` A number telling you the size of the Page you must load.
+ * Often components can only render so much options before becoming
+ * unwieldy. They can tell you the size of options they an support
+ * through this parameter.
+ */
+export type FetchOptionsCallback<T> = (
+  query: string,
+  page: number,
+  size: number
+) => Promise<Page<T>>;
+
+type IsOptionSelectedConfig<T> = {
+  option: T;
+  optionForValue: OptionForValue<T>;
+  isOptionEqual?: OptionEqual<T>;
+  value?: T[] | T;
+};
+
+export function isOptionSelected<T>({
+  option,
+  optionForValue,
+  isOptionEqual,
+  value
+}: IsOptionSelectedConfig<T>): boolean {
+  if (!value) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    if (isOptionEqual) {
+      return value.some(v => isOptionEqual(v, option));
+    } else {
+      const label = optionForValue(option);
+      return value.some(v => label === optionForValue(v));
+    }
+  } else {
+    if (isOptionEqual) {
+      return isOptionEqual(value, option);
+    } else {
+      const label = optionForValue(option);
+      return label === optionForValue(value);
+    }
+  }
+}

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -1,5 +1,4 @@
 import { ValidationError } from '@42.nl/jarb-final-form';
-import { Page } from '@42.nl/spring-connect';
 
 import { Translation } from '../utilities/translation/translator';
 export { Color } from '../core/types';
@@ -20,45 +19,3 @@ export type UnionKeys<T> = T extends any ? keyof T : never;
 export type DistributiveOmit<T, K extends UnionKeys<T>> = T extends any
   ? Omit<T, Extract<keyof T, K>>
   : never;
-
-
-/**
- * Callback to determine the label for a given value of type T.
- * Aka the text the user sees when selecting a value.
- */
-export type OptionForValue<T> = (value: T) => string;
-
-/**
- * Callback to determine if the option is currently enabled.
- */
-export type OptionEnabledCallback<T> = (option: T) => boolean;
-
-/**
- * Callback which should return a Page of options which can
- * be selected by the user.
- */
-export type OptionsFetcher<T> = () => Promise<Page<T>>;
-
-/**
- * Callback which should return a Page of options which can
- * be selected by the user. 
- * 
- * It is given three parameters:
- * 
- * 1. `query` A string you must use to filter the number of options.
- * Used for searches.
- * 
- * 2. `page` A number telling you which page you must load. Used
- * to limit the total number of elements by asking for a small slice
- * each time.
- * 
- * 3. `size` A number telling you the size of the Page you must load. 
- * Often components can only render so much options before becoming
- * unwieldy. They can tell you the size of options they an support
- * through this parameter.
- */
-export type FetchOptionsCallback<T> = (
-  query: string,
-  page: number,
-  size: number
-) => Promise<Page<T>>;

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -21,7 +21,7 @@ export function randomUser(): User {
     email: `user-${id}@42.nl`,
     active: true,
     roles: [UserRole.ADMIN]
-  }
+  };
 }
 
 const admin = {
@@ -43,7 +43,7 @@ const user = {
 export const userUser = Object.freeze(user);
 
 const coordinator = {
-  id: 1337,
+  id: 777,
   email: 'coordinator@42.nl',
   active: false,
   roles: [UserRole.ADMIN, UserRole.USER]


### PR DESCRIPTION
Before the equality of selections were determined based on if the two
values had the same label. This is a good heuristic for the default
implementation, which it still is.

Now however the user can supply a custom checker via the `isOptionEqual`
prop. Here the user implements a feature that gives two values and must
return a boolean. This allows the user to have full control of the
check whether a value is selected or not.

For example you could implement `isOptionEqual` like this to check the
`id` of the items.

```tsx
<ValuePicker
  {/* Rest of the props omitted for brevity */}
  isOptionEqual={(a: User, b: User) => a.id === b.id}
/>
```

You could even use `lodash.isEqual` when you really want a deep check
for equality:

```tsx
<ValuePicker
  {/* Rest of the props omitted for brevity */}
  isOptionEqual={lodash.isEqual}
/>
```

Closes: #209