### PR TITLE
fix: IconPicker button type to 'button'

### DIFF
--- a/src/form/IconPicker/IconPicker.tsx
+++ b/src/form/IconPicker/IconPicker.tsx
@@ -164,7 +164,7 @@ export default function IconPicker(props: Props) {
                 </div>
               </span>
             ) : null}
-            <Button id="icon-picker-popover" color="primary">
+            <Button id="icon-picker-popover" type="button" color="primary">
               {placeholder}
             </Button>
           </div>

--- a/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
+++ b/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Component: IconPicker ui no results 1`] = `
       color="primary"
       id="icon-picker-popover"
       tag="button"
+      type="button"
     >
       Select your best friend
     </Button>
@@ -130,6 +131,7 @@ exports[`Component: IconPicker ui with selected value 1`] = `
       color="primary"
       id="icon-picker-popover"
       tag="button"
+      type="button"
     >
       Select your best friend
     </Button>
@@ -861,6 +863,7 @@ exports[`Component: IconPicker ui without selected value 1`] = `
       color="primary"
       id="icon-picker-popover"
       tag="button"
+      type="button"
     >
       Select your best friend
     </Button>


### PR DESCRIPTION
Previously it had the default HTML property of a button as it was not
given, which is `submit`. Resulting in clicking on the `IconPicker`
button in a form to submit the entire form.