### PR TITLE
Added possibility to customize ModalPicker options

### DIFF
--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { pageWithContentAndExactSize } from '../../../test/utils';
-import { userUser, adminUser } from '../../../test/fixtures';
+import { adminUser, userUser } from '../../../test/fixtures';
 import { User } from '../../../test/types';
 
 import ModalPickerMultiple, {
@@ -11,6 +11,8 @@ import ModalPickerMultiple, {
 
 import { FinalForm, Form } from '../../story-utils';
 import { Tooltip, Icon } from '../../..';
+import { ListGroup, ListGroupItem } from 'reactstrap';
+import Avatar from '../../../core/Avatar/Avatar';
 
 storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
   .add('default', () => {
@@ -114,6 +116,46 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           }
           optionForValue={(user: User) => user.email}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
+          value={value}
+          onChange={setValue}
+        />
+      </Form>
+    );
+  })
+  .add('custom renderOptions', () => {
+    const [value, setValue] = useState<User[] | undefined>([]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple<User>
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          fetchOptions={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+          }
+          optionForValue={(user: User) => user.email}
+          renderOptions={options => (
+            <ListGroup>
+              {options.map(({ option, isSelected, toggle }) => (
+                <ListGroupItem
+                  key={option.email}
+                  onClick={toggle}
+                  className="d-flex justify-content-between align-items-center clickable"
+                >
+                  <span>
+                    <Avatar
+                      src="https://www.placecage.com/100/100"
+                      alt={option.email}
+                    />
+                    {option.email}
+                  </span>
+                  {isSelected ? <Icon icon="check" color="primary" /> : null}
+                </ListGroupItem>
+              ))}
+            </ListGroup>
+          )}
           value={value}
           onChange={setValue}
         />

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -4,9 +4,11 @@ import { storiesOf } from '@storybook/react';
 import ModalPickerSingle, { JarbModalPickerSingle } from './ModalPickerSingle';
 import { FinalForm, Form } from '../../story-utils';
 import { pageWithContentAndExactSize } from '../../../test/utils';
-import { userUser, adminUser } from '../../../test/fixtures';
+import { adminUser, userUser } from '../../../test/fixtures';
 import { User } from '../../../test/types';
 import { Icon, Tooltip } from '../../..';
+import Avatar from '../../../core/Avatar/Avatar';
+import { ListGroup, ListGroupItem } from 'reactstrap';
 
 storiesOf('Form/ModalPicker/ModalPickerSingle', module)
   .add('basic', () => {
@@ -93,6 +95,47 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           placeholder="Select your best friend"
           canSearch={true}
           optionForValue={(user: User) => user.email}
+          isOptionEqual={(a: User, b: User) => a.id === b.id}
+          fetchOptions={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+          }
+          value={value}
+          onChange={setValue}
+        />
+      </Form>
+    );
+  })
+  .add('custom renderOptions', () => {
+    const [value, setValue] = useState<User | undefined>();
+
+    return (
+      <Form>
+        <ModalPickerSingle<User>
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          optionForValue={(user: User) => user.email}
+          renderOptions={options => (
+            <ListGroup>
+              {options.map(({ option, isSelected, toggle }) => (
+                <ListGroupItem
+                  key={option.email}
+                  onClick={toggle}
+                  className="d-flex justify-content-between align-items-center clickable"
+                >
+                  <span>
+                    <Avatar
+                      src="https://www.placecage.com/100/100"
+                      alt={option.email}
+                    />
+                    {option.email}
+                  </span>
+                  {isSelected ? <Icon icon="check" color="primary" /> : null}
+                </ListGroupItem>
+              ))}
+            </ListGroup>
+          )}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           fetchOptions={() =>
             Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))

--- a/src/form/option.ts
+++ b/src/form/option.ts
@@ -1,4 +1,5 @@
 import { Page } from '@42.nl/spring-connect';
+import { ReactNode } from 'react';
 
 /**
  * Callback to determine the label for a given value of type T.
@@ -7,6 +8,14 @@ import { Page } from '@42.nl/spring-connect';
 export type OptionForValue<T> = (value: T) => string;
 
 export type OptionEqual<T> = (a: T, b: T) => boolean;
+
+export type RenderOptionsOption<T> = {
+  option: T;
+  isSelected: boolean;
+  toggle: () => void;
+};
+
+export type RenderOptions<T> = (options: RenderOptionsOption<T>[]) => ReactNode;
 
 /**
  * Callback to determine if the option is currently enabled.


### PR DESCRIPTION
You might, for example, want to display the options in the
ModalPicker with a profile image when selecting users.
Added renderOptions callback which you can use to customize
how the options are displayed in a ModalPicker.

Closes #333