### PR TITLE
fix: the `EpicTable` color could not be overridden.

### DIFF
--- a/src/table/EpicTable/EpicTable.scss
+++ b/src/table/EpicTable/EpicTable.scss
@@ -37,8 +37,8 @@
   }
 
   &-header {
-    background-color: $primary;
-    color: color-yiq($primary);
+    background-color: map-get($theme-colors, primary);
+    color: color-yiq(map-get($theme-colors, primary));
     font-weight: bold;
     flex-grow: 1;
 


### PR DESCRIPTION
The `EpicTable` used the `$primary` for the `background-color` for
the header. But this is not correct and should be:
`background-color: map-get($theme-colors, primary);`.

This way the user can override the color from their own scss.

Closes: #319