### PR TITLE
feat: added Tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6307,6 +6307,15 @@
         "@types/testing-library__react-hooks": "^3.0.0"
       }
     },
+    "@tippy.js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@tippy.js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-KF45vW/jKh/nBXk/2zzTFslv/T46zOMkIoDJ56ymZ+M00yHttk58J5wZ29oqGqDIUnobWSZD+cFpbR4u/UUvgw==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "tippy.js": "^5.1.1"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -32151,6 +32160,14 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+    },
+    "tippy.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.2.1.tgz",
+      "integrity": "sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==",
+      "requires": {
+        "popper.js": "^1.16.0"
+      }
     },
     "tlds": {
       "version": "1.207.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "overlayscrollbars": "1.10.3",
     "overlayscrollbars-react": "0.2.1",
     "pica": "5.1.0",
+    "@tippy.js/react": "3.1.1",
     "react-avatar-editor": "12.0.0-beta.0",
     "react-bootstrap-typeahead": "4.0.0-alpha.6",
     "react-color": "2.18.0",

--- a/src/core/Tooltip/Tooltip.stories.tsx
+++ b/src/core/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Tooltip } from './Tooltip';
+import Tag from '../Tag/Tag';
+import { Row, Col, Button } from 'reactstrap';
+
+storiesOf('core|Tooltip', module)
+  .addParameters({ component: Tooltip })
+  .add('default', () => (
+    <div className="d-flex flex-column">
+      <Row className="my-3">
+        <Col className="d-flex justify-content-around align-items-center">
+          <Tooltip content="This is a tooltip">
+            <Tag color="danger" text="Hover me!" />
+          </Tooltip>
+
+          <Tooltip content="Tooltip-text">
+            <h5>Can be wrapped around any component</h5>
+          </Tooltip>
+
+          <Tooltip content="This is a tooltip">Plain text</Tooltip>
+
+          <Tooltip content="Buttons work too">
+            <Button>Hover this button!</Button>
+          </Tooltip>
+        </Col>
+      </Row>
+    </div>
+  ))
+
+  .add('alignment', () => (
+    <>
+      <h6>Alignment</h6>
+      <Row className="mt-4">
+        <Col className="d-flex justify-content-around">
+          <Tooltip content={'Placement bottom'} placement="bottom">
+            <Tag color="danger" text="Hover me!" />
+          </Tooltip>
+
+          <Tooltip content={'Placement left'} placement="left">
+            <Tag color="warning" text="Hover me!" />
+          </Tooltip>
+          <Tooltip content={'Placement right'} placement="right">
+            <Tag color="primary" text="Hover me!" />
+          </Tooltip>
+
+          <Tooltip content={'Placement top'} placement="top">
+            <Tag color="success" text="Hover me!" />
+          </Tooltip>
+        </Col>
+      </Row>
+      <hr></hr>
+
+      <h6>Alignment-modifier</h6>
+      <Row className="mt-3">
+        <Col className="d-flex justify-content-around">
+          <Tooltip content={'right-start'} placement="right-start">
+            <Button style={{ height: 75 }}> Hover me! </Button>
+          </Tooltip>
+
+          <Tooltip content={'right'} placement="right">
+            <Button style={{ height: 75 }}> Hover me! </Button>
+          </Tooltip>
+
+          <Tooltip content={'right-end'} placement="right-end">
+            <Button style={{ height: 75 }}> Hover me! </Button>
+          </Tooltip>
+        </Col>
+      </Row>
+    </>
+  ))
+
+  .add('width & distance', () => (
+    <>
+      <h6>Max width</h6>
+      <Row className="mt-4">
+        <Col className="d-flex justify-content-around">
+          <Tooltip
+            content={<p className="text-center">You can set me to be narrow</p>}
+            maxWidth={80}
+          >
+            <Tag color="warning" text={'Hover me!'} />
+          </Tooltip>
+
+          <Tooltip
+            content={
+              <p className="text-center">Or you can set me to be wide...</p>
+            }
+            maxWidth={500}
+          >
+            <Tag color="warning" text={'Hover me!'} />
+          </Tooltip>
+        </Col>
+      </Row>
+
+      <hr></hr>
+
+      <h6>Distance</h6>
+      <Row className="mt-4">
+        <Col className="d-flex justify-content-around">
+          <Tooltip content="far away" distance={15}>
+            <Tag color="success" text="Hover me!" />
+          </Tooltip>
+
+          <Tooltip content="default distance">
+            <Tag color="success" text="Hover me!" />
+          </Tooltip>
+
+          <Tooltip content="very close" distance={3}>
+            <Tag color="success" text="Hover me!" />
+          </Tooltip>
+        </Col>
+      </Row>
+    </>
+  ))
+
+  .add('components as content', () => (
+    <>
+      <h6>Components</h6>
+      <Row className="mt-4">
+        <Col className="d-flex justify-content-around">
+          <Tooltip
+            interactive
+            content={
+              <div>
+                {' '}
+                I can render <b style={{ color: 'orange' }}> HTML content</b>
+              </div>
+            }
+          >
+            <p color="orange">HTML</p>
+          </Tooltip>
+
+          <Tooltip
+            interactive
+            content={<Button color="danger"> React components too!</Button>}
+          >
+            <p>React</p>
+          </Tooltip>
+
+          <Tooltip
+            interactive
+            placement="left"
+            content={
+              <Tooltip
+                interactive
+                placement="left"
+                content={
+                  <Tooltip
+                    interactive
+                    placement="left"
+                    content={
+                      <Tooltip
+                        interactive
+                        placement="left"
+                        content={
+                          <Tooltip
+                            interactive
+                            placement="left"
+                            content={
+                              <Tooltip interactive content="Pretty cool right?">
+                                <p>5</p>
+                              </Tooltip>
+                            }
+                          >
+                            <p>4</p>
+                          </Tooltip>
+                        }
+                      >
+                        <p>3</p>
+                      </Tooltip>
+                    }
+                  >
+                    <p>2</p>
+                  </Tooltip>
+                }
+              >
+                <p>1</p>
+              </Tooltip>
+            }
+          >
+            <p>Tooltip-ception</p>
+          </Tooltip>
+        </Col>
+      </Row>
+
+      <hr></hr>
+      <h6>Interactive</h6>
+
+      <Row className="mt-4">
+        <Col className="d-flex justify-content-around">
+          <Tooltip content="You cannot click my contents">
+            <Tag color="danger" text="I am not interactive" />
+          </Tooltip>
+          <Tooltip interactive content="You can click my content!">
+            <Tag color="success" text="I am interactive!" />
+          </Tooltip>
+        </Col>
+      </Row>
+    </>
+  ))
+
+  .add('custom wrapper', () => (
+    <>
+      <h6>Custom wrapper</h6>
+      <Row className="mt-4">
+        <Col className="d-flex justify-content-around">
+          <Tooltip content="My children are in a <span>" tag="span">
+            By default, my children get wrapped in a span
+          </Tooltip>
+
+          <Tooltip content="My children are in a <div>" tag="div">
+            You can change that with the tag property
+          </Tooltip>
+        </Col>
+      </Row>
+    </>
+  ));

