### PR TITLE
fix: types.ts prevents coverage of 100%

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 export type Color =
   | 'primary'
   | 'secondary'


### PR DESCRIPTION
Because the Color type in types.ts starts with a pipeline, it is seen as
a statement (which is not tested).
Added a comment to make tests ignore the types file.