### PR TITLE
fix: SearchInput did not update the `onChange` callback.

### DIFF
--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, KeyboardEvent } from 'react';
+import React, { useRef, KeyboardEvent, useEffect } from 'react';
 import { debounce as lodashDebounce, DebounceSettings } from 'lodash';
 import { Input, InputProps, InputGroup, InputGroupAddon } from 'reactstrap';
 
@@ -108,6 +108,11 @@ export default function SearchInput(props: Props) {
   const handleChange = useRef(
     lodashDebounce(onChange, debounce, debounceSettings)
   );
+
+  // When the onChange changes update the handleChange
+  useEffect(() => {
+    handleChange.current = lodashDebounce(onChange, debounce, debounceSettings);
+  }, [onChange, debounce, debounceSettings]);
 
   function handleKeyUp(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === 'Enter') {


### PR DESCRIPTION
Because the `onChange` callback is wrapped inside of a `useRef` which
in turn calls `lodash.debounce`. The `useRef` will not update anything
when the `useRef` functions params change.

We must do this manually, added an `useEffect` which updates the
`useRef.current` whenever the params to the `debounce` change.

This way a new `onChange` callback is actually used.

Closes: #265