--- a/src/core/Tooltip/Tooltip.test.tsx
+++ b/src/core/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { Tooltip } from './Tooltip';
+
+describe('Component: Tooltip', () => {
+  describe('ui', () => {
+    test('default', () => {
+      const tooltip = shallow(
+        <Tooltip content={<> Tooltip Content </>}>
+          <div>The tooltip should be wrapped around this div, in a span</div>
+        </Tooltip>
+      );
+      expect(toJson(tooltip)).toMatchSnapshot(
+        'Component: Tooltip => ui => default'
+      );
+    });
+
+    test('with custom tag', () => {
+      const tooltip = shallow(
+        <Tooltip tag="div" content="Tooltip content">
+          <div>The tooltip should be wrapped around this div, in a div</div>
+        </Tooltip>
+      );
+      expect(toJson(tooltip)).toMatchSnapshot(
+        'Component: Tooltip => ui => with tag'
+      );
+    });
+
+    test('with class', () => {
+      const tooltip = shallow(
+        <Tooltip className="extra-classnames" content={<> Tooltip content </>}>
+          <div>The tooltip should be wrapped around this div, in a div</div>
+        </Tooltip>
+      );
+      expect(tooltip.find('span').props().className).toBe('extra-classnames');
+    });
+
+    test('with style', () => {
+      const tooltip = mount(
+        <Tooltip
+          style={{ marginTop: 5, padding: 10 }}
+          content={<> Tooltip content </>}
+        >
+          <div>The tooltip should be wrapped around this div, in a div</div>
+        </Tooltip>
+      );
+
+      //Test is the concat of the 'outline:0' css property goes well with additional provided css properties.
+      expect(tooltip.find('span').props().style).toEqual({
+        outline: 0,
+        marginTop: 5,
+        padding: 10
+      });
+    });
+  });
+
+  test('with style, override outline', () => {
+    const tooltip = mount(
+      <Tooltip style={{ outline: 20 }} content={<> Tooltip content </>}>
+        <div>The tooltip should be wrapped around this div, in a div</div>
+      </Tooltip>
+    );
+
+    //Test if the outline is overriden when specified
+    expect(tooltip.find('span').props().style).toEqual({ outline: 20 });
+  });
+});

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -1,0 +1,95 @@
+import React, { CSSProperties } from 'react';
+import * as Popper from 'popper.js';
+import Tippy from '@tippy.js/react';
+
+/*** Tooltip component based on the Tippy Library ***/
+interface Props {
+  /**
+   * Target component that, when hovered, will trigger the tooltip to show up.
+   * The target(children) of the tooltip are wrapped into a div.
+   * This is a bypass to not have to forward the ref to the DOM node.
+   */
+  children: React.ReactNode;
+
+  /**
+   * Content shown inside of the tooltip.
+   */
+  content: React.ReactNode;
+
+  /**
+   * Optional alignment relative to the target where the tooltip will be shown.
+   */
+  placement?: Popper.Placement;
+
+  /**
+   * Optional distance that the tooltip will show up relative from the target.
+   * Possible values: number (px), string (with units "rem" only).
+   */
+  distance?: number | string;
+
+  /**
+   * Optional value that allows you to interact with the Tooltip. This is useful for when
+   * you have a clickable component inside of your Tooltip.
+   * When set to true, the Tooltip will no longer dissapear when clicked
+   */
+  interactive?: boolean;
+
+  /**
+   * Optional that allows you to override the default max width of the tooltip
+   * Possible values: number (px), string (with units "rem") or string 'none'.
+   */
+  maxWidth?: number | string;
+
+  /**
+   * Optional that allows you to override the default element that the children get put inside of.
+   * Default value is a span.
+   */
+  tag?: 'span' | 'div';
+
+  /**
+   * Optional className that is added to the Wrapper component
+   * Allowing you to add classes like margins and padding that would otherwise get lost
+   * by the wrapping of the children inside of the CustomTag.
+   */
+  className?: string;
+
+  /**
+   * Optional CSS properties that are added to the Wrapper component
+   * Allowing you to add CSS properties that would otherwise get lost
+   * by the wrapping of the children inside of the CustomTag.
+   */
+  style?: CSSProperties;
+}
+
+/**
+ * Bootstrap-like Tooltip component based on the Tippy.js library.
+ */
+export function Tooltip({
+  children,
+  placement = 'top',
+  content,
+  distance = 7,
+  interactive,
+  maxWidth = 350,
+  tag = 'span',
+  className,
+  style
+}: Props) {
+  const Tag = tag;
+
+  return (
+    <Tippy
+      className="border-0"
+      content={<> {content} </>}
+      placement={placement}
+      distance={distance}
+      interactive={interactive}
+      boundary="viewport"
+      maxWidth={maxWidth}
+    >
+      <Tag className={className} style={{ outline: 0, ...style }} tabIndex={0}>
+        {children}
+      </Tag>
+    </Tippy>
+  );
+}

