### PR TITLE
Added optional label to SearchInput

### DIFF
--- a/src/core/SearchInput/SearchInput.stories.tsx
+++ b/src/core/SearchInput/SearchInput.stories.tsx
@@ -67,6 +67,21 @@ storiesOf('core|SearchInput', module)
       </Card>
     );
   })
+  .add('with label', () => {
+    const [query, setQuery] = useState('');
+
+    return (
+      <Card body>
+        <p>You searched for: {query}</p>
+        <SearchInput
+          id="search"
+          label="Search"
+          value={query}
+          onChange={setQuery}
+        />
+      </Card>
+    );
+  })
   .add('with external value', () => {
     const [query, setQuery] = useState('');
 

--- a/src/core/SearchInput/SearchInput.test.tsx
+++ b/src/core/SearchInput/SearchInput.test.tsx
@@ -11,11 +11,13 @@ describe('Component: SearchInput', () => {
   function setup({
     debounce,
     showIcon,
-    debounceSettings
+    debounceSettings,
+    showLabel
   }: {
     debounce?: number;
     showIcon?: boolean;
     debounceSettings?: lodash.DebounceSettings;
+    showLabel?: boolean;
   }) {
     // @ts-ignore
     jest.spyOn(lodash, 'debounce').mockImplementation(fn => {
@@ -24,16 +26,32 @@ describe('Component: SearchInput', () => {
 
     const onChangeSpy = jest.fn();
 
-    const searchInput = shallow(
-      <SearchInput
-        value=""
-        debounce={debounce}
-        debounceSettings={debounceSettings}
-        onChange={onChangeSpy}
-        showIcon={showIcon}
-        placeholder="Search..."
-      />
-    );
+    let searchInput;
+    if (showLabel) {
+      searchInput = shallow(
+        <SearchInput
+          value=""
+          debounce={debounce}
+          debounceSettings={debounceSettings}
+          onChange={onChangeSpy}
+          showIcon={showIcon}
+          placeholder="Search..."
+          id="search"
+          label="Search"
+        />
+      );
+    } else {
+      searchInput = shallow(
+        <SearchInput
+          value=""
+          debounce={debounce}
+          debounceSettings={debounceSettings}
+          onChange={onChangeSpy}
+          showIcon={showIcon}
+          placeholder="Search..."
+        />
+      );
+    }
 
     return { searchInput, onChangeSpy };
   }
@@ -53,6 +71,12 @@ describe('Component: SearchInput', () => {
 
     test('without icon', () => {
       const { searchInput } = setup({ showIcon: false });
+
+      expect(toJson(searchInput)).toMatchSnapshot();
+    });
+
+    test('with label', () => {
+      const { searchInput } = setup({ showIcon: false, showLabel: true });
 
       expect(toJson(searchInput)).toMatchSnapshot();
     });

--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -1,6 +1,13 @@
 import React, { useRef, KeyboardEvent, useEffect } from 'react';
 import { debounce as lodashDebounce, DebounceSettings } from 'lodash';
-import { Input, InputProps, InputGroup, InputGroupAddon } from 'reactstrap';
+import {
+  Input,
+  InputProps,
+  InputGroup,
+  InputGroupAddon,
+  FormGroup,
+  Label
+} from 'reactstrap';
 
 import { Icon } from '../Icon';
 
@@ -24,7 +31,7 @@ type ModifiedInputProps = Omit<
   | 'defaultValue'
 >;
 
-interface Props extends ModifiedInputProps {
+interface BaseProps extends ModifiedInputProps {
   /**
    * Optionally the number of milliseconds to debounce the onChange.
    *
@@ -88,6 +95,25 @@ interface Props extends ModifiedInputProps {
   ) => React.ReactNode;
 }
 
+interface WithoutLabel extends BaseProps {
+  id?: never;
+  label?: never;
+}
+
+interface WithLabel extends BaseProps {
+  /**
+   * The id of the form element.
+   */
+  id: string;
+
+  /**
+   * The label of the form element.
+   */
+  label: string;
+}
+
+export type Props = WithoutLabel | WithLabel;
+
 /**
  * SearchInput is a component which shows an input field which has
  * the onChange debounced by a number of milliseconds. Useful for
@@ -141,6 +167,7 @@ export default function SearchInput(props: Props) {
 
   const input = (
     <Input
+      id={'id' in props ? props.id : undefined}
       className={!showIcon ? className : ''}
       innerRef={inputRef}
       defaultValue={value}
@@ -162,5 +189,14 @@ export default function SearchInput(props: Props) {
     input
   );
 
-  return children ? <>{children(searchInput, { setValue })}</> : searchInput;
+  return 'label' in props ? (
+    <FormGroup>
+      <Label for={props.id}>{props.label}</Label>
+      {children ? <>{children(searchInput, { setValue })}</> : searchInput}
+    </FormGroup>
+  ) : children ? (
+    <>{children(searchInput, { setValue })}</>
+  ) : (
+    searchInput
+  );
 }

--- a/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -58,6 +58,43 @@ exports[`Component: SearchInput ui with icon when undefined 1`] = `
 </InputGroup>
 `;
 
+exports[`Component: SearchInput ui with label 1`] = `
+<FormGroup
+  tag="div"
+>
+  <Label
+    for="search"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Search
+  </Label>
+  <Input
+    className=""
+    defaultValue=""
+    id="search"
+    innerRef={
+      Object {
+        "current": null,
+      }
+    }
+    label="Search"
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    placeholder="Search..."
+    type="text"
+  />
+</FormGroup>
+`;
+
 exports[`Component: SearchInput ui without icon 1`] = `
 <Input
   className=""

--- a/src/form/ModalPicker/ModalPicker.tsx
+++ b/src/form/ModalPicker/ModalPicker.tsx
@@ -7,7 +7,7 @@ import {
   ModalFooter,
   Button,
   Row,
-  Col,
+  Col
 } from 'reactstrap';
 
 import Pagination from '../../core/Pagination/Pagination';
@@ -126,7 +126,6 @@ export default function ModalPicker(props: Props) {
           <Row>
             <Col>
               <SearchInput
-                id="search"
                 value={query}
                 placeholder={t({
                   overrideText: text.placeholder,
@@ -134,7 +133,7 @@ export default function ModalPicker(props: Props) {
                   fallback: 'Search...'
                 })}
                 onChange={value => fetchOptions(value)}
-              ></SearchInput>
+              />
             </Col>
           </Row>
         ) : null}

--- a/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
+++ b/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
@@ -65,7 +65,6 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
         }
       >
         <SearchInput
-          id="search"
           onChange={[Function]}
           placeholder="Search..."
           value=""


### PR DESCRIPTION
You might want to display a label above the SearchInput to clarify which
SearchInput is used for what purpose in cases where multiple SearchInput
are used inside the same frame/component.
Added possibility to specify a label to display above the input field.
Wraps the field in a FromGroup when label is specified.

Closes #336