### PR TITLE
Fix: Bootstrap sizes should be a registered type

### DIFF
--- a/src/core/Avatar/Avatar.test.tsx
+++ b/src/core/Avatar/Avatar.test.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import Avatar, { Size } from './Avatar';
+import Avatar from './Avatar';
+import { BootstrapSize } from '../types';
 
 describe('Component: Avatar', () => {
   let avatar: ShallowWrapper;
 
-  function setup({ size }: { size?: Size }) {
+  function setup({ size }: { size?: BootstrapSize }) {
     avatar = shallow(
       <Avatar
         className="red"

--- a/src/core/Avatar/Avatar.tsx
+++ b/src/core/Avatar/Avatar.tsx
@@ -2,8 +2,7 @@ import React, { ReactNode } from 'react';
 import { UncontrolledTooltip } from 'reactstrap';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
-
-export type Size = 'xs' | 'sm' | 'md' | 'lg';
+import { BootstrapSize } from '../types';
 
 interface Props {
   /**
@@ -26,7 +25,7 @@ interface Props {
    *
    * @default md
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: BootstrapSize;
 
   /**
    * Optional extra CSS class you want to add to the component.

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -5,7 +5,7 @@ import Spinner from '../Spinner/Spinner';
 import { Icon, IconType } from '../Icon';
 import useShowSpinner from './useShowSpinner';
 
-import { Color } from '../types';
+import { BootstrapSize, Color } from '../types';
 
 export type IconPosition = 'left' | 'right';
 
@@ -73,7 +73,7 @@ interface WithIconAndText extends BaseProps {
    *
    * Defaults to 'md'.
    */
-  size?: 'sm' | 'md' | 'lg';
+  size?: BootstrapSize;
 }
 
 interface WithIcon extends BaseProps {
@@ -99,7 +99,7 @@ interface WithText extends BaseProps {
    *
    * Defaults to 'md'.
    */
-  size?: 'sm' | 'md' | 'lg';
+  size?: BootstrapSize;
 }
 
 export type Props = WithIcon | WithText | WithIconAndText;

--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -10,6 +10,7 @@ import {
 } from 'reactstrap';
 
 import { Icon } from '../Icon';
+import { BootstrapSize } from '../types';
 
 interface SearchInputApi {
   /**
@@ -126,7 +127,7 @@ interface WithLabelAndIcon extends BaseProps {
   /**
    * Optional size you want to give the icon.
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: BootstrapSize;
 }
 
 interface WithoutLabelButWithIcon extends WithoutLabel {
@@ -140,7 +141,7 @@ interface WithoutLabelButWithIcon extends WithoutLabel {
   /**
    * Optional size you want to give the icon.
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: BootstrapSize;
 }
 
 export type Props =

--- a/src/core/SubmitButton/SubmitButton.tsx
+++ b/src/core/SubmitButton/SubmitButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Button from '../Button/Button';
-import Icon from '../Icon/Icon';
+import { BootstrapSize } from '../types';
 
 export interface Props {
   /**
@@ -15,7 +15,7 @@ export interface Props {
    *
    * @default md
    */
-  size?: 'lg' | 'sm' | 'md';
+  size?: BootstrapSize;
 
   /**
    * Optional callback for what needs to happen when the button is clicked.
@@ -53,8 +53,9 @@ export default function SubmitButton({
       inProgress={inProgress}
       className={`float-right ${className}`}
       onClick={onClick}
+      icon="save"
     >
-      <Icon icon="save" /> {children}
+      {children}
     </Button>
   );
 }

--- a/src/core/SubmitButton/__snapshots__/SubmitButton.test.tsx.snap
+++ b/src/core/SubmitButton/__snapshots__/SubmitButton.test.tsx.snap
@@ -4,15 +4,12 @@ exports[`Component: SubmitButton ui with all optional params: Component: SubmitB
 <Button
   className="float-right extra-css-class"
   color="primary"
+  icon="save"
   inProgress={true}
   onClick={[MockFunction]}
   size="lg"
   type="submit"
 >
-  <Icon
-    icon="save"
-  />
-   
   Submit
 </Button>
 `;
@@ -21,14 +18,11 @@ exports[`Component: SubmitButton ui with all required props: Component: SubmitBu
 <Button
   className="float-right "
   color="primary"
+  icon="save"
   inProgress={true}
   onClick={[MockFunction]}
   type="submit"
 >
-  <Icon
-    icon="save"
-  />
-   
   Submit
 </Button>
 `;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,3 +9,5 @@ export type Color =
   | 'muted'
   | 'dark'
   | 'light';
+
+export type BootstrapSize = 'xs' | 'sm' | 'md' | 'lg';


### PR DESCRIPTION
Bootstrap sizes like 'xs' | 'sm' | 'md' | 'lg' are used and defined in
multiple files. This should be separated into a BootstrapSize type
defined in one place.

Closes #339