--- a/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: Tooltip ui default: Component: Tooltip => ui => default 1`] = `
+<ForwardRef(TippyWrapper)
+  boundary="viewport"
+  className="border-0"
+  content={
+    <React.Fragment>
+       
+      <React.Fragment>
+         Tooltip Content 
+      </React.Fragment>
+       
+    </React.Fragment>
+  }
+  distance={7}
+  maxWidth={350}
+  placement="top"
+>
+  <span
+    style={
+      Object {
+        "outline": 0,
+      }
+    }
+    tabIndex={0}
+  >
+    <div>
+      The tooltip should be wrapped around this div, in a span
+    </div>
+  </span>
+</ForwardRef(TippyWrapper)>
+`;
+
+exports[`Component: Tooltip ui with custom tag: Component: Tooltip => ui => with tag 1`] = `
+<ForwardRef(TippyWrapper)
+  boundary="viewport"
+  className="border-0"
+  content={
+    <React.Fragment>
+       
+      Tooltip content
+       
+    </React.Fragment>
+  }
+  distance={7}
+  maxWidth={350}
+  placement="top"
+>
+  <div
+    style={
+      Object {
+        "outline": 0,
+      }
+    }
+    tabIndex={0}
+  >
+    <div>
+      The tooltip should be wrapped around this div, in a div
+    </div>
+  </div>
+</ForwardRef(TippyWrapper)>
+`;

--- a/src/main.scss
+++ b/src/main.scss
@@ -29,6 +29,7 @@
 @import '~react-bootstrap-typeahead/css/Typeahead-bs4.css';
 @import '~react-quill/dist/quill.snow.css';
 @import '~overlayscrollbars/css/OverlayScrollbars.css';
+@import '~tippy.js/dist/tippy.css';
 
 // Form components
 @import './form/ImageUpload/ImageUpload';


### PR DESCRIPTION
Added a Bootstrap style Tooltip component based on Tippy.js

The Tooltip can be wrapped around the target component. On hover the Tooltip will be shown on this component.

Internally the Tooltip wraps the target inside of a CustomTag (this can be a div or a span).
This CustomTag gets a tabIndex={0} for the sake of handeling the forwardRef.

You can add content to the Tooltip which is displayed on hover over the Target component.
This content can be other React components as well.

Styling can be done through several properties such as placement, distance from target, interactivity, maxWidth, bootstrap classNames and css style.