### PR TITLE
improvement: DateTimeInput datepicker in modal

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -163,6 +163,9 @@ Here is a JSON notation containing all keys and default translations:
   "OpenCloseModal": {
     "CANCEL": "Cancel",
     "SAVE": "Save"
+  },
+  "DateTimeModal": {
+    "SELECT": "Select"
   }
 }
 ```

--- a/src/form/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/form/DateRangePicker/DateRangePicker.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Form, FinalForm } from '../story-utils';
+import { FinalForm, Form } from '../story-utils';
 import DateRangePicker, { JarbDateRangePicker } from './DateRangePicker';
 
 storiesOf('Form|DateTime/DateRangePicker', module)
@@ -27,6 +27,32 @@ storiesOf('Form|DateTime/DateRangePicker', module)
             timeFormat: 'HH:mm:ss',
             isDateAllowed: current => current.day() !== 0 && current.day() !== 6
           }}
+        />
+      </Form>
+    );
+  })
+  .add('open in modal', () => {
+    return (
+      <Form>
+        <DateRangePicker
+          onChange={() => action('value changed')}
+          from={{
+            id: 'fromId',
+            label: 'From Date',
+            placeholder: 'Please enter a From date',
+            dateFormat: 'YYYY-MM-DD',
+            timeFormat: 'HH:mm:ss',
+            isDateAllowed: current => current.day() !== 0 && current.day() !== 6
+          }}
+          to={{
+            id: 'toId',
+            label: 'To Date',
+            placeholder: 'Please enter a To date',
+            dateFormat: 'YYYY-MM-DD',
+            timeFormat: 'HH:mm:ss',
+            isDateAllowed: current => current.day() !== 0 && current.day() !== 6
+          }}
+          mode={'modal'}
         />
       </Form>
     );

--- a/src/form/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/form/DateRangePicker/DateRangePicker.test.tsx
@@ -10,7 +10,15 @@ describe('Component: DateRangePicker', () => {
   let onChangeSpy: jest.Mock;
   let onFocusSpy: jest.Mock;
 
-  function setup({ value, onFocus }: { value: Value; onFocus: boolean }) {
+  function setup({
+    value,
+    onFocus,
+    mode
+  }: {
+    value: Value;
+    onFocus: boolean;
+    mode?: 'modal' | 'default';
+  }) {
     onChangeSpy = jest.fn();
     onFocusSpy = jest.fn();
 
@@ -37,6 +45,7 @@ describe('Component: DateRangePicker', () => {
         }}
         color="danger"
         valid={false}
+        mode={mode}
       />
     );
   }
@@ -68,6 +77,20 @@ describe('Component: DateRangePicker', () => {
         'Component: DateRangePicker => ui => with errors'
       );
       expect(dateRangePicker.find('FormFeedback').length).toBe(1);
+    });
+
+    test('open in modal', () => {
+      setup({
+        value: {
+          from: new Date(2200, 0, 1, 12, 30, 40),
+          to: new Date(2010, 0, 1, 12, 30, 40)
+        },
+        onFocus: false,
+        mode: 'modal'
+      });
+      expect(toJson(dateRangePicker)).toMatchSnapshot(
+        'Component: DateRangePicker => ui => open in modal'
+      );
     });
   });
 

--- a/src/form/DateRangePicker/DateRangePicker.tsx
+++ b/src/form/DateRangePicker/DateRangePicker.tsx
@@ -88,6 +88,12 @@ interface Props {
    * Optionally the error message to render.
    */
   error?: React.ReactNode;
+
+  /**
+   * Whether or not the date picker should be displayed in a modal.
+   * Defaults to opening in a tooltip-like layout.
+   */
+  mode?: 'modal' | 'default';
 }
 
 interface State {
@@ -148,7 +154,7 @@ export default class DateRangePicker extends Component<Props, State> {
   }
 
   render() {
-    const { className = '', valid, color } = this.props;
+    const { className = '', valid, color, mode } = this.props;
 
     return (
       <Row className={`date-range-picker ${className}`}>
@@ -160,6 +166,7 @@ export default class DateRangePicker extends Component<Props, State> {
             onFocus={() => this.onFocus()}
             valid={valid}
             color={color}
+            mode={mode}
           />
         </Col>
         <Col sm="12" md="6">
@@ -170,6 +177,7 @@ export default class DateRangePicker extends Component<Props, State> {
             onFocus={() => this.onFocus()}
             valid={valid}
             color={color}
+            mode={mode}
           />
         </Col>
         <Col xs="12" className="mb-2">

--- a/src/form/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/src/form/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -87,6 +87,101 @@ exports[`Component: DateRangePicker ui no errors: Component: DateRangePicker => 
 </Row>
 `;
 
+exports[`Component: DateRangePicker ui open in modal: Component: DateRangePicker => ui => open in modal 1`] = `
+<Row
+  className="date-range-picker "
+  tag="div"
+  widths={
+    Array [
+      "xs",
+      "sm",
+      "md",
+      "lg",
+      "xl",
+    ]
+  }
+>
+  <Col
+    md="6"
+    sm="12"
+    tag="div"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    <DateTimeInput
+      color="danger"
+      dateFormat="YYYY-MM-DD"
+      id="fromId"
+      isDateAllowed={[Function]}
+      label="From Date"
+      mode="modal"
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="Please enter a From date"
+      timeFormat="HH:mm:ss"
+      valid={false}
+      value={2200-01-01T11:30:40.000Z}
+    />
+  </Col>
+  <Col
+    md="6"
+    sm="12"
+    tag="div"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    <DateTimeInput
+      color="danger"
+      dateFormat="YYYY-MM-DD"
+      id="toId"
+      isDateAllowed={[Function]}
+      label="To Date"
+      mode="modal"
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="Please enter a To date"
+      timeFormat="HH:mm:ss"
+      valid={false}
+      value={2010-01-01T11:30:40.000Z}
+    />
+  </Col>
+  <Col
+    className="mb-2"
+    tag="div"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+    xs="12"
+  >
+    <FormFeedback
+      tag="div"
+    >
+      The "From Date" must be before the "To Date"
+    </FormFeedback>
+  </Col>
+</Row>
+`;
+
 exports[`Component: DateRangePicker ui with errors: Component: DateRangePicker => ui => with errors 1`] = `
 <Row
   className="date-range-picker "

