### PR TITLE
fix: duplicate ID in asyncPage stories

### DIFF
--- a/src/core/AsyncPage/AsyncPage.stories.tsx
+++ b/src/core/AsyncPage/AsyncPage.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { useAsync } from 'react-async';
-import { Card, ListGroup, ListGroupItem, Button } from 'reactstrap';
-import { Page, emptyPage } from '@42.nl/spring-connect';
+import { Button, Card, ListGroup, ListGroupItem } from 'reactstrap';
+import { emptyPage, Page } from '@42.nl/spring-connect';
 
 import AsyncPage from './AsyncPage';
 
@@ -191,7 +191,7 @@ storiesOf('core|async/AsyncPage', module)
     );
   })
 
-  .add('when empty with custom title', () => {
+  .add('when empty with custom content', () => {
     const state = useAsync(emptyData);
 
     return (


### PR DESCRIPTION
The console gives a warning about a duplicate ID being used for stories
in AsyncPage. Also, the duplicate ID caused one of the stories not to be
displayed in the menu.
Changed the ID for one of the stories so there is no warning anymore and
both of the stories are displayed in the menu.