### PR TITLE
fix: form example strange text-area resizing bug.

### DIFF
--- a/src/form/story-utils.tsx
+++ b/src/form/story-utils.tsx
@@ -23,7 +23,7 @@ export function FinalForm({ children }: Props) {
       render={({ handleSubmit, submitting, values, errors }) => (
         <Fragment>
           <Row>
-            <Col>
+            <Col lg={6}>
               <Form>
                 {children}
 
@@ -35,7 +35,7 @@ export function FinalForm({ children }: Props) {
                 </SubmitButton>
               </Form>
             </Col>
-            <Col>
+            <Col lg={6}>
               <h2>Values</h2>
               <pre>{JSON.stringify(values, null, 2)}</pre>
               <h2>Errors</h2>


### PR DESCRIPTION
Because the `Col` of the `FinalForm` component did not have a size
constraints it will by default try do divide the width evenly.

Because the `<pre>` element gets really large when the user enters a
large value into the `Textarea` the division of width is unfairly given
to the right `Col`.

Fixed by adding a `lg={6}` to the `Col`'s making the widths explicit.
This prevents `bootstrap` from dividing the width itself.

Fixes: #80