--- a/src/form/DateTimeInput/DateTimeInput.scss
+++ b/src/form/DateTimeInput/DateTimeInput.scss
@@ -4,137 +4,153 @@
     font-style: italic;
   }
 
-  .rdt {
-    //@extend .dropdown-menu;
-    position: relative;
-    &.rdtOpen {
-      .rdtPicker {
-        display: block;
+  &.with-modal > .rdt {
+    .input-group-append .material-icons {
+      margin-right: 0;
+    }
+
+    > .rdtPicker {
+      display: none;
+    }
+  }
+}
+
+.date-time-modal .rdt .rdtPicker {
+  border: none;
+  float: none;
+  position: relative;
+}
+
+.rdt {
+  //@extend .dropdown-menu;
+  position: relative;
+  &.rdtOpen {
+    .rdtPicker {
+      display: block;
+    }
+
+    td.rdtDay.rdtDisabled:hover {
+      cursor: not-allowed;
+      background: none;
+    }
+
+    button,
+    td,
+    td.rdtDay:hover,
+    td.rdtHour:hover,
+    td.rdtMinute:hover,
+    td.rdtSecond:hover,
+    .rdtTimeToggle:hover {
+      cursor: pointer;
+    }
+    .rdtSwitch,
+    .rdtPrev,
+    .rdtNext {
+      @extend .rounded;
+      &:hover {
+        background: $gray-200;
+      }
+    }
+
+    .rdtCounters {
+      display: inline-block;
+
+      .rdtCounter {
+        width: 2.5rem;
+      }
+      > div {
+        float: left;
+      }
+    }
+  }
+  .rdtPicker {
+    width: 271px;
+    padding: 0;
+    margin-top: 5px;
+    @extend .dropdown-menu;
+    table {
+      @extend .table, .mb-0;
+      border-spacing: 5px;
+      border-collapse: separate;
+      thead > tr > th,
+      tbody > tr > td,
+      tfoot > tr > td {
+        text-align: center;
+        font-size: 0.85rem;
+        padding: 0.25rem;
       }
 
-      td.rdtDay.rdtDisabled:hover {
-        cursor: not-allowed;
-        background: none;
-      }
-
-      button,
-      td,
-      td.rdtDay:hover,
-      td.rdtHour:hover,
-      td.rdtMinute:hover,
-      td.rdtSecond:hover,
-      .rdtTimeToggle:hover {
-        cursor: pointer;
-      }
-      .rdtSwitch,
-      .rdtPrev,
-      .rdtNext {
-        @extend .rounded;
-        &:hover {
-          background: $gray-200;
+      thead {
+        > tr {
+          > th {
+            border: none;
+            font-weight: 400;
+            &.dow {
+              text-transform: uppercase;
+            }
+          }
+        }
+        &::after {
+          content: '';
+          position: absolute;
+          border-bottom: 1px solid $gray-200;
+          width: 100%;
+          left: 0;
         }
       }
-
-      .rdtCounters {
-        display: inline-block;
-
-        .rdtCounter {
-          width: 2.5rem;
-        }
-        > div {
-          float: left;
+      tbody > tr > td {
+        border: 0;
+        padding: 0;
+        vertical-align: middle;
+        font-weight: 300;
+        color: $gray-600;
+        &.rdtOld,
+        &.rdtNew {
+          color: lighten($gray-600, 35%);
         }
       }
     }
-    .rdtPicker {
-      width: 271px;
-      padding: 0;
-      margin-top: 5px;
-      @extend .dropdown-menu;
-      table {
-        @extend .table, .mb-0;
-        border-spacing: 5px;
-        border-collapse: separate;
-        thead > tr > th,
-        tbody > tr > td,
-        tfoot > tr > td {
-          text-align: center;
-          font-size: 0.85rem;
-          padding: 0.25rem;
+    .rdtMonths,
+    .rdtYears,
+    .rdtDays {
+      table > tbody > tr > td {
+        &.rdtActive,
+        &.rdtActive:hover {
+          @extend .rounded-circle;
+          @include box-shadow(
+            1px 1px 3px rgba(map-get($theme-colors, success), 0.24),
+            0 1px 2px rgba(map-get($theme-colors, success), 0.48)
+          );
+          background: map-get($theme-colors, success);
+          color: white;
+          font-weight: 500;
         }
-
-        thead {
-          > tr {
-            > th {
-              border: none;
-              font-weight: 400;
-              &.dow {
-                text-transform: uppercase;
-              }
-            }
-          }
-          &::after {
-            content: '';
-            position: absolute;
-            border-bottom: 1px solid $gray-200;
-            width: 100%;
-            left: 0;
-          }
-        }
-        tbody > tr > td {
-          border: 0;
-          padding: 0;
-          vertical-align: middle;
-          font-weight: 300;
-          color: $gray-600;
-          &.rdtOld,
-          &.rdtNew {
-            color: lighten($gray-600, 35%);
-          }
+        &:hover {
+          @extend .rounded-circle;
+          background: $gray-200;
         }
       }
-      .rdtMonths,
-      .rdtYears,
-      .rdtDays {
-        table > tbody > tr > td {
-          &.rdtActive,
-          &.rdtActive:hover {
-            @extend .rounded-circle;
-            @include box-shadow(
-              1px 1px 3px rgba(map-get($theme-colors, success), 0.24),
-              0 1px 2px rgba(map-get($theme-colors, success), 0.48)
-            );
-            background: map-get($theme-colors, success);
-            color: white;
-            font-weight: 500;
-          }
-          &:hover {
-            @extend .rounded-circle;
-            background: $gray-200;
-          }
-        }
-      }
+    }
 
-      .rdtDays {
-        table > tbody > tr > td {
-          width: 33px;
-          height: 33px;
-        }
+    .rdtDays {
+      table > tbody > tr > td {
+        width: 33px;
+        height: 33px;
       }
+    }
 
-      .rdtToday {
-        font-weight: bold;
-        color: map-get($theme-colors, success);
-      }
+    .rdtToday {
+      font-weight: bold;
+      color: map-get($theme-colors, success);
+    }
 
-      .rdtMonths,
-      .rdtYears {
-        table > tbody > tr > td {
-          width: 61px;
-          height: 61px;
-          &:hover {
-            background: $gray-200;
-          }
+    .rdtMonths,
+    .rdtYears {
+      table > tbody > tr > td {
+        width: 61px;
+        height: 61px;
+        &:hover {
+          background: $gray-200;
         }
       }
     }

--- a/src/form/DateTimeInput/DateTimeInput.stories.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -82,6 +82,27 @@ storiesOf('Form|DateTime/DateTimeInput', module)
             return date.isBefore(new Date());
           }}
           onChange={() => action('value changed')}
+        />
+      </Form>
+    );
+  })
+  .add('open in modal', () => {
+    const [value, setValue] = useState();
+
+    return (
+      <Form>
+        <DateTimeInput
+          id="dateOfBirth"
+          label="Date of birth"
+          placeholder="Please enter your date and time of birth"
+          dateFormat="YYYY-MM-DD"
+          timeFormat="HH:mm:ss"
+          isDateAllowed={date => {
+            return date.isBefore(new Date());
+          }}
+          value={value}
+          onChange={setValue}
+          mode="modal"
         />
       </Form>
     );

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.test.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { DateTimeModal } from './DateTimeModal';
+
+import * as Value from './useValue';
+
+describe('Component: DateTimeModal', () => {
+  function setup({ hasValue = false }: { hasValue?: boolean }) {
+    const onCloseSpy = jest.fn();
+    const onSaveSpy = jest.fn();
+    const isDateAllowedSpy = jest.fn();
+
+    const dateTimeModal = shallow(
+      <DateTimeModal
+        isOpen={true}
+        onClose={onCloseSpy}
+        onSave={onSaveSpy}
+        dateFormat="YYYY-MM-DD"
+        timeFormat="HH:II:SS"
+        isDateAllowed={isDateAllowedSpy}
+        defaultValue={hasValue ? new Date(2020, 1, 1, 0, 0, 0) : undefined}
+      />
+    );
+    return { dateTimeModal, onCloseSpy, onSaveSpy, isDateAllowedSpy };
+  }
+
+  describe('ui', () => {
+    test('without value', () => {
+      const { dateTimeModal } = setup({});
+
+      expect(toJson(dateTimeModal)).toMatchSnapshot(
+        'Component: DateTimeModal => ui => without value'
+      );
+    });
+
+    test('with value', () => {
+      const { dateTimeModal } = setup({ hasValue: true });
+
+      expect(toJson(dateTimeModal)).toMatchSnapshot(
+        'Component: DateTimeModal => ui => with value'
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('should update internal value when a date is selected', () => {
+      const setValueSpy = jest.fn();
+      const useValueSpy = jest
+        .spyOn(Value, 'useValue')
+        .mockReturnValue(['', setValueSpy]);
+      const { dateTimeModal } = setup({});
+
+      const value = new Date(2020, 2, 1, 0, 0, 0);
+
+      // @ts-ignore
+      dateTimeModal
+        .find('DateTime')
+        .props()
+        // @ts-ignore
+        .onChange(value);
+
+      expect(setValueSpy).toBeCalledTimes(1);
+      expect(setValueSpy).toBeCalledWith(value);
+
+      useValueSpy.mockRestore();
+    });
+
+    it('should not update external value when a date is selected', () => {
+      const { dateTimeModal, onCloseSpy, onSaveSpy } = setup({});
+
+      const value = new Date(2020, 2, 1, 0, 0, 0);
+
+      // @ts-ignore
+      dateTimeModal
+        .find('DateTime')
+        .props()
+        // @ts-ignore
+        .onChange(value);
+
+      expect(onCloseSpy).toBeCalledTimes(0);
+      expect(onSaveSpy).toBeCalledTimes(0);
+    });
+
+    it('should close modal without value when modal is closed', () => {
+      const { dateTimeModal, onCloseSpy, onSaveSpy } = setup({});
+
+      const value = new Date(2020, 2, 1, 0, 0, 0);
+
+      // @ts-ignore
+      dateTimeModal
+        .find('DateTime')
+        .props()
+        // @ts-ignore
+        .onChange(value);
+
+      // @ts-ignore
+      dateTimeModal
+        .find('OpenCloseModal')
+        .props()
+        // @ts-ignore
+        .onClose();
+
+      expect(onCloseSpy).toBeCalledTimes(1);
+      expect(onSaveSpy).toBeCalledTimes(0);
+    });
+
+    it('should close modal with new value when clicking select button', () => {
+      const { dateTimeModal, onCloseSpy, onSaveSpy } = setup({});
+
+      const value = new Date(2020, 2, 1, 0, 0, 0);
+
+      // @ts-ignore
+      dateTimeModal
+        .find('DateTime')
+        .props()
+        // @ts-ignore
+        .onChange(value);
+
+      // @ts-ignore
+      dateTimeModal
+        .find('OpenCloseModal')
+        .props()
+        // @ts-ignore
+        .onSave();
+
+      expect(onSaveSpy).toBeCalledTimes(1);
+      expect(onSaveSpy).toBeCalledWith(value);
+
+      expect(onCloseSpy).toBeCalledTimes(0);
+    });
+
+    test('is date allowed', () => {
+      const { dateTimeModal, isDateAllowedSpy } = setup({});
+
+      const value = new Date(2020, 2, 1, 0, 0, 0);
+      const current = new Date();
+
+      // @ts-ignore
+      dateTimeModal
+        .find('DateTime')
+        .props()
+        // @ts-ignore
+        .isValidDate(value, current);
+
+      expect(isDateAllowedSpy).toBeCalledTimes(1);
+      expect(isDateAllowedSpy).toBeCalledWith(value, current);
+    });
+  });
+});

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import Datetime from 'react-datetime';
+import moment, { Moment } from 'moment';
+import { constant, get } from 'lodash';
+
+import { IsDateAllowed } from '../DateTimeInput';
+import { DateFormat, TimeFormat } from '../types';
+import { t } from '../../../utilities/translation/translation';
+import { useValue } from './useValue';
+import { OpenCloseModal } from '../../../core/OpenCloseModal/OpenCloseModal';
+
+export type Text = {
+  cancel?: string;
+  select?: string;
+};
+
+type Props = {
+  /**
+   * Whether or not the modal is open.
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback for when the modal should close.
+   */
+  onClose: () => void;
+
+  /**
+   * The label of the form element.
+   */
+  label?: React.ReactNode;
+
+  /**
+   * Callback for when the form element changes.
+   */
+  onSave: (value: Moment | string) => void;
+
+  /**
+   * The value that the form element currently has.
+   */
+  defaultValue?: Date;
+
+  /**
+   * The format for the date, follows Moment.js format.
+   *
+   * At least a DateFormat or TimeFormat should be defined, otherwise
+   * an error occurs.
+   *
+   * @see https://momentjs.com/docs/#/displaying/format/
+   */
+  dateFormat: DateFormat;
+
+  /**
+   * The format for the time, follows Moment.js format.
+   *
+   * At least a TimeFormat or DateFormat should be defined, otherwise
+   * an error occurs.
+   *
+   * @see https://momentjs.com/docs/#/displaying/format/
+   */
+  timeFormat: TimeFormat;
+
+  /**
+   * Optionally the locale moment js should use.
+   */
+  locale?: string;
+
+  /**
+   * Optional Callback which returns whether a date is selectable.
+   * Is ran for every date which is displayed. By default every
+   * date can be selected.
+   */
+  isDateAllowed?: IsDateAllowed;
+
+  /**
+   * Optionally customized text within the component.
+   * This text should already be translated.
+   */
+  text?: Text;
+};
+
+export function DateTimeModal(props: Props) {
+  const {
+    isOpen,
+    onClose,
+    onSave,
+    label,
+    dateFormat,
+    timeFormat,
+    locale,
+    text = {
+      save: t({
+        key: 'DateTimeModal.SELECT',
+        fallback: 'Select'
+      })
+    }
+  } = props;
+  const isDateAllowed = get(props, 'isDateAllowed', constant(true));
+
+  const [value, setValue] = useValue(
+    props.defaultValue ? moment(props.defaultValue) : ''
+  );
+
+  return (
+    <OpenCloseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={() => onSave(value)}
+      label={label}
+      text={text}
+      size="sm"
+      className="date-time-modal"
+    >
+      <Datetime
+        input={false}
+        open={true}
+        closeOnSelect={false}
+        onChange={x => setValue(x)}
+        value={value}
+        dateFormat={dateFormat}
+        timeFormat={timeFormat}
+        locale={locale}
+        isValidDate={(date: Moment, current?: Moment) =>
+          isDateAllowed(date, current)
+        }
+      />
+    </OpenCloseModal>
+  );
+}

--- a/src/form/DateTimeInput/DateTimeModal/__snapshots__/DateTimeModal.test.tsx.snap
+++ b/src/form/DateTimeInput/DateTimeModal/__snapshots__/DateTimeModal.test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: DateTimeModal ui with value: Component: DateTimeModal => ui => with value 1`] = `
+<OpenCloseModal
+  className="date-time-modal"
+  isOpen={true}
+  onClose={[MockFunction]}
+  onSave={[Function]}
+  size="sm"
+  text={
+    Object {
+      "save": "Select",
+    }
+  }
+>
+  <DateTime
+    className=""
+    closeOnSelect={false}
+    closeOnTab={true}
+    dateFormat="YYYY-MM-DD"
+    defaultValue=""
+    input={false}
+    inputProps={Object {}}
+    isValidDate={[Function]}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onNavigateBack={[Function]}
+    onNavigateForward={[Function]}
+    onViewModeChange={[Function]}
+    open={true}
+    strictParsing={true}
+    timeConstraints={Object {}}
+    timeFormat="HH:II:SS"
+    utc={false}
+    value={"2020-01-31T23:00:00.000Z"}
+  />
+</OpenCloseModal>
+`;
+
+exports[`Component: DateTimeModal ui without value: Component: DateTimeModal => ui => without value 1`] = `
+<OpenCloseModal
+  className="date-time-modal"
+  isOpen={true}
+  onClose={[MockFunction]}
+  onSave={[Function]}
+  size="sm"
+  text={
+    Object {
+      "save": "Select",
+    }
+  }
+>
+  <DateTime
+    className=""
+    closeOnSelect={false}
+    closeOnTab={true}
+    dateFormat="YYYY-MM-DD"
+    defaultValue=""
+    input={false}
+    inputProps={Object {}}
+    isValidDate={[Function]}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onNavigateBack={[Function]}
+    onNavigateForward={[Function]}
+    onViewModeChange={[Function]}
+    open={true}
+    strictParsing={true}
+    timeConstraints={Object {}}
+    timeFormat="HH:II:SS"
+    utc={false}
+    value=""
+  />
+</OpenCloseModal>
+`;

--- a/src/form/DateTimeInput/DateTimeModal/useValue.ts
+++ b/src/form/DateTimeInput/DateTimeModal/useValue.ts
@@ -1,0 +1,6 @@
+import { useState } from 'react';
+import { Moment } from 'moment';
+
+export function useValue(defaultValue: Moment | string) {
+  return useState<Moment | string>(defaultValue);
+}

--- a/src/form/DateTimeInput/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/src/form/DateTimeInput/__snapshots__/DateTimeInput.test.tsx.snap
@@ -1,8 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: DateTimeInput ui InputGroup: Component: DateTimeInput => ui => InputGroup 1`] = `
+<div
+  className="input-group"
+>
+  <t
+    id={10}
+    render={[Function]}
+  />
+  <Addon
+    icon="calendar_today"
+    onClick={[Function]}
+    position="right"
+  />
+</div>
+`;
+
+exports[`Component: DateTimeInput ui MaskedInput: Component: DateTimeInput => ui => MaskedInput 1`] = `
+<Input
+  id={10}
+  innerRef={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="text"
+/>
+`;
+
+exports[`Component: DateTimeInput ui with date picker in modal: Component: DateTimeInput => ui => with date picker in modal 1`] = `
+<FormGroup
+  className="date-time-input with-modal"
+  color="success"
+  tag="div"
+>
+  <Label
+    for="dateOfBirth"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Date of birth
+     
+    <span
+      className="date-time-input-format text-muted"
+    >
+      (
+      YYYY-MM-DD HH:mm:ss
+      )
+    </span>
+  </Label>
+  <DateTime
+    className=""
+    closeOnSelect={true}
+    closeOnTab={true}
+    dateFormat="YYYY-MM-DD"
+    defaultValue=""
+    input={true}
+    inputProps={
+      Object {
+        "invalid": false,
+        "mask": Array [
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+          "-",
+          /\\\\d/,
+          /\\\\d/,
+          "-",
+          /\\\\d/,
+          /\\\\d/,
+          " ",
+          /\\\\d/,
+          /\\\\d/,
+          ":",
+          /\\\\d/,
+          /\\\\d/,
+          ":",
+          /\\\\d/,
+          /\\\\d/,
+        ],
+        "placeholder": "Please enter your date of birth",
+      }
+    }
+    isValidDate={[Function]}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[MockFunction]}
+    onNavigateBack={[Function]}
+    onNavigateForward={[Function]}
+    onViewModeChange={[Function]}
+    open={false}
+    renderInput={[Function]}
+    strictParsing={true}
+    timeConstraints={Object {}}
+    timeFormat="HH:mm:ss"
+    utc={false}
+  />
+  Some error
+  <DateTimeModal
+    dateFormat="YYYY-MM-DD"
+    isDateAllowed={[Function]}
+    isOpen={false}
+    label="Please enter your date of birth"
+    onClose={[Function]}
+    onSave={[Function]}
+    timeFormat="HH:mm:ss"
+  />
+</FormGroup>
+`;
+
 exports[`Component: DateTimeInput ui with format error: Component: DateTimeInput => ui => with format error 1`] = `
 <FormGroup
-  className="date-time-input "
+  className="date-time-input"
   color="success"
   tag="div"
 >
@@ -83,7 +199,7 @@ exports[`Component: DateTimeInput ui with format error: Component: DateTimeInput
 
 exports[`Component: DateTimeInput ui with label: Component: DateTimeInput => ui => with label 1`] = `
 <FormGroup
-  className="date-time-input "
+  className="date-time-input"
   color="success"
   tag="div"
 >
@@ -164,7 +280,7 @@ exports[`Component: DateTimeInput ui with label: Component: DateTimeInput => ui 
 
 exports[`Component: DateTimeInput ui without label: Component: DateTimeInput => ui => without label 1`] = `
 <FormGroup
-  className="date-time-input "
+  className="date-time-input"
   color="success"
   tag="div"
 >
@@ -218,14 +334,4 @@ exports[`Component: DateTimeInput ui without label: Component: DateTimeInput => 
   />
   Some error
 </FormGroup>
-`;
-
-exports[`MaskedInputWrapper: maskedInput 1`] = `
-<Input
-  id={10}
-  innerRef={[Function]}
-  onBlur={[Function]}
-  onChange={[Function]}
-  type="text"
-/>
 `;

--- a/src/form/DateTimeInput/useHasFormatError/useHasFormatError.ts
+++ b/src/form/DateTimeInput/useHasFormatError/useHasFormatError.ts
@@ -1,0 +1,5 @@
+import { useState } from 'react';
+
+export function useHasFormatError() {
+  return useState(false);
+}

--- a/src/form/DateTimeInput/useIsModalOpen/useIsModalOpen.ts
+++ b/src/form/DateTimeInput/useIsModalOpen/useIsModalOpen.ts
@@ -1,0 +1,5 @@
+import { useState } from 'react';
+
+export function useIsModalOpen() {
+  return useState(false);
+}


### PR DESCRIPTION
When used in EpicTable, the DateTimeInput causes extra blank space
underneath the content of the table, so the content will become
scrollable vertically. It should be possible to display the date picker
in a modal. That way, the date picker doesn't conflict visually when
used in a table.
Added an option to display a button next to the inpit that will open the
datepicker in a modal when clicked.

Closes #382