### PR TITLE
improvement: Added possibility to customize TextEditor toolbar

### DIFF
--- a/src/form/TextEditor/TextEditor.test.tsx
+++ b/src/form/TextEditor/TextEditor.test.tsx
@@ -14,11 +14,13 @@ describe('Component: TextEditor', () => {
   function setup({
     value,
     hasPlaceholder = true,
-    hasLabel = true
+    hasLabel = true,
+    hasToolbarOptions = false
   }: {
     value?: string;
     hasPlaceholder?: boolean;
     hasLabel?: boolean;
+    hasToolbarOptions?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -31,7 +33,14 @@ describe('Component: TextEditor', () => {
       onBlur: onBlurSpy,
       onFocus: onFocusSpy,
       error: 'Some error',
-      valid: true
+      valid: true,
+      modules: hasToolbarOptions
+        ? {
+            toolbar: {
+              container: []
+            }
+          }
+        : undefined
     };
 
     if (hasLabel) {
@@ -70,6 +79,14 @@ describe('Component: TextEditor', () => {
 
       expect(toJson(textEditor)).toMatchSnapshot(
         'Component: textEditor => ui => without label'
+      );
+    });
+
+    test('with custom toolbar', () => {
+      setup({ value: 'Maarten', hasLabel: false, hasToolbarOptions: true });
+
+      expect(toJson(textEditor)).toMatchSnapshot(
+        'Component: textEditor => ui => with custom toolbar'
       );
     });
   });

--- a/src/form/TextEditor/TextEditor.tsx
+++ b/src/form/TextEditor/TextEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormGroup, Label } from 'reactstrap';
 import ReactQuill from 'react-quill';
 import classNames from 'classnames';
+import { StringMap } from 'quill';
 
 import withJarb from '../withJarb/withJarb';
 import { doBlur } from '../utils';
@@ -53,6 +54,11 @@ interface BaseProps {
    * Useful for styling the component.
    */
   className?: string;
+
+  /**
+   * Optional configuration option to i.e. customize the toolbar.
+   */
+  modules?: StringMap;
 }
 
 interface WithoutLabel extends BaseProps {
@@ -99,17 +105,18 @@ export default function TextEditor(props: Props) {
     error,
     color,
     value,
-    className = ''
+    className = '',
+    modules
   } = props;
 
   const inputProps = {
     id,
     placeholder,
-    //@ts-ignore
-    onChange: content => onChange(content),
+    onChange: (content: string) => onChange(content),
     onBlur: () => doBlur(onBlur),
     onFocus,
-    value
+    value,
+    modules
   };
 
   const classes = classNames({ 'is-invalid': valid === false });

--- a/src/form/TextEditor/__snapshots__/TextEditor.test.tsx.snap
+++ b/src/form/TextEditor/__snapshots__/TextEditor.test.tsx.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: TextEditor ui with custom toolbar: Component: textEditor => ui => with custom toolbar 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Quill
+    className=""
+    modules={
+      Object {
+        "toolbar": Object {
+          "container": Array [],
+        },
+      }
+    }
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[MockFunction]}
+    placeholder="Please enter your first name"
+    theme="snow"
+    value="Maarten"
+  />
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: TextEditor ui with value: Component: textEditor => ui => with value 1`] = `
 <FormGroup
   className=""


### PR DESCRIPTION
It would be nice to have an option to add a custom dropdown to the
TextEditor toolbar to i.e. provide placeholders when writing an e-mail
template.
Added modules prop to TextEditor to specify custom options
like a custom toolbar.