### PR TITLE
fix: ModalPickerSingle should not overflow a fixed-width container

### DIFF
--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ModalPickerOpener } from './ModalPickerOpener';
+import { adminUser } from '../../../test/fixtures';
+import toJson from 'enzyme-to-json';
+import * as useComponentOverflow from './useComponentOverflow/useComponentOverflow';
+
+describe('Component: ModalPickerOpener', () => {
+  function setup({
+    hasValues = false,
+    withTooltip = false
+  }: {
+    hasValues?: boolean;
+    withTooltip?: boolean;
+  }) {
+    const openModalSpy = jest.fn();
+    const values = hasValues ? adminUser.email : undefined;
+
+    jest
+      .spyOn(useComponentOverflow, 'useComponentOverflow')
+      .mockImplementation(() => withTooltip);
+
+    const modalPickerOpener = shallow(
+      <ModalPickerOpener
+        openModal={openModalSpy}
+        label="Best friend"
+        values={values}
+      />
+    );
+
+    return { modalPickerOpener, openModalSpy };
+  }
+
+  describe('ui', () => {
+    test('without values', () => {
+      const { modalPickerOpener } = setup({});
+      expect(toJson(modalPickerOpener)).toMatchSnapshot(
+        'Component: ModalPickerOpener => ui => without values'
+      );
+    });
+
+    test('with values', () => {
+      const { modalPickerOpener } = setup({ hasValues: true });
+      expect(toJson(modalPickerOpener)).toMatchSnapshot(
+        'Component: ModalPickerOpener => ui => with values'
+      );
+    });
+
+    test('tooltip', () => {
+      const { modalPickerOpener } = setup({
+        hasValues: true,
+        withTooltip: true
+      });
+
+      expect(toJson(modalPickerOpener)).toMatchSnapshot(
+        'Component: ModalPickerOpener => ui => with tooltip'
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('should open the modal when the select button is clicked', () => {
+      const { modalPickerOpener, openModalSpy } = setup({});
+
+      // @ts-ignore
+      modalPickerOpener
+        .find('Button')
+        .props()
+        // @ts-ignore
+        .onClick();
+
+      expect(openModalSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -1,0 +1,55 @@
+import React, { useRef } from 'react';
+import { Button } from 'reactstrap';
+import Tooltip from '../../../core/Tooltip/Tooltip';
+import { useComponentOverflow } from './useComponentOverflow/useComponentOverflow';
+
+interface Props {
+  /**
+   * Function to open the modal, called when the button is clicked.
+   */
+  openModal: () => void;
+
+  /**
+   * The label to display on the button.
+   */
+  label: React.ReactNode;
+
+  /**
+   * The display of selected item(s).
+   */
+  values?: React.ReactNode;
+}
+
+export function ModalPickerOpener(props: Props) {
+  const { openModal, label, values } = props;
+
+  const ref = useRef<HTMLElement>(null);
+
+  const isOverflowing = useComponentOverflow(ref, values);
+
+  return (
+    <div className="d-flex align-items-center">
+      {values ? (
+        <span className="text-truncate mr-1 position-relative" ref={ref}>
+          {isOverflowing ? (
+            <Tooltip
+              content={values}
+              className="w-100 h-100 position-absolute"
+              tag="div"
+            >
+              {' '}
+            </Tooltip>
+          ) : null}
+          {values}
+        </span>
+      ) : null}
+      <Button
+        color="primary"
+        onClick={openModal}
+        className="flex-grow-0 flex-shrink-0"
+      >
+        {label}
+      </Button>
+    </div>
+  );
+}

--- a/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
+++ b/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: ModalPickerOpener ui tooltip: Component: ModalPickerOpener => ui => with tooltip 1`] = `
+<div
+  className="d-flex align-items-center"
+>
+  <span
+    className="text-truncate mr-1 position-relative"
+  >
+    <Tooltip
+      className="w-100 h-100 position-absolute"
+      content="admin@42.nl"
+      tag="div"
+    >
+       
+    </Tooltip>
+    admin@42.nl
+  </span>
+  <Button
+    className="flex-grow-0 flex-shrink-0"
+    color="primary"
+    onClick={[MockFunction]}
+    tag="button"
+  >
+    Best friend
+  </Button>
+</div>
+`;
+
+exports[`Component: ModalPickerOpener ui with values: Component: ModalPickerOpener => ui => with values 1`] = `
+<div
+  className="d-flex align-items-center"
+>
+  <span
+    className="text-truncate mr-1 position-relative"
+  >
+    admin@42.nl
+  </span>
+  <Button
+    className="flex-grow-0 flex-shrink-0"
+    color="primary"
+    onClick={[MockFunction]}
+    tag="button"
+  >
+    Best friend
+  </Button>
+</div>
+`;
+
+exports[`Component: ModalPickerOpener ui without values: Component: ModalPickerOpener => ui => without values 1`] = `
+<div
+  className="d-flex align-items-center"
+>
+  <Button
+    className="flex-grow-0 flex-shrink-0"
+    color="primary"
+    onClick={[MockFunction]}
+    tag="button"
+  >
+    Best friend
+  </Button>
+</div>
+`;

--- a/src/form/ModalPicker/ModalPickerOpener/useComponentOverflow/useComponentOverflow.test.ts
+++ b/src/form/ModalPicker/ModalPickerOpener/useComponentOverflow/useComponentOverflow.test.ts
@@ -1,0 +1,95 @@
+import * as useComponentOverflow from './useComponentOverflow';
+
+describe('HoC: useComponentOverflow', () => {
+  test('isOverflowing', () => {
+    expect(
+      useComponentOverflow.isOverflowing({
+        clientWidth: 50,
+        scrollWidth: 50
+      } as HTMLElement)
+    ).toBe(false);
+
+    expect(
+      useComponentOverflow.isOverflowing({
+        clientWidth: 50,
+        scrollWidth: 100
+      } as HTMLElement)
+    ).toBe(true);
+  });
+
+  test('handleResizeCallback', () => {
+    const ref = { current: null } as { current: HTMLElement | null };
+    const setComponentOverflowSpy = jest.fn();
+
+    useComponentOverflow.handleResizeCallback(ref, setComponentOverflowSpy)();
+
+    expect(setComponentOverflowSpy).toBeCalledTimes(0);
+
+    ref.current = document.createElement('div');
+
+    useComponentOverflow.handleResizeCallback(ref, setComponentOverflowSpy)();
+    expect(setComponentOverflowSpy).toBeCalledTimes(1);
+    expect(setComponentOverflowSpy).toBeCalledWith(false);
+  });
+
+  test('layoutEffect', () => {
+    const ref = { current: null } as { current: HTMLElement | null };
+    const handleResizeSpy = jest.fn();
+
+    useComponentOverflow.layoutEffect(ref, handleResizeSpy, undefined)();
+
+    expect(handleResizeSpy).toBeCalledTimes(0);
+    handleResizeSpy.mockReset();
+
+    const addEventListenerSpy = jest.fn();
+    const removeEventListenerSpy = jest.fn();
+    ref.current = Object.assign(
+      {
+        addEventListener: addEventListenerSpy,
+        removeEventListener: removeEventListenerSpy
+      },
+      document.createElement('div')
+    );
+
+    const eventListenerResult = useComponentOverflow.layoutEffect(
+      ref,
+      handleResizeSpy,
+      undefined
+    )();
+
+    expect(handleResizeSpy).toBeCalledTimes(1);
+    expect(addEventListenerSpy).toBeCalledTimes(1);
+    expect(addEventListenerSpy).toBeCalledWith('resize', handleResizeSpy, {
+      passive: true
+    });
+    handleResizeSpy.mockReset();
+    addEventListenerSpy.mockReset();
+
+    // @ts-ignore
+    eventListenerResult();
+
+    expect(removeEventListenerSpy).toBeCalledTimes(1);
+    expect(removeEventListenerSpy).toBeCalledWith('resize', handleResizeSpy);
+    removeEventListenerSpy.mockReset();
+
+    const observeSpy = jest.fn();
+    const unobserveSpy = jest.fn();
+    const resizeObserverResult = useComponentOverflow.layoutEffect(
+      ref,
+      handleResizeSpy,
+      { observe: observeSpy, unobserve: unobserveSpy }
+    )();
+
+    expect(handleResizeSpy).toBeCalledTimes(1);
+    expect(observeSpy).toBeCalledTimes(1);
+    expect(observeSpy).toBeCalledWith(ref.current);
+    expect(addEventListenerSpy).toBeCalledTimes(0);
+
+    // @ts-ignore
+    resizeObserverResult();
+
+    expect(unobserveSpy).toBeCalledTimes(1);
+    expect(unobserveSpy).toBeCalledWith(ref.current);
+    expect(removeEventListenerSpy).toBeCalledTimes(0);
+  });
+});

--- a/src/form/ModalPicker/ModalPickerOpener/useComponentOverflow/useComponentOverflow.ts
+++ b/src/form/ModalPicker/ModalPickerOpener/useComponentOverflow/useComponentOverflow.ts
@@ -1,0 +1,72 @@
+import { RefObject, useCallback, useLayoutEffect, useState } from 'react';
+import { useResizeObserver } from '../useResizeObserver/useResizeObserver';
+
+export function useComponentOverflow(
+  ref: RefObject<HTMLElement>,
+  values: React.ReactNode
+) {
+  const [componentOverflow, setComponentOverflow] = useState(
+    isOverflowing(ref.current)
+  );
+
+  const handleResize = useCallback(
+    handleResizeCallback(ref, setComponentOverflow),
+    [ref]
+  );
+
+  const resizeObserver = useResizeObserver(handleResize);
+
+  useLayoutEffect(layoutEffect(ref, handleResize, resizeObserver), [
+    ref,
+    handleResize,
+    values,
+    resizeObserver
+  ]);
+
+  return componentOverflow;
+}
+
+export function isOverflowing(el: HTMLElement | null) {
+  return el ? el.clientWidth < el.scrollWidth : false;
+}
+
+export function handleResizeCallback(
+  ref: RefObject<HTMLElement>,
+  setComponentOverflow: (value: boolean) => void
+) {
+  return () => {
+    if (ref.current) {
+      setComponentOverflow(isOverflowing(ref.current));
+    }
+  };
+}
+
+export function layoutEffect(
+  ref: RefObject<HTMLElement>,
+  handleResize: () => void,
+  resizeObserver?: any
+) {
+  return () => {
+    if (!ref.current) {
+      return;
+    }
+
+    handleResize();
+
+    const el = ref.current;
+
+    if (resizeObserver) {
+      resizeObserver.observe(el);
+
+      return () => {
+        resizeObserver.unobserve(el);
+      };
+    }
+
+    el.addEventListener('resize', handleResize, { passive: true });
+
+    return () => {
+      el.removeEventListener('resize', handleResize);
+    };
+  };
+}

--- a/src/form/ModalPicker/ModalPickerOpener/useResizeObserver/useResizeObserver.test.ts
+++ b/src/form/ModalPicker/ModalPickerOpener/useResizeObserver/useResizeObserver.test.ts
@@ -1,0 +1,27 @@
+import * as useResizeObserver from './useResizeObserver';
+import { setResizeObserver } from './utils';
+
+describe('HoC: useResizeObserver', () => {
+  test('ResizeObserver', () => {
+    const entries = [
+      document.createElement('div'),
+      document.createElement('div')
+    ];
+    const resizeObserverSpy = jest.fn((fn: (entries: any[]) => void) => {
+      return { fire: (entries: any[]) => fn(entries) };
+    });
+    const handleResizeSpy = jest.fn();
+
+    const oldResizeObserver = setResizeObserver(resizeObserverSpy);
+
+    useResizeObserver.useResizeObserver(handleResizeSpy).fire(entries);
+
+    expect(resizeObserverSpy).toBeCalledTimes(1);
+
+    expect(handleResizeSpy).toBeCalledTimes(2);
+    expect(handleResizeSpy).toHaveBeenNthCalledWith(1, entries[0], 0, entries);
+    expect(handleResizeSpy).toHaveBeenNthCalledWith(2, entries[1], 1, entries);
+
+    setResizeObserver(oldResizeObserver);
+  });
+});

--- a/src/form/ModalPicker/ModalPickerOpener/useResizeObserver/useResizeObserver.ts
+++ b/src/form/ModalPicker/ModalPickerOpener/useResizeObserver/useResizeObserver.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+
+export function useResizeObserver(handleResize: () => void) {
+  return typeof ResizeObserver !== 'undefined'
+    ? new ResizeObserver(entries => entries.forEach(handleResize))
+    : undefined;
+}

--- a/src/form/ModalPicker/ModalPickerOpener/useResizeObserver/utils.ts
+++ b/src/form/ModalPicker/ModalPickerOpener/useResizeObserver/utils.ts
@@ -1,0 +1,11 @@
+// @ts-nocheck
+
+export function setResizeObserver(newResizeObserver: any) {
+  const oldResizeObserver = window.ResizeObserver
+    ? window.ResizeObserver
+    : undefined;
+
+  window.ResizeObserver = newResizeObserver;
+
+  return oldResizeObserver;
+}

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -137,21 +137,19 @@ describe('Component: ModalPickerMultiple', () => {
         showAddButton: false
       });
 
-      const moreOrLessContentArray = modalPickerMultiple
-        .find('MoreOrLess')
-        .at(0)
-        .props().content;
-
-      // @ts-ignore
-      expect(moreOrLessContentArray[0].props.text).toBe('admin@42.nl');
-      // @ts-ignore
-      expect(moreOrLessContentArray[1].props.text).toBe('user@42.nl');
+      expect(
+        modalPickerMultiple.find('ModalPickerOpener').props().values
+      ).toMatchSnapshot(
+        'Component: ModalPickerMultiple => ui => should render multiple labels with the selected values when the value array is not empty'
+      );
     });
 
     it('should render no labels when the value array is empty', () => {
       setup({ value: undefined, showAddButton: false });
 
-      expect(modalPickerMultiple.find('MoreOrLess').exists()).toBe(false);
+      expect(
+        modalPickerMultiple.find('ModalPickerOpener').props().values
+      ).toBeUndefined();
     });
 
     it('should render multiple labels inside the modal with the selected values when the selected property is not empty', () => {
@@ -237,10 +235,10 @@ describe('Component: ModalPickerMultiple', () => {
 
         // @ts-ignore
         modalPickerMultiple
-          .find('Button')
+          .find('ModalPickerOpener')
           .props()
           // @ts-ignore
-          .onClick();
+          .openModal();
         expect(fetchOptionsSpy).toHaveBeenCalledTimes(1);
         expect(fetchOptionsSpy).toHaveBeenCalledWith('', 1, 10);
 
@@ -278,10 +276,10 @@ describe('Component: ModalPickerMultiple', () => {
 
         // @ts-ignore
         modalPickerMultiple
-          .find('Button')
+          .find('ModalPickerOpener')
           .props()
           // @ts-ignore
-          .onClick();
+          .openModal();
 
         expect(fetchOptionsSpy).toHaveBeenCalledTimes(1);
         expect(fetchOptionsSpy).toHaveBeenCalledWith('', 1, 10);
@@ -488,60 +486,6 @@ describe('Component: ModalPickerMultiple', () => {
       ]);
     });
 
-    it('should remove the tag upon clicking', () => {
-      const value = [adminUser, userUser];
-      setup({ value, showAddButton: false });
-
-      modalPickerMultiple.setState({
-        page: pageOfUsers,
-        selected: value
-      });
-
-      const tags = modalPickerMultiple
-        .find('MoreOrLess')
-        .at(0)
-        .props().content;
-
-      // Click on user, user should be removed
-      // @ts-ignore
-      tags[0].props.onRemove(adminUser);
-      expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith([userUser]);
-
-      // Click on admin, admin should be removed
-      // @ts-ignore
-      tags[1].props.onRemove(userUser);
-      expect(onChangeSpy).toHaveBeenCalledTimes(2);
-      expect(onChangeSpy).toHaveBeenCalledWith([adminUser]);
-    });
-
-    it('should remove the tag upon clicking', () => {
-      const value = [adminUser, userUser];
-      setup({ value, showAddButton: false });
-
-      modalPickerMultiple.setState({
-        page: pageOfUsers,
-        selected: value
-      });
-
-      const tags = modalPickerMultiple
-        .find('MoreOrLess')
-        .at(0)
-        .props().content;
-
-      // Click on user, user should be removed
-      // @ts-ignore
-      tags[0].props.onRemove(adminUser);
-      expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith([userUser]);
-
-      // Click on admin, admin should be removed
-      // @ts-ignore
-      tags[1].props.onRemove(userUser);
-      expect(onChangeSpy).toHaveBeenCalledTimes(2);
-      expect(onChangeSpy).toHaveBeenCalledWith([adminUser]);
-    });
-
     it('should when the user removes a label inside the modal the label should be removed', () => {
       setup({ value: [adminUser, userUser], showAddButton: false });
 
@@ -706,31 +650,31 @@ describe('Component: ModalPickerMultiple', () => {
     test('becomes empty', () => {
       setup({ value: [adminUser], showAddButton: false });
 
-      //@ts-ignore
-      const moreOrLess = modalPickerMultiple.find('MoreOrLess').props();
-
-      //@ts-ignore
-      expect(moreOrLess.content[0].props.text).toBe('admin@42.nl');
+      expect(
+        modalPickerMultiple.find('ModalPickerOpener').props().values
+      ).toEqual(<React.Fragment>admin@42.nl</React.Fragment>);
 
       modalPickerMultiple.setProps({ value: undefined });
 
-      expect(modalPickerMultiple.find('MoreOrLess').exists()).toBe(false);
+      expect(
+        modalPickerMultiple.find('ModalPickerOpener').props().values
+      ).toBeUndefined();
     });
 
     test('becomes filled', () => {
       setup({ value: undefined, showAddButton: false });
 
-      expect(modalPickerMultiple.find('MoreOrLess').exists()).toBe(false);
+      expect(
+        modalPickerMultiple.find('ModalPickerOpener').props().values
+      ).toBeUndefined();
 
       modalPickerMultiple.setProps({
         value: [adminUser]
       });
 
-      //@ts-ignore
-      const moreOrLess = modalPickerMultiple.find('MoreOrLess').props();
-
-      //@ts-ignore
-      expect(moreOrLess.content[0].props.text).toBe('admin@42.nl');
+      expect(
+        modalPickerMultiple.find('ModalPickerOpener').props().values
+      ).toEqual(<React.Fragment>admin@42.nl</React.Fragment>);
     });
   });
 });

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Button, Col, FormGroup, Input, Label, Row } from 'reactstrap';
+import { Col, FormGroup, Input, Label, Row } from 'reactstrap';
 import { emptyPage, Page } from '@42.nl/spring-connect';
 
 import withJarb from '../../withJarb/withJarb';
 import { doBlur } from '../../utils';
-import MoreOrLess from '../../../core/MoreOrLess/MoreOrLess';
 import Tag from '../../../core/Tag/Tag';
 import { Color } from '../../types';
 import ModalPicker from '../ModalPicker';
@@ -18,6 +17,7 @@ import {
   RenderOptions,
   RenderOptionsOption
 } from '../../option';
+import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
 
 interface BaseProps<T> {
   /**
@@ -202,14 +202,6 @@ export default class ModalPickerMultiple<T> extends React.Component<
     this.setState({ selected });
   }
 
-  tagClicked(tag: T) {
-    const value = this.props.value as T[];
-    const selected = value.filter(v => v !== tag);
-
-    this.props.onChange(selected);
-    doBlur(this.props.onBlur);
-  }
-
   fetchOptions(query: string) {
     this.setState({ query }, () => {
       this.loadPage(1);
@@ -244,7 +236,14 @@ export default class ModalPickerMultiple<T> extends React.Component<
 
   render() {
     const value = this.props.value;
-    const { placeholder, error, color, className = '', ...props } = this.props;
+    const {
+      placeholder,
+      error,
+      color,
+      className = '',
+      optionForValue,
+      ...props
+    } = this.props;
 
     return (
       <FormGroup className={className} color={color}>
@@ -252,12 +251,13 @@ export default class ModalPickerMultiple<T> extends React.Component<
           <Label for={props.id}>{props.label}</Label>
         ) : null}
 
-        <div>
-          {this.renderTagsInMoreOrLess(value)}
-          <Button color="primary" onClick={() => this.openModal()}>
-            {placeholder}
-          </Button>
-        </div>
+        <ModalPickerOpener
+          openModal={() => this.openModal()}
+          label={placeholder}
+          values={
+            value ? <>{value.map(optionForValue).join(', ')}</> : undefined
+          }
+        />
 
         {error}
         {this.renderModal()}
@@ -370,16 +370,6 @@ export default class ModalPickerMultiple<T> extends React.Component<
     });
   }
 
-  renderTagsInMoreOrLess(values?: T[]) {
-    const content = this.renderTags(v => this.tagClicked(v), values);
-
-    if (!content) {
-      return null;
-    }
-
-    return <MoreOrLess className="mb-2" limit={3} content={content} />;
-  }
-
   renderModalCurrentSelection() {
     const { selected } = this.state;
 
@@ -399,11 +389,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
     );
   }
 
-  renderTags(onClick: (value: T) => void, values?: T[]): JSX.Element[] | null {
-    if (!values) {
-      return null;
-    }
-
+  renderTags(onClick: (value: T) => void, values: T[]): JSX.Element[] | null {
     const { optionForValue } = this.props;
 
     return values.map(value => {

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -1,36 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: ModalPickerMultiple ui should render multiple labels with the selected values when the value array is not empty: Component: ModalPickerMultiple => ui => should render multiple labels with the selected values when the value array is not empty 1`] = `
+<React.Fragment>
+  admin@42.nl, user@42.nl
+</React.Fragment>
+`;
+
 exports[`Component: ModalPickerMultiple ui should render properly without label: Component: ModalPickerMultiple => ui => should render properly without label 1`] = `
 <FormGroup
   className=""
   color="success"
   tag="div"
 >
-  <div>
-    <MoreOrLess
-      className="mb-2"
-      content={
-        Array [
-          <Tag
-            onRemove={[Function]}
-            text="admin@42.nl"
-          />,
-          <Tag
-            onRemove={[Function]}
-            text="user@42.nl"
-          />,
-        ]
-      }
-      limit={3}
-    />
-    <Button
-      color="primary"
-      onClick={[Function]}
-      tag="button"
-    >
-      Select your best friend
-    </Button>
-  </div>
+  <ModalPickerOpener
+    label="Select your best friend"
+    openModal={[Function]}
+    values={
+      <React.Fragment>
+        admin@42.nl, user@42.nl
+      </React.Fragment>
+    }
+  />
   Some error
   <ModalPicker
     canSearch={true}
@@ -110,31 +100,15 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
   >
     Best Friend
   </Label>
-  <div>
-    <MoreOrLess
-      className="mb-2"
-      content={
-        Array [
-          <Tag
-            onRemove={[Function]}
-            text="admin@42.nl"
-          />,
-          <Tag
-            onRemove={[Function]}
-            text="user@42.nl"
-          />,
-        ]
-      }
-      limit={3}
-    />
-    <Button
-      color="primary"
-      onClick={[Function]}
-      tag="button"
-    >
-      Select your best friend
-    </Button>
-  </div>
+  <ModalPickerOpener
+    label="Select your best friend"
+    openModal={[Function]}
+    values={
+      <React.Fragment>
+        admin@42.nl, user@42.nl
+      </React.Fragment>
+    }
+  />
   Some error
   <ModalPicker
     canSearch={true}

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -128,12 +128,17 @@ describe('Component: ModalPickerSingle', () => {
 
     it('should render a label with the selected value when the value is not empty', () => {
       setup({ value: adminUser, showAddButton: false });
-      expect(modalPickerSingle.find('span').text()).toBe('admin@42.nl');
+      expect(modalPickerSingle.find('ModalPickerOpener').props().values).toBe(
+        'admin@42.nl'
+      );
     });
 
     it('should not render a label when the value is empty', () => {
       setup({ value: undefined, showAddButton: false });
-      expect(modalPickerSingle.find('span').exists()).toBe(false);
+      expect(
+        // @ts-ignore
+        modalPickerSingle.find('ModalPickerOpener').props.values
+      ).toBeUndefined();
     });
 
     it('should render EmptyState when the totalElements of the page are zero', () => {
@@ -180,12 +185,11 @@ describe('Component: ModalPickerSingle', () => {
       const promise = Promise.resolve(pageOfUsers);
       fetchOptionsSpy.mockReturnValue(promise);
 
-      // @ts-ignore
       modalPickerSingle
-        .find('Button')
+        .find('ModalPickerOpener')
         .props()
         // @ts-ignore
-        .onClick();
+        .openModal();
 
       expect(fetchOptionsSpy).toHaveBeenCalledTimes(1);
       expect(fetchOptionsSpy).toHaveBeenCalledWith('', 1, 10);
@@ -260,7 +264,6 @@ describe('Component: ModalPickerSingle', () => {
       setup({ value: undefined, showAddButton: false });
       modalPickerSingle.setState({ isOpen: true });
 
-      // @ts-ignore
       modalPickerSingle
         .find('ModalPicker')
         .at(0)
@@ -285,7 +288,7 @@ describe('Component: ModalPickerSingle', () => {
         // @ts-ignore
         .modalSaved();
 
-      // @ts-ignore;
+      // @ts-ignore
       expect(modalPickerSingle.state().isOpen).toBe(false);
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
@@ -475,25 +478,31 @@ describe('Component: ModalPickerSingle', () => {
     test('becomes empty', () => {
       setup({ value: adminUser, showAddButton: false });
 
-      const value = modalPickerSingle.find('span').text();
-      expect(value).toBe('admin@42.nl');
+      expect(modalPickerSingle.find('ModalPickerOpener').props().values).toBe(
+        'admin@42.nl'
+      );
 
       modalPickerSingle.setProps({ value: undefined });
 
-      expect(modalPickerSingle.find('span').exists()).toBe(false);
+      expect(
+        modalPickerSingle.find('ModalPickerOpener').props().values
+      ).toBeUndefined();
     });
 
     test('becomes filled', () => {
       setup({ value: undefined, showAddButton: false });
 
-      expect(modalPickerSingle.find('span').exists()).toBe(false);
+      expect(
+        modalPickerSingle.find('ModalPickerOpener').props().values
+      ).toBeUndefined();
 
       modalPickerSingle.setProps({
         value: adminUser
       });
 
-      const value = modalPickerSingle.find('span').text();
-      expect(value).toBe('admin@42.nl');
+      expect(modalPickerSingle.find('ModalPickerOpener').props().values).toBe(
+        'admin@42.nl'
+      );
     });
   });
 });

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Col, FormGroup, Input, Label, Row } from 'reactstrap';
+import { Col, FormGroup, Input, Label, Row } from 'reactstrap';
 import { emptyPage, Page } from '@42.nl/spring-connect';
 
 import ModalPicker from '../ModalPicker';
@@ -16,6 +16,7 @@ import {
   RenderOptions,
   RenderOptionsOption
 } from '../../option';
+import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
 
 interface BaseProps<T> {
   /**
@@ -241,14 +242,11 @@ export default class ModalPickerSingle<T> extends React.Component<
           <Label for={props.id}>{props.label}</Label>
         ) : null}
 
-        <div>
-          {selected ? (
-            <span className="mr-1">{optionForValue(selected)}</span>
-          ) : null}
-          <Button color="primary" onClick={() => this.openModal()}>
-            {placeholder}
-          </Button>
-        </div>
+        <ModalPickerOpener
+          openModal={() => this.openModal()}
+          label={placeholder}
+          values={selected ? optionForValue(selected) : undefined}
+        />
 
         {error}
 

--- a/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
+++ b/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
@@ -6,20 +6,11 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
   color="success"
   tag="div"
 >
-  <div>
-    <span
-      className="mr-1"
-    >
-      admin@42.nl
-    </span>
-    <Button
-      color="primary"
-      onClick={[Function]}
-      tag="button"
-    >
-      Select your best friend
-    </Button>
-  </div>
+  <ModalPickerOpener
+    label="Select your best friend"
+    openModal={[Function]}
+    values="admin@42.nl"
+  />
   Some error
   <ModalPicker
     canSearch={true}
@@ -99,20 +90,11 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
   >
     Best Friend
   </Label>
-  <div>
-    <span
-      className="mr-1"
-    >
-      admin@42.nl
-    </span>
-    <Button
-      color="primary"
-      onClick={[Function]}
-      tag="button"
-    >
-      Select your best friend
-    </Button>
-  </div>
+  <ModalPickerOpener
+    label="Select your best friend"
+    openModal={[Function]}
+    values="admin@42.nl"
+  />
   Some error
   <ModalPicker
     canSearch={true}

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -348,22 +348,30 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
             Best friend
           </label>
         </Label>
-        <div>
-          <Button
-            color="primary"
-            onClick={[Function]}
-            tag="button"
+        <ModalPickerOpener
+          label="Select your best friend"
+          openModal={[Function]}
+        >
+          <div
+            className="d-flex align-items-center"
           >
-            <button
-              aria-label={null}
-              className="btn btn-primary"
+            <Button
+              className="flex-grow-0 flex-shrink-0"
+              color="primary"
               onClick={[Function]}
-              type="button"
+              tag="button"
             >
-              Select your best friend
-            </button>
-          </Button>
-        </div>
+              <button
+                aria-label={null}
+                className="flex-grow-0 flex-shrink-0 btn btn-primary"
+                onClick={[Function]}
+                type="button"
+              >
+                Select your best friend
+              </button>
+            </Button>
+          </div>
+        </ModalPickerOpener>
         <ModalPicker
           canSearch={true}
           closeModal={[Function]}
@@ -580,22 +588,30 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
             Best friend
           </label>
         </Label>
-        <div>
-          <Button
-            color="primary"
-            onClick={[Function]}
-            tag="button"
+        <ModalPickerOpener
+          label="Select your best friend"
+          openModal={[Function]}
+        >
+          <div
+            className="d-flex align-items-center"
           >
-            <button
-              aria-label={null}
-              className="btn btn-primary"
+            <Button
+              className="flex-grow-0 flex-shrink-0"
+              color="primary"
               onClick={[Function]}
-              type="button"
+              tag="button"
             >
-              Select your best friend
-            </button>
-          </Button>
-        </div>
+              <button
+                aria-label={null}
+                className="flex-grow-0 flex-shrink-0 btn btn-primary"
+                onClick={[Function]}
+                type="button"
+              >
+                Select your best friend
+              </button>
+            </Button>
+          </div>
+        </ModalPickerOpener>
         <ModalPicker
           canSearch={true}
           closeModal={[Function]}


### PR DESCRIPTION
When ModalPickerSingle is used within a fixed-width container like a
table cell, a long label should not cause the button to be (partly)
hidden.

Closes #365