### PR TITLE
Fix: Defined size as property of SearchInput

### DIFF
--- a/src/core/SearchInput/SearchInput.test.tsx
+++ b/src/core/SearchInput/SearchInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import lodash from 'lodash';
@@ -33,7 +33,6 @@ describe('Component: SearchInput', () => {
       debounce,
       debounceSettings,
       onChange: onChangeSpy,
-      showIcon,
       placeholder: 'Search...'
     };
 
@@ -47,6 +46,19 @@ describe('Component: SearchInput', () => {
     if (withChildren) {
       // eslint-disable-next-line react/display-name
       props.children = () => <h1>Children</h1>;
+    }
+
+    switch (showIcon) {
+      case true:
+        // Ignore the typescript error because it doesn't know about label here
+        // @ts-ignore
+        props.showIcon = true;
+        break;
+      case false:
+        props.showIcon = false;
+        break;
+      default:
+        break;
     }
 
     const searchInput = shallow(<SearchInput {...props} />);

--- a/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Component: SearchInput ui with icon 1`] = `
     />
   </InputGroupAddon>
   <Input
-    className=""
     defaultValue=""
     innerRef={
       Object {
@@ -43,7 +42,6 @@ exports[`Component: SearchInput ui with icon when undefined 1`] = `
     />
   </InputGroupAddon>
   <Input
-    className=""
     defaultValue=""
     innerRef={
       Object {


### PR DESCRIPTION
Size is used when showIcon is true, but size is not defined in props.
Therefor size is not type-safe. People might not know they could change
the size of the icon or what the available sizes are.
Separated Props into 2 different interfaces, one with showIcon true
which has an optional size, the other with optional showIcon false
where size is not allowed.

Closes #334