### PR TITLE
Added possibility to change tag used for Button

### DIFF
--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -92,6 +92,24 @@ describe('Component: Button', () => {
           expect(toJson(button)).toMatchSnapshot();
         });
       });
+
+      describe('tag', () => {
+        test('use span by default', () => {
+          const button = shallow(<Button onClick={jest.fn()}>Save</Button>);
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('can override tag', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} tag="div">
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+      });
     });
 
     describe('button with icon', () => {
@@ -158,6 +176,28 @@ describe('Component: Button', () => {
           expect(toJson(button)).toMatchSnapshot();
         });
       });
+
+      describe('tag', () => {
+        test('use span by default', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} icon="save">
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('can override tag', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} icon="save" tag="div">
+              Save
+            </Button>
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+      });
     });
 
     describe('icon', () => {
@@ -191,6 +231,22 @@ describe('Component: Button', () => {
         test('is enabled', () => {
           const button = shallow(
             <Button onClick={jest.fn()} icon="save" disabled={false} />
+          );
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+      });
+
+      describe('tag', () => {
+        test('use span by default', () => {
+          const button = shallow(<Button onClick={jest.fn()} icon="save" />);
+
+          expect(toJson(button)).toMatchSnapshot();
+        });
+
+        test('can override tag', () => {
+          const button = shallow(
+            <Button onClick={jest.fn()} icon="save" tag="div" />
           );
 
           expect(toJson(button)).toMatchSnapshot();

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -11,6 +11,13 @@ export type IconPosition = 'left' | 'right';
 
 interface BaseProps {
   /**
+   * Optionally the tag you want to use for the wrapper of the button.
+   *
+   * @default span
+   */
+  tag?: 'span' | 'div';
+
+  /**
    * Optionally the type of button it is, defaults to 'button'.
    *
    * @default button
@@ -114,6 +121,7 @@ export type Props = WithIcon | WithText | WithIconAndText;
  * clicked when performing some call to the back-end.
  */
 export default function Button({
+  tag = 'span',
   type = 'button',
   color = 'primary',
   inProgress,
@@ -133,11 +141,37 @@ export default function Button({
     }
   }
 
-  const children = 'children' in props ? props.children : undefined;
-  const icon = 'icon' in props ? props.icon : undefined;
-  const disabled = 'disabled' in props ? props.disabled : undefined;
+  function getContent() {
+    const icon = 'icon' in props ? props.icon : undefined;
+    const disabled = 'disabled' in props ? props.disabled : undefined;
 
-  if (children !== undefined) {
+    if ('children' in props) {
+      return getRSButton(props.children, disabled, icon);
+    }
+
+    if (showSpinner) {
+      return <Spinner size={24} color="" />;
+    }
+
+    // We know that at this point it must have an icon,
+    // because the Button now extends WithIcon.
+    const iconCast = props.icon as IconType;
+
+    return (
+      <Icon
+        onClick={handleOnClick}
+        icon={iconCast}
+        color={color}
+        disabled={inProgress || disabled}
+      />
+    );
+  }
+
+  function getRSButton(
+    children: React.ReactNode,
+    disabled?: boolean,
+    icon?: IconType
+  ) {
     const outline = 'outline' in props ? props.outline : undefined;
     const size = 'size' in props ? props.size : 'md';
     const iconPosition = 'iconPosition' in props ? props.iconPosition : 'left';
@@ -150,40 +184,26 @@ export default function Button({
     };
 
     return (
-      <span className={`button ${className} ${color}`}>
-        <RSButton
-          onClick={handleOnClick}
-          disabled={inProgress || disabled}
-          {...buttonProps}
-        >
-          {showSpinner ? (
-            <Spinner size={16} color={outline ? '' : 'white'} />
-          ) : icon !== undefined ? (
-            <Icon icon={icon} className={`material-icons-${iconPosition}`} />
-          ) : null}
-          {children}
-        </RSButton>
-      </span>
+      <RSButton
+        onClick={handleOnClick}
+        disabled={inProgress || disabled}
+        {...buttonProps}
+      >
+        {showSpinner ? (
+          <Spinner size={16} color={outline ? '' : 'white'} />
+        ) : icon !== undefined ? (
+          <Icon icon={icon} className={`material-icons-${iconPosition}`} />
+        ) : null}
+        {children}
+      </RSButton>
+    );
+  }
+
+  if (tag === 'span') {
+    return (
+      <span className={`button ${className} ${color}`}>{getContent()}</span>
     );
   } else {
-    // We know that at this point it must be have icon,
-    // because the Button now extends WithIcon.
-    const iconCast = icon as IconType;
-
-    return (
-      <span className={`button ${className} ${color}`}>
-        {showSpinner ? (
-          // Color is empty string so we can override the color
-          <Spinner size={24} color="" />
-        ) : (
-          <Icon
-            onClick={handleOnClick}
-            icon={iconCast}
-            color={color}
-            disabled={inProgress || disabled}
-          />
-        )}
-      </span>
-    );
+    return <div className={`button ${className} ${color}`}>{getContent()}</div>;
   }
 }

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -142,6 +142,38 @@ exports[`Component: Button ui button size use md by default 1`] = `
 </span>
 `;
 
+exports[`Component: Button ui button tag can override tag 1`] = `
+<div
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</div>
+`;
+
+exports[`Component: Button ui button tag use span by default 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</span>
+`;
+
 exports[`Component: Button ui button with icon normal inProgress is false 1`] = `
 <span
   className="button  primary"
@@ -246,6 +278,46 @@ exports[`Component: Button ui button with icon outline inProgress is true 1`] = 
 </span>
 `;
 
+exports[`Component: Button ui button with icon tag can override tag 1`] = `
+<div
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    <Icon
+      className="material-icons-left"
+      icon="save"
+    />
+    Save
+  </Button>
+</div>
+`;
+
+exports[`Component: Button ui button with icon tag use span by default 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    color="primary"
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    <Icon
+      className="material-icons-left"
+      icon="save"
+    />
+    Save
+  </Button>
+</span>
+`;
+
 exports[`Component: Button ui icon disabled is disabled 1`] = `
 <span
   className="button  primary"
@@ -291,6 +363,30 @@ exports[`Component: Button ui icon inProgress inProgress is true 1`] = `
   <Spinner
     color=""
     size={24}
+  />
+</span>
+`;
+
+exports[`Component: Button ui icon tag can override tag 1`] = `
+<div
+  className="button  primary"
+>
+  <Icon
+    color="primary"
+    icon="save"
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`Component: Button ui icon tag use span by default 1`] = `
+<span
+  className="button  primary"
+>
+  <Icon
+    color="primary"
+    icon="save"
+    onClick={[Function]}
   />
 </span>
 `;


### PR DESCRIPTION
Button does not accept margin through the mb classes Bootstrap provides
because it's parent element is a span which negates the set margin.
Added `tag` to Button properties to choose between span or div as
wrapper tag.

Closes #57