### PR TITLE
Fix: Type integrity

### DIFF
--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -9,7 +9,7 @@ import { BootstrapSize, Color } from '../types';
 
 export type IconPosition = 'left' | 'right';
 
-interface BaseProps {
+export interface BaseProps {
   /**
    * Optionally the type of button it is, defaults to 'button'.
    *
@@ -81,6 +81,12 @@ interface WithIcon extends BaseProps {
    * The Icon you want to use.
    */
   icon: IconType;
+
+  iconPosition?: IconPosition;
+
+  children?: never;
+  outline?: never;
+  size?: never;
 }
 
 interface WithText extends BaseProps {
@@ -100,6 +106,9 @@ interface WithText extends BaseProps {
    * Defaults to 'md'.
    */
   size?: BootstrapSize;
+
+  icon?: never;
+  iconPosition?: never;
 }
 
 export type Props = WithIcon | WithText | WithIconAndText;
@@ -133,14 +142,12 @@ export default function Button({
     }
   }
 
-  const children = 'children' in props ? props.children : undefined;
-  const icon = 'icon' in props ? props.icon : undefined;
   const disabled = 'disabled' in props ? props.disabled : undefined;
 
-  if (children !== undefined) {
+  if ('children' in props) {
+    const children = props.children;
     const outline = 'outline' in props ? props.outline : undefined;
     const size = 'size' in props ? props.size : 'md';
-    const iconPosition = 'iconPosition' in props ? props.iconPosition : 'left';
 
     const buttonProps = {
       type,
@@ -158,8 +165,14 @@ export default function Button({
         >
           {showSpinner ? (
             <Spinner size={16} color={outline ? '' : 'white'} />
-          ) : icon !== undefined ? (
-            <Icon icon={icon} className={`material-icons-${iconPosition}`} />
+          ) : 'icon' in props && props.icon ? (
+            <Icon
+              icon={props.icon}
+              className={
+                'material-icons-' +
+                ('iconPosition' in props ? props.iconPosition : 'left')
+              }
+            />
           ) : null}
           {children}
         </RSButton>
@@ -168,6 +181,7 @@ export default function Button({
   } else {
     // We know that at this point it must be have icon,
     // because the Button now extends WithIcon.
+    const icon = props.icon;
     const iconCast = icon as IconType;
 
     return (
@@ -186,4 +200,16 @@ export default function Button({
       </span>
     );
   }
+}
+
+export function isWithIcon(props: Props): props is WithIcon {
+  return props.children === undefined && props.icon !== undefined;
+}
+
+export function isWithIconAndText(props: Props): props is WithIconAndText {
+  return props.children !== undefined && props.icon !== undefined;
+}
+
+export function isWithText(props: Props): props is WithText {
+  return props.children !== undefined && props.icon === undefined;
 }

--- a/src/core/ConfirmButton/ConfirmButton.test.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.test.tsx
@@ -115,18 +115,31 @@ describe('Component: ConfirmButton', () => {
     let confirmButton: ShallowWrapper;
     let onConfirmSpy: jest.Mock<any, any>;
 
-    function setup({ button, icon }: { icon?: IconType; button?: string }) {
+    type Props =
+      | { icon: IconType; button?: never }
+      | { button: string; icon?: never };
+
+    function setup({ button, icon }: Props) {
       onConfirmSpy = jest.fn();
 
-      confirmButton = shallow(
-        <ConfirmButton
-          onConfirm={onConfirmSpy}
-          dialogText="Are you sure you want a ConfirmButton?"
-          icon={icon}
-        >
-          {button}
-        </ConfirmButton>
-      );
+      const props = {
+        onConfirm: onConfirmSpy,
+        dialogText: 'Are you sure you want a ConfirmButton?'
+      };
+
+      if (icon && button) {
+        confirmButton = shallow(
+          <ConfirmButton icon={icon} {...props}>
+            {button}
+          </ConfirmButton>
+        );
+      } else if (icon) {
+        confirmButton = shallow(<ConfirmButton icon={icon} {...props} />);
+      } else {
+        confirmButton = shallow(
+          <ConfirmButton {...props}>{button}</ConfirmButton>
+        );
+      }
     }
 
     function openModal() {

--- a/src/core/ConfirmButton/ConfirmButton.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
-import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
-import Button from '../Button/Button';
+import Button, {
+  BaseProps as ButtonBaseProps,
+  isWithIcon,
+  isWithIconAndText,
+  isWithText,
+  Props as ButtonProps
+} from '../Button/Button';
 import { Color } from '../types';
 import IconType from '../Icon/types';
 import { t } from '../../utilities/translation/translation';
@@ -89,6 +95,8 @@ interface WithIcon extends BaseProps {
    * The Icon you want to use.
    */
   icon: IconType;
+
+  children?: never;
 }
 
 interface WithText extends BaseProps {
@@ -96,6 +104,8 @@ interface WithText extends BaseProps {
    * Optionally the text of the button.
    */
   children: React.ReactNode;
+
+  icon?: never;
 }
 
 type Props = WithIcon | WithText | WithIconAndText;
@@ -116,8 +126,6 @@ export default function ConfirmButton({
   className,
   ...props
 }: Props) {
-  const children = 'children' in props ? props.children : undefined;
-  const icon = 'icon' in props ? props.icon : undefined;
   const [isOpen, setOpen] = useState(false);
   const { modalHeader, confirm, cancel } = text;
 
@@ -131,19 +139,34 @@ export default function ConfirmButton({
     onConfirm(event);
   }
 
+  function getProps() {
+    const buttonProps: ButtonBaseProps = {
+      onClick: openModal,
+      color,
+      inProgress: !!inProgress
+    };
+
+    if (isWithIcon(props) || isWithIconAndText(props)) {
+      const withIcon = buttonProps as WithIcon | WithIconAndText;
+
+      withIcon.icon = props.icon;
+    }
+
+    if (isWithText(props) || isWithIconAndText(props)) {
+      const withText = buttonProps as WithText | WithIconAndText;
+
+      withText.children = props.children;
+    }
+
+    return buttonProps as ButtonProps;
+  }
+
   return (
     <div
       className={className}
-      style={{ display: icon && !children ? 'inline' : 'block' }}
+      style={{ display: 'children' in props ? 'block' : 'inline' }}
     >
-      <Button
-        onClick={openModal}
-        icon={icon}
-        color={color}
-        inProgress={!!inProgress}
-      >
-        {children}
-      </Button>
+      <Button {...getProps()} />
 
       <Modal isOpen={isOpen} toggle={() => setOpen(false)}>
         <ModalHeader toggle={() => setOpen(false)}>

--- a/src/form/Input/Addon/Addon.tsx
+++ b/src/form/Input/Addon/Addon.tsx
@@ -34,6 +34,8 @@ interface IconProps extends BaseProps {
    * The icon to use as the Addon.
    */
   icon: IconType;
+
+  text?: never;
 }
 
 interface TextProps extends BaseProps {
@@ -41,6 +43,8 @@ interface TextProps extends BaseProps {
    * The text to use as the Addon.
    */
   text: string;
+
+  icon?: never;
 }
 
 export type Props = IconProps | TextProps;


### PR DESCRIPTION
In Addon, you can specify icon and text without warning.
Added `text?: never` to IconProps and `icon?: never` to TextProps so
you'll get a warning that icon and text cannot be used together.
Did the same with ConfirmButton where icon and children should never be
`undefined`, they either have a valid value or they're not specified at
all.

Closes #335