### PR TITLE
improvement: withJarb errors in tooltip

### DIFF
--- a/src/form/FormError/FormError.tsx
+++ b/src/form/FormError/FormError.tsx
@@ -3,7 +3,7 @@ import { FormFeedback } from 'reactstrap';
 import { useErrorsForValidator } from '@42.nl/react-error-store';
 
 import { Meta, MetaError } from '../types';
-import { keyForError, errorMessage } from './utils';
+import { errorMessage, keyForError } from './utils';
 import { useSettledErrors } from './useSettledErrors';
 import { useOnChange } from './useOnChange';
 import { OnChange } from './types';
@@ -29,6 +29,11 @@ interface Props {
    * they are removed.
    */
   onChange?: OnChange;
+
+  /**
+   * Optionally: classes to put on the div around the errors.
+   */
+  className?: string;
 }
 
 /**
@@ -40,7 +45,7 @@ interface Props {
  * is `Entity.property`.
  */
 export default function FormError(props: Props) {
-  const { value, meta, validator, onChange } = props;
+  const { value, meta, validator, onChange, className } = props;
   const backEndErrors = useErrorsForValidator(validator);
   const frontEndErrors = useSettledErrors(meta, value);
 
@@ -53,7 +58,7 @@ export default function FormError(props: Props) {
   }
 
   return (
-    <>
+    <div className={className}>
       {frontEndErrors.map((e: MetaError) => (
         <FormFeedback key={keyForError(e)}>{errorMessage(e)}</FormFeedback>
       ))}
@@ -61,7 +66,6 @@ export default function FormError(props: Props) {
       {backEndErrors.map((e: string) => (
         <FormFeedback key={e}>{errorMessage(e)}</FormFeedback>
       ))}
-    </>
+    </div>
   );
 }
-

--- a/src/form/FormError/__snapshots__/FormError.test.tsx.snap
+++ b/src/form/FormError/__snapshots__/FormError.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component: FormError ui both errors: Component: FormError => ui => has both errors 1`] = `
-<Fragment>
+<div>
   <FormFeedback
     key="ERROR_REQUIRED"
     tag="div"
@@ -14,27 +14,27 @@ exports[`Component: FormError ui both errors: Component: FormError => ui => has 
   >
     back-end error
   </FormFeedback>
-</Fragment>
+</div>
 `;
 
 exports[`Component: FormError ui has back-end errors: Component: FormError => ui => has back-end errors 1`] = `
-<Fragment>
+<div>
   <FormFeedback
     key="back-end error"
     tag="div"
   >
     back-end error
   </FormFeedback>
-</Fragment>
+</div>
 `;
 
 exports[`Component: FormError ui has front-end errors: Component: FormError => ui => has front-end errors 1`] = `
-<Fragment>
+<div>
   <FormFeedback
     key="ERROR_REQUIRED"
     tag="div"
   >
     Name is required
   </FormFeedback>
-</Fragment>
+</div>
 `;

--- a/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
+++ b/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
@@ -1,5 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HoC: withJarb errorMode: tooltip: withJarb => errorMode: tooltip => formError 1`] = `
+<div
+  className="withjarb-tooltip"
+>
+  <FormFeedback
+    key=""
+    tag="div"
+  />
+</div>
+`;
+
+exports[`HoC: withJarb errorMode: tooltip: withJarb => errorMode: tooltip => jarbField 1`] = `
+<ForwardRef(TippyWrapper)
+  boundary="viewport"
+  className="border-0"
+  content={
+    <React.Fragment>
+       
+      <Field
+        name="firstName"
+        render={[Function]}
+        subscription={
+          Object {
+            "active": true,
+            "error": true,
+            "touched": true,
+            "validating": true,
+            "value": true,
+          }
+        }
+      />
+       
+    </React.Fragment>
+  }
+  distance={7}
+  maxWidth={350}
+  placement="bottom"
+>
+  <div
+    className="w-100"
+    style={
+      Object {
+        "outline": 0,
+      }
+    }
+    tabIndex={0}
+  >
+    <Input
+      color=""
+      onBlur={[MockFunction]}
+      onChange={[Function]}
+      value="value"
+    />
+  </div>
+</ForwardRef(TippyWrapper)>
+`;
+
 exports[`HoC: withJarb should throw an error when detecting illegal props 1`] = `
 "
         withJarb: illegal props detected on \\"JarbInput\\".
@@ -17,12 +74,12 @@ exports[`HoC: withJarb should throw an error when detecting illegal props 1`] = 
 `;
 
 exports[`HoC: withJarb ui: withJarb => ui => formError 1`] = `
-<Fragment>
+<div>
   <FormFeedback
     key=""
     tag="div"
   />
-</Fragment>
+</div>
 `;
 
 exports[`HoC: withJarb ui: withJarb => ui => jarbField 1`] = `

--- a/src/form/withJarb/useHasErrors/useHasErrors.test.ts
+++ b/src/form/withJarb/useHasErrors/useHasErrors.test.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useHasErrors } from './useHasErrors';
+import { renderHook } from '@testing-library/react-hooks';
+
+test('return value', () => {
+  const stateSpy = jest.spyOn(React, 'useState');
+
+  const { unmount } = renderHook(() => useHasErrors());
+  unmount();
+
+  expect(stateSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/form/withJarb/useHasErrors/useHasErrors.ts
+++ b/src/form/withJarb/useHasErrors/useHasErrors.ts
@@ -1,0 +1,5 @@
+import { useState } from 'react';
+
+export function useHasErrors() {
+  return useState(false);
+}

--- a/src/form/withJarb/withJarb.scss
+++ b/src/form/withJarb/withJarb.scss
@@ -1,0 +1,7 @@
+.withjarb-tooltip .invalid-feedback {
+  color: $white;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}

--- a/src/form/withJarb/withJarb.test.tsx
+++ b/src/form/withJarb/withJarb.test.tsx
@@ -4,6 +4,7 @@ import toJson from 'enzyme-to-json';
 import * as reactErrorStore from '@42.nl/react-error-store';
 
 import withJarb from './withJarb';
+import * as useHasErrors from './useHasErrors/useHasErrors';
 
 import { validMeta } from '../../test/fixtures';
 
@@ -23,6 +24,10 @@ describe('HoC: withJarb', () => {
   function setup() {
     onBlurSpy = jest.fn();
     onChangeSpy = jest.fn();
+
+    jest
+      .spyOn(useHasErrors, 'useHasErrors')
+      .mockImplementation(() => [false, jest.fn()]);
 
     jarbFieldParent = shallow(
       <JarbInput
@@ -61,6 +66,43 @@ describe('HoC: withJarb', () => {
     expect(toJson(jarbFieldParent)).toMatchSnapshot('withJarb => ui');
     expect(toJson(jarbField)).toMatchSnapshot('withJarb => ui => jarbField');
     expect(toJson(formError)).toMatchSnapshot('withJarb => ui => formError');
+  });
+
+  test('errorMode: tooltip', () => {
+    jest
+      .spyOn(useHasErrors, 'useHasErrors')
+      .mockImplementation(() => [true, jest.fn()]);
+
+    const jarbInput = shallow(
+      <JarbInput
+        name="firstName"
+        jarb={{ validator: 'User.email', label: 'First name' }}
+        validators={[isSuperman]}
+        initialValue="beheer@42.nl"
+        errorMode="tooltip"
+      />
+    );
+
+    const input = { onBlur: onBlurSpy, onChange: onChangeSpy, value: 'value' };
+
+    const tooltip = shallow(
+      // @ts-ignore
+      jarbInput.props().render({ input, meta: validMeta })
+    );
+
+    const tooltipFormError = shallow(
+      tooltip
+        .props()
+        // @ts-ignore
+        .content.props.children[1].props.render({ input, meta: validMeta })
+    );
+
+    expect(toJson(tooltip)).toMatchSnapshot(
+      'withJarb => errorMode: tooltip => jarbField'
+    );
+    expect(toJson(tooltipFormError)).toMatchSnapshot(
+      'withJarb => errorMode: tooltip => formError'
+    );
   });
 
   it('should throw an error when detecting illegal props', () => {

--- a/src/main.scss
+++ b/src/main.scss
@@ -41,6 +41,7 @@
 @import './form/Toggle/Toggle';
 @import './form/Typeahead/Typeahead';
 @import './form/ColorPicker/ColorPicker';
+@import './form/withJarb/withJarb';
 
 // Table
 @import './table/EpicTable/EpicTable';


### PR DESCRIPTION
If you want to display a form in an EpicTable, showing errors below the
inputs will clutter the frame. Instead, you could display the errors in
a tooltip that'll show on hover.
Added the possibility to specify if the errors should be displayed in a
tooltip or not. Defaults to displaying the errors underneath the input.

Closes #358