### PR TITLE
improvement: withJarb support accepting errors as React.ReactNode

### DIFF
--- a/src/form/FormError/FormError.tsx
+++ b/src/form/FormError/FormError.tsx
@@ -3,7 +3,7 @@ import { FormFeedback } from 'reactstrap';
 import { useErrorsForValidator } from '@42.nl/react-error-store';
 
 import { Meta, MetaError } from '../types';
-import { errorMessage, keyForError } from './utils';
+import { errorMessage } from './utils';
 import { useSettledErrors } from './useSettledErrors';
 import { useOnChange } from './useOnChange';
 import { OnChange } from './types';
@@ -59,8 +59,8 @@ export default function FormError(props: Props) {
 
   return (
     <div className={className}>
-      {frontEndErrors.map((e: MetaError) => (
-        <FormFeedback key={keyForError(e)}>{errorMessage(e)}</FormFeedback>
+      {frontEndErrors.map((e: MetaError, index: number) => (
+        <FormFeedback key={`${index}`}>{errorMessage(e)}</FormFeedback>
       ))}
 
       {backEndErrors.map((e: string) => (

--- a/src/form/FormError/__snapshots__/FormError.test.tsx.snap
+++ b/src/form/FormError/__snapshots__/FormError.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component: FormError ui both errors: Component: FormError => ui => has both errors 1`] = `
 <div>
   <FormFeedback
-    key="ERROR_REQUIRED"
+    key="0"
     tag="div"
   >
     Name is required
@@ -31,7 +31,7 @@ exports[`Component: FormError ui has back-end errors: Component: FormError => ui
 exports[`Component: FormError ui has front-end errors: Component: FormError => ui => has front-end errors 1`] = `
 <div>
   <FormFeedback
-    key="ERROR_REQUIRED"
+    key="0"
     tag="div"
   >
     Name is required

--- a/src/form/FormError/utils.test.tsx
+++ b/src/form/FormError/utils.test.tsx
@@ -1,32 +1,9 @@
-import { errorMessage, keyForError } from './utils';
+import React from 'react';
+import { errorMessage } from './utils';
 import {
   setTranslator,
   Translator
 } from '../../utilities/translation/translator';
-
-describe('keyForError', () => {
-  test('Error is a string', () => {
-    expect(keyForError('Serious error')).toBe('Serious error');
-  });
-
-  test('Error is a Translation', () => {
-    expect(
-      keyForError({ key: 'test', data: { age: 12 }, fallback: 'test' })
-    ).toBe('test');
-  });
-
-  test('Error is ValidationError', () => {
-    const error = {
-      type: 'ERROR_REQUIRED',
-      label: 'Name',
-      value: '',
-      reasons: {}
-    };
-
-    // @ts-ignore
-    expect(keyForError(error)).toBe('ERROR_REQUIRED');
-  });
-});
 
 describe('errorMessage', () => {
   let t: Translator;
@@ -42,6 +19,23 @@ describe('errorMessage', () => {
 
     expect(t).toHaveBeenCalledTimes(0);
     expect(error).toEqual('Serious error');
+  });
+
+  test('Error is a ReactNode', () => {
+    const error = errorMessage(
+      <ul>
+        <li>You are wrong!</li>
+        <li>This is not correct!</li>
+      </ul>
+    );
+
+    expect(t).toHaveBeenCalledTimes(0);
+    expect(error).toEqual(
+      <ul>
+        <li>You are wrong!</li>
+        <li>This is not correct!</li>
+      </ul>
+    );
   });
 
   test('Error is a Translation', () => {

--- a/src/form/FormError/utils.tsx
+++ b/src/form/FormError/utils.tsx
@@ -1,27 +1,16 @@
+import React from 'react';
 import { ValidationError } from '@42.nl/jarb-final-form';
 import { MetaError } from '../types';
 import {
-  Translation,
-  getTranslator
+  getTranslator,
+  Translation
 } from '../../utilities/translation/translator';
 
-export function keyForError(error: MetaError) {
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  if ((error as ValidationError).type === undefined) {
-    return (error as Translation).key;
-  }
-
-  return (error as ValidationError).type;
-}
-
-export function errorMessage(error: MetaError): string {
+export function errorMessage(error: MetaError): React.ReactNode {
   const translator = getTranslator();
 
   // We consider it translated already
-  if (typeof error === 'string') {
+  if (typeof error === 'string' || React.isValidElement(error)) {
     return error;
   }
 

--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -6,23 +6,23 @@ import { Moment } from 'moment';
 import { JarbInput } from './Input/Input';
 import { FinalForm } from './story-utils';
 import {
-  JarbFileInput,
-  JarbImageUpload,
-  JarbTextEditor,
-  JarbTextarea,
-  JarbDateTimeInput,
-  JarbDateRangePicker,
-  JarbSelect,
-  JarbTypeaheadSingle,
-  JarbModalPickerSingle,
-  JarbTypeaheadMultiple,
-  JarbModalPickerMultiple,
-  requireFile,
-  limitFileSize,
-  requireImage,
-  limitImageSize,
   JarbCheckboxMultipleSelect,
-  JarbIconPicker
+  JarbDateRangePicker,
+  JarbDateTimeInput,
+  JarbFileInput,
+  JarbIconPicker,
+  JarbImageUpload,
+  JarbModalPickerMultiple,
+  JarbModalPickerSingle,
+  JarbSelect,
+  JarbTextarea,
+  JarbTextEditor,
+  JarbTypeaheadMultiple,
+  JarbTypeaheadSingle,
+  limitFileSize,
+  limitImageSize,
+  requireFile,
+  requireImage
 } from '..';
 import { pageOfUsers } from '../test/fixtures';
 import { User } from '../test/types';
@@ -57,9 +57,15 @@ async function firstNameAvailable(value?: string) {
 
   await sleep(random(2000, 5000));
 
-  return ['Maarten', 'Jeffrey'].includes(value)
-    ? undefined
-    : 'First name not available';
+  return ['Maarten', 'Jeffrey'].includes(value) ? (
+    undefined
+  ) : (
+    <ul>
+      <li>First name not available</li>
+      <li>You can use Jeffrey</li>
+      <li>You can use Maarten</li>
+    </ul>
+  );
 }
 
 async function lastNameAvailable(value?: string) {
@@ -69,9 +75,15 @@ async function lastNameAvailable(value?: string) {
 
   await sleep(random(100, 500));
 
-  return ['Hus', 'van Hoven'].includes(value)
-    ? undefined
-    : 'Last name not available';
+  return ['Hus', 'van Hoven'].includes(value) ? (
+    undefined
+  ) : (
+    <ul>
+      <li>Last name not available</li>
+      <li>You can use Hus</li>
+      <li>You can use van Hoven</li>
+    </ul>
+  );
 }
 
 const mask = [

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -1,9 +1,11 @@
 import { ValidationError } from '@42.nl/jarb-final-form';
 
 import { Translation } from '../utilities/translation/translator';
+import { ReactNode } from 'react';
+
 export { Color } from '../core/types';
 
-export type MetaError = ValidationError | string | Translation;
+export type MetaError = ValidationError | ReactNode | Translation;
 
 /**
  * Defines the type of the Meta property as given by final-form.

--- a/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
+++ b/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`HoC: withJarb errorMode: tooltip: withJarb => errorMode: tooltip => for
   className="withjarb-tooltip"
 >
   <FormFeedback
-    key=""
+    key="0"
     tag="div"
   />
 </div>
@@ -76,7 +76,7 @@ exports[`HoC: withJarb should throw an error when detecting illegal props 1`] = 
 exports[`HoC: withJarb ui: withJarb => ui => formError 1`] = `
 <div>
   <FormFeedback
-    key=""
+    key="0"
     tag="div"
   />
 </div>


### PR DESCRIPTION
This way, the user can render errors in a custom element, for example as
a list item.
Replaced string with ReactNode as type of MetaError to accept custom
nodes as well.
Uses the index as key when mapping ReactNode errors.

Closes #369