### PR TITLE
improvement: added horizontal mode to multiple checkbox/radio

### DIFF
--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -213,7 +213,6 @@ export default function SearchInput(props: Props) {
       ...rest
     };
 
-    console.log(showIcon);
     if (showIcon) {
       return (
         <InputGroup className={className} size={size}>

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -8,7 +8,7 @@ import CheckboxMultipleSelect, {
 import { FinalForm, Form } from '../story-utils';
 import { pageOfUsers, userUser } from '../../test/fixtures';
 import { User } from '../../test/types';
-import { Tooltip, Icon } from '../..';
+import { Icon, Tooltip } from '../..';
 
 interface SubjectOption {
   value: string;
@@ -37,6 +37,32 @@ storiesOf('Form|CheckboxMultipleSelect', module)
             value={value}
             onChange={setValue}
           />
+        </Form>
+      </div>
+    );
+  })
+  .add('horizontal', () => {
+    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
+
+    return (
+      <div>
+        <Form>
+          <CheckboxMultipleSelect
+            id="subject"
+            label="Subject"
+            placeholder="Please select your subjects"
+            optionForValue={(option: SubjectOption) => option.label}
+            isOptionEnabled={option => option.value !== 'awesome'}
+            options={options.filter((_, index) => index < 5)}
+            value={value}
+            onChange={setValue}
+            horizontal={true}
+          />
+
+          <p>
+            <strong>Disclaimer:</strong> horizontal mode works best when there
+            are not too many items
+          </p>
         </Form>
       </div>
     );

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
@@ -23,13 +23,15 @@ describe('Component: CheckboxMultipleSelect', () => {
     isOptionEnabled,
     text,
     hasPlaceholder = true,
-    hasLabel = true
+    hasLabel = true,
+    horizontal
   }: {
     value?: User[];
     isOptionEnabled?: OptionEnabledCallback<User>;
     text?: Text;
     hasPlaceholder?: boolean;
     hasLabel?: boolean;
+    horizontal?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -43,7 +45,8 @@ describe('Component: CheckboxMultipleSelect', () => {
       value,
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
-      error: 'Some error'
+      error: 'Some error',
+      horizontal
     };
 
     if (hasLabel) {
@@ -57,7 +60,7 @@ describe('Component: CheckboxMultipleSelect', () => {
 
   describe('ui', () => {
     test('with value', () => {
-      setup({ value: [adminUser], isOptionEnabled: undefined });
+      setup({ value: [adminUser] });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => with value'
@@ -92,11 +95,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     });
 
     test('without placeholder', () => {
-      setup({
-        value: [adminUser],
-        isOptionEnabled: undefined,
-        hasPlaceholder: false
-      });
+      setup({ value: [adminUser], hasPlaceholder: false });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => without placeholder'
@@ -104,14 +103,18 @@ describe('Component: CheckboxMultipleSelect', () => {
     });
 
     test('without label', () => {
-      setup({
-        value: [adminUser],
-        isOptionEnabled: undefined,
-        hasLabel: false
-      });
+      setup({ value: [adminUser], hasLabel: false });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => without label'
+      );
+    });
+
+    test('horizontal', () => {
+      setup({ value: [adminUser], horizontal: true });
+
+      expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
+        'Component: CheckboxMultipleSelect => ui => horizontal'
       );
     });
   });

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -100,6 +100,13 @@ interface BaseProps<T> {
    * This text should already be translated.
    */
   text?: Text;
+
+  /**
+   * Whether or not to show the CheckboxMultipleSelect horizontally.
+   *
+   * Defaults to `false`
+   */
+  horizontal?: boolean;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -226,49 +233,59 @@ export default class CheckboxMultipleSelect<T> extends Component<
   }
 
   renderCheckboxes() {
+    const { horizontal = false } = this.props;
+
+    if (horizontal) {
+      return this.renderOptions(this.state.options, true);
+    } else {
+      const { options } = this.state;
+
+      const chunks = chunk(options, 10);
+
+      return (
+        <Row>
+          {chunks.map((options, index) => {
+            return (
+              <Col xs="auto" key={index} style={{ width: '300px' }}>
+                {this.renderOptions(options, false)}
+              </Col>
+            );
+          })}
+        </Row>
+      );
+    }
+  }
+
+  renderOptions(options: T[], horizontal: boolean) {
     const { optionForValue, value, isOptionEqual } = this.props;
-
-    const { options } = this.state;
-
-    const chunks = chunk(options, 10);
 
     const isOptionEnabled = get(this.props, 'isOptionEnabled', constant(true));
 
-    return (
-      <Row>
-        {chunks.map((options, index) => {
-          return (
-            <Col xs="auto" key={index} style={{ width: '300px' }}>
-              {options.map((option, index) => {
-                const label = optionForValue(option);
+    return options.map((option, index) => {
+      const label = optionForValue(option);
 
-                const isChecked = isOptionSelected({
-                  option,
-                  optionForValue,
-                  isOptionEqual,
-                  value
-                });
+      const isChecked = isOptionSelected({
+        option,
+        optionForValue,
+        isOptionEqual,
+        value
+      });
 
-                return (
-                  <FormGroup check key={label}>
-                    <Label check>
-                      <RSInput
-                        type="checkbox"
-                        checked={isChecked}
-                        value={index}
-                        disabled={!isOptionEnabled(option)}
-                        onChange={() => this.optionClicked(option, isChecked)}
-                      />{' '}
-                      {label}
-                    </Label>
-                  </FormGroup>
-                );
-              })}
-            </Col>
-          );
-        })}
-      </Row>
-    );
+      return (
+        <FormGroup check key={label} inline={horizontal}>
+          <Label check>
+            <RSInput
+              type="checkbox"
+              checked={isChecked}
+              value={index}
+              disabled={!isOptionEnabled(option)}
+              onChange={() => this.optionClicked(option, isChecked)}
+            />{' '}
+            {label}
+          </Label>
+        </FormGroup>
+      );
+    });
   }
 }
 

--- a/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
+++ b/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
@@ -1,5 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMultipleSelect => ui => horizontal 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="subject"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Subject
+  </Label>
+  <p
+    className="text-muted"
+  >
+    <em>
+      Please select your subjects
+    </em>
+  </p>
+  <FormGroup
+    check={true}
+    inline={true}
+    key="admin@42.nl"
+    tag="div"
+  >
+    <Label
+      check={true}
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Input
+        checked={true}
+        disabled={false}
+        onChange={[Function]}
+        type="checkbox"
+        value={0}
+      />
+       
+      admin@42.nl
+    </Label>
+  </FormGroup>
+  <FormGroup
+    check={true}
+    inline={true}
+    key="coordinator@42.nl"
+    tag="div"
+  >
+    <Label
+      check={true}
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Input
+        checked={false}
+        disabled={false}
+        onChange={[Function]}
+        type="checkbox"
+        value={1}
+      />
+       
+      coordinator@42.nl
+    </Label>
+  </FormGroup>
+  <FormGroup
+    check={true}
+    inline={true}
+    key="user@42.nl"
+    tag="div"
+  >
+    <Label
+      check={true}
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Input
+        checked={false}
+        disabled={false}
+        onChange={[Function]}
+        type="checkbox"
+        value={2}
+      />
+       
+      user@42.nl
+    </Label>
+  </FormGroup>
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMultipleSelect => ui => with value 1`] = `
 <FormGroup
   className=""
@@ -60,6 +181,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
     >
       <FormGroup
         check={true}
+        inline={false}
         key="admin@42.nl"
         tag="div"
       >
@@ -89,6 +211,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
       </FormGroup>
       <FormGroup
         check={true}
+        inline={false}
         key="coordinator@42.nl"
         tag="div"
       >
@@ -118,6 +241,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
       </FormGroup>
       <FormGroup
         check={true}
+        inline={false}
         key="user@42.nl"
         tag="div"
       >
@@ -196,6 +320,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
     >
       <FormGroup
         check={true}
+        inline={false}
         key="admin@42.nl"
         tag="div"
       >
@@ -225,6 +350,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
       </FormGroup>
       <FormGroup
         check={true}
+        inline={false}
         key="coordinator@42.nl"
         tag="div"
       >
@@ -254,6 +380,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
       </FormGroup>
       <FormGroup
         check={true}
+        inline={false}
         key="user@42.nl"
         tag="div"
       >
@@ -340,6 +467,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
     >
       <FormGroup
         check={true}
+        inline={false}
         key="admin@42.nl"
         tag="div"
       >
@@ -369,6 +497,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
       </FormGroup>
       <FormGroup
         check={true}
+        inline={false}
         key="coordinator@42.nl"
         tag="div"
       >
@@ -398,6 +527,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
       </FormGroup>
       <FormGroup
         check={true}
+        inline={false}
         key="user@42.nl"
         tag="div"
       >

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -40,6 +40,39 @@ storiesOf('Form|RadioGroup', module)
       </Form>
     );
   })
+  .add('horizontal', () => {
+    const [subject, setSubject] = useState<SubjectOption | undefined>(
+      undefined
+    );
+
+    return (
+      <Form>
+        <Checkbox<SubjectOption>
+          id="subject"
+          label="Subject"
+          placeholder="Please enter your subject"
+          optionForValue={(option: SubjectOption) => option.label}
+          isOptionEnabled={option => option.value !== 'awesome'}
+          options={[
+            { value: 'awesome', label: 'Awesome shit' },
+            { value: 'super', label: 'Super shit' },
+            { value: 'great', label: 'Great shit' },
+            { value: 'good', label: 'good shit' }
+          ]}
+          value={subject}
+          onChange={setSubject}
+          horizontal={true}
+        />
+
+        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+
+        <p>
+          <strong>Disclaimer:</strong> horizontal mode works best when there are
+          not too many items
+        </p>
+      </Form>
+    );
+  })
   .add('fetched options', () => {
     const [subject, setSubject] = useState<User>(randomUser());
 

--- a/src/form/RadioGroup/RadioGroup.test.tsx
+++ b/src/form/RadioGroup/RadioGroup.test.tsx
@@ -18,13 +18,15 @@ describe('Component: RadioGroup', () => {
     isOptionEnabled,
     text,
     hasPlaceholder = true,
-    hasLabel = true
+    hasLabel = true,
+    horizontal
   }: {
     value?: User;
     isOptionEnabled?: OptionEnabledCallback<User>;
     text?: Text;
     hasPlaceholder?: boolean;
     hasLabel?: boolean;
+    horizontal?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -39,7 +41,8 @@ describe('Component: RadioGroup', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      valid: false
+      valid: false,
+      horizontal
     };
 
     if (hasLabel) {
@@ -99,6 +102,18 @@ describe('Component: RadioGroup', () => {
 
       expect(toJson(radioGroup)).toMatchSnapshot(
         'Component: RadioGroup => ui => without label'
+      );
+    });
+
+    test('horizontal', () => {
+      setup({
+        value: adminUser,
+        isOptionEnabled: undefined,
+        horizontal: true
+      });
+
+      expect(toJson(radioGroup)).toMatchSnapshot(
+        'Component: RadioGroup => ui => horizontal'
       );
     });
   });

--- a/src/form/RadioGroup/RadioGroup.tsx
+++ b/src/form/RadioGroup/RadioGroup.tsx
@@ -104,6 +104,13 @@ interface BaseProps<T> {
    * This text should already be translated.
    */
   text?: Text;
+
+  /**
+   * Whether or not to show the RadioGroup horizontally.
+   *
+   * Defaults to `false`
+   */
+  horizontal?: boolean;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -134,7 +141,8 @@ export default function RadioGroup<T>(props: Props<T>) {
     onChange,
     onBlur,
     optionForValue,
-    isOptionEqual
+    isOptionEqual,
+    horizontal = false
   } = props;
 
   const { options, loading } = useOptions({
@@ -172,7 +180,7 @@ export default function RadioGroup<T>(props: Props<T>) {
           const label = optionForValue(option);
 
           return (
-            <FormGroup key={label} check>
+            <FormGroup key={label} check inline={horizontal}>
               <Label check>
                 <Input
                   type="radio"

--- a/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => with value 1`] = `
+exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => horizontal 1`] = `
 <FormGroup
   className=""
   tag="fieldset"
@@ -17,6 +17,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
   </p>
   <FormGroup
     check={true}
+    inline={true}
     key="admin@42.nl"
     tag="div"
   >
@@ -46,6 +47,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
   </FormGroup>
   <FormGroup
     check={true}
+    inline={true}
     key="coordinator@42.nl"
     tag="div"
   >
@@ -75,6 +77,116 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
   </FormGroup>
   <FormGroup
     check={true}
+    inline={true}
+    key="user@42.nl"
+    tag="div"
+  >
+    <Label
+      check={true}
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Input
+        checked={false}
+        disabled={false}
+        onChange={[Function]}
+        type="radio"
+        value="user@42.nl"
+      />
+       
+      user@42.nl
+    </Label>
+  </FormGroup>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => with value 1`] = `
+<FormGroup
+  className=""
+  tag="fieldset"
+>
+  <legend>
+    Subject
+  </legend>
+  <p
+    className="text-muted"
+  >
+    <em>
+      Please enter your subject
+    </em>
+  </p>
+  <FormGroup
+    check={true}
+    inline={false}
+    key="admin@42.nl"
+    tag="div"
+  >
+    <Label
+      check={true}
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Input
+        checked={true}
+        disabled={false}
+        onChange={[Function]}
+        type="radio"
+        value="admin@42.nl"
+      />
+       
+      admin@42.nl
+    </Label>
+  </FormGroup>
+  <FormGroup
+    check={true}
+    inline={false}
+    key="coordinator@42.nl"
+    tag="div"
+  >
+    <Label
+      check={true}
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Input
+        checked={false}
+        disabled={false}
+        onChange={[Function]}
+        type="radio"
+        value="coordinator@42.nl"
+      />
+       
+      coordinator@42.nl
+    </Label>
+  </FormGroup>
+  <FormGroup
+    check={true}
+    inline={false}
     key="user@42.nl"
     tag="div"
   >
@@ -120,6 +232,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
   </p>
   <FormGroup
     check={true}
+    inline={false}
     key="admin@42.nl"
     tag="div"
   >
@@ -149,6 +262,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
   </FormGroup>
   <FormGroup
     check={true}
+    inline={false}
     key="coordinator@42.nl"
     tag="div"
   >
@@ -178,6 +292,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
   </FormGroup>
   <FormGroup
     check={true}
+    inline={false}
     key="user@42.nl"
     tag="div"
   >
@@ -219,6 +334,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
   </legend>
   <FormGroup
     check={true}
+    inline={false}
     key="admin@42.nl"
     tag="div"
   >
@@ -248,6 +364,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
   </FormGroup>
   <FormGroup
     check={true}
+    inline={false}
     key="coordinator@42.nl"
     tag="div"
   >
@@ -277,6 +394,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
   </FormGroup>
   <FormGroup
     check={true}
+    inline={false}
     key="user@42.nl"
     tag="div"
   >

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
               >
                 <FormGroup
                   check={true}
+                  inline={false}
                   key="admin@42.nl"
                   tag="div"
                 >
@@ -171,6 +172,7 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
                 </FormGroup>
                 <FormGroup
                   check={true}
+                  inline={false}
                   key="coordinator@42.nl"
                   tag="div"
                 >
@@ -217,6 +219,7 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
                 </FormGroup>
                 <FormGroup
                   check={true}
+                  inline={false}
                   key="user@42.nl"
                   tag="div"
                 >
@@ -742,6 +745,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
         </p>
         <FormGroup
           check={true}
+          inline={false}
           key="admin@42.nl"
           tag="div"
         >
@@ -788,6 +792,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
         </FormGroup>
         <FormGroup
           check={true}
+          inline={false}
           key="coordinator@42.nl"
           tag="div"
         >
@@ -834,6 +839,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
         </FormGroup>
         <FormGroup
           check={true}
+          inline={false}
           key="user@42.nl"
           tag="div"
         >


### PR DESCRIPTION
If you want to display inputs i.e. in a table, it might be better to
display options horizontally instead of vertically.
Added horizontal mode to RadioGroup and CheckboxMultipleSelect to allow
for options to be displayed horizontally instead of vertically.

Closes #355