### PR TITLE
improvement: generic modal layout

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -159,6 +159,10 @@ Here is a JSON notation containing all keys and default translations:
   },
   "RadioGroup": {
     "LOADING": "Loading..."
+  },
+  "OpenCloseModal": {
+    "CANCEL": "Cancel",
+    "SAVE": "Save"
   }
 }
 ```

--- a/src/core/ConfirmButton/ConfirmButton.test.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.test.tsx
@@ -154,7 +154,7 @@ describe('Component: ConfirmButton', () => {
         .onClick(event);
 
       // @ts-ignore
-      expect(confirmButton.find('Modal').props().isOpen).toBe(true);
+      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(true);
     }
 
     it('should open the Modal when the ConfirmButton button is clicked', () => {
@@ -174,12 +174,12 @@ describe('Component: ConfirmButton', () => {
         .onClick(event);
 
       // @ts-ignore
-      expect(confirmButton.find('Modal').props().isOpen).toBe(true);
+      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(true);
 
       expect(event.stopPropagation).toHaveBeenCalledTimes(1);
     });
 
-    it('should close the Modal when the Cancel button is clicked', () => {
+    it('should close the Modal', () => {
       setup({
         button: 'Delete',
         icon: undefined
@@ -188,50 +188,10 @@ describe('Component: ConfirmButton', () => {
       openModal();
 
       // @ts-ignore
-      confirmButton
-        .find('Button')
-        .at(1)
-        .prop('onClick')();
+      confirmButton.find('OpenCloseModal').prop('onClose')();
 
       // @ts-ignore
-      expect(confirmButton.find('Modal').props().isOpen).toBe(false);
-    });
-
-    it('should close the Modal when the Header is clicked', () => {
-      setup({
-        button: 'Delete',
-        icon: undefined
-      });
-
-      openModal();
-
-      // @ts-ignore
-      confirmButton
-        .find('ModalHeader')
-        .props()
-        // @ts-ignore
-        .toggle();
-
-      // @ts-ignore
-      expect(confirmButton.find('Modal').props().isOpen).toBe(false);
-    });
-
-    it('should close the Modal the user clicks outside the Modal', () => {
-      setup({
-        button: 'Delete',
-        icon: undefined
-      });
-
-      openModal();
-
-      confirmButton
-        .find('Modal')
-        .props()
-        // @ts-ignore
-        .toggle();
-
-      // @ts-ignore
-      expect(confirmButton.find('Modal').props().isOpen).toBe(false);
+      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(false);
     });
 
     it('should close and save the Modal when the Accept button is clicked', () => {
@@ -241,20 +201,17 @@ describe('Component: ConfirmButton', () => {
       });
 
       openModal();
-      const event = new Event('click');
 
       // @ts-ignore
       confirmButton
-        .find('Button')
-        .at(2)
+        .find('OpenCloseModal')
         // @ts-ignore
-        .prop('onClick')(event);
+        .prop('onSave')();
 
       expect(onConfirmSpy).toHaveBeenCalledTimes(1);
-      expect(onConfirmSpy).toHaveBeenCalledWith(event);
 
       // @ts-ignore
-      expect(confirmButton.find('Modal').props().isOpen).toBe(false);
+      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(false);
     });
   });
 });

--- a/src/core/ConfirmButton/ConfirmButton.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
 import Button, {
   BaseProps as ButtonBaseProps,
@@ -11,6 +10,7 @@ import Button, {
 import { Color } from '../types';
 import IconType from '../Icon/types';
 import { t } from '../../utilities/translation/translation';
+import { OpenCloseModal } from '../../core/OpenCloseModal/OpenCloseModal';
 
 interface Text {
   /**
@@ -55,7 +55,7 @@ interface BaseProps {
    * Basically replaces the logic you would normally put in an `onClick`
    * event in a normal button.
    */
-  onConfirm: (event: React.MouseEvent<HTMLElement>) => void;
+  onConfirm: () => void;
 
   /**
    * Whether or not the action you are performing is currently in
@@ -134,9 +134,9 @@ export default function ConfirmButton({
     setOpen(true);
   }
 
-  function saveModal(event: React.MouseEvent<HTMLElement>) {
+  function saveModal() {
     setOpen(false);
-    onConfirm(event);
+    onConfirm();
   }
 
   function getProps() {
@@ -168,32 +168,30 @@ export default function ConfirmButton({
     >
       <Button {...getProps()} />
 
-      <Modal isOpen={isOpen} toggle={() => setOpen(false)}>
-        <ModalHeader toggle={() => setOpen(false)}>
-          {t({
-            overrideText: modalHeader,
-            key: 'ConfirmButton.MODAL_HEADER',
-            fallback: 'Confirmation'
-          })}
-        </ModalHeader>
-        <ModalBody>{dialogText}</ModalBody>
-        <ModalFooter>
-          <Button color="secondary" onClick={() => setOpen(false)}>
-            {t({
-              overrideText: cancel,
-              key: 'ConfirmButton.CANCEL',
-              fallback: 'Cancel'
-            })}
-          </Button>
-          <Button color="primary" onClick={e => saveModal(e)}>
-            {t({
-              overrideText: confirm,
-              key: 'ConfirmButton.CONFIRM',
-              fallback: 'Confirm'
-            })}
-          </Button>
-        </ModalFooter>
-      </Modal>
+      <OpenCloseModal
+        isOpen={isOpen}
+        onClose={() => setOpen(false)}
+        onSave={() => saveModal()}
+        label={t({
+          overrideText: modalHeader,
+          key: 'ConfirmButton.MODAL_HEADER',
+          fallback: 'Confirmation'
+        })}
+        text={{
+          cancel: t({
+            overrideText: cancel,
+            key: 'ConfirmButton.CANCEL',
+            fallback: 'Cancel'
+          }),
+          save: t({
+            overrideText: confirm,
+            key: 'ConfirmButton.CONFIRM',
+            fallback: 'Confirm'
+          })
+        }}
+      >
+        {dialogText}
+      </OpenCloseModal>
     </div>
   );
 }

--- a/src/core/ConfirmButton/__snapshots__/ConfirmButton.test.tsx.snap
+++ b/src/core/ConfirmButton/__snapshots__/ConfirmButton.test.tsx.snap
@@ -16,70 +16,26 @@ exports[`Component: ConfirmButton ui button and icon: Component: ConfirmButton =
   >
     Delete user
   </Button>
-  <Modal
-    autoFocus={true}
-    backdrop={true}
-    backdropTransition={
-      Object {
-        "mountOnEnter": true,
-        "timeout": 150,
-      }
-    }
-    centered={false}
-    fade={true}
+  <OpenCloseModal
     isOpen={false}
-    keyboard={true}
-    modalTransition={
+    label="Confirmation"
+    onClose={[Function]}
+    onSave={[Function]}
+    text={
       Object {
-        "timeout": 300,
+        "cancel": "Cancel",
+        "save": "Confirm",
       }
     }
-    onClosed={[Function]}
-    onOpened={[Function]}
-    returnFocusAfterClose={true}
-    role="dialog"
-    scrollable={false}
-    toggle={[Function]}
-    unmountOnClose={true}
-    zIndex={1050}
   >
-    <ModalHeader
-      charCode={215}
-      closeAriaLabel="Close"
-      tag="h5"
-      toggle={[Function]}
-      wrapTag="div"
-    >
-      Confirmation
-    </ModalHeader>
-    <ModalBody
-      tag="div"
-    >
-      <p>
-        Are you sure you want to 
-        <strong>
-          delete
-        </strong>
-         the user?
-      </p>
-    </ModalBody>
-    <ModalFooter
-      tag="div"
-    >
-      <Button
-        color="secondary"
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-      <Button
-        color="primary"
-        onClick={[Function]}
-      >
-        Confirm
-      </Button>
-    </ModalFooter>
-  </Modal>
+    <p>
+      Are you sure you want to 
+      <strong>
+        delete
+      </strong>
+       the user?
+    </p>
+  </OpenCloseModal>
 </div>
 `;
 
@@ -100,70 +56,26 @@ exports[`Component: ConfirmButton ui custom class, color and texts: Component: C
   >
     Delete user
   </Button>
-  <Modal
-    autoFocus={true}
-    backdrop={true}
-    backdropTransition={
-      Object {
-        "mountOnEnter": true,
-        "timeout": 150,
-      }
-    }
-    centered={false}
-    fade={true}
+  <OpenCloseModal
     isOpen={false}
-    keyboard={true}
-    modalTransition={
+    label="PLEASE SAY YES"
+    onClose={[Function]}
+    onSave={[Function]}
+    text={
       Object {
-        "timeout": 300,
+        "cancel": "NO",
+        "save": "YES",
       }
     }
-    onClosed={[Function]}
-    onOpened={[Function]}
-    returnFocusAfterClose={true}
-    role="dialog"
-    scrollable={false}
-    toggle={[Function]}
-    unmountOnClose={true}
-    zIndex={1050}
   >
-    <ModalHeader
-      charCode={215}
-      closeAriaLabel="Close"
-      tag="h5"
-      toggle={[Function]}
-      wrapTag="div"
-    >
-      PLEASE SAY YES
-    </ModalHeader>
-    <ModalBody
-      tag="div"
-    >
-      <p>
-        Are you sure you want to 
-        <strong>
-          delete
-        </strong>
-         the user?
-      </p>
-    </ModalBody>
-    <ModalFooter
-      tag="div"
-    >
-      <Button
-        color="secondary"
-        onClick={[Function]}
-      >
-        NO
-      </Button>
-      <Button
-        color="primary"
-        onClick={[Function]}
-      >
-        YES
-      </Button>
-    </ModalFooter>
-  </Modal>
+    <p>
+      Are you sure you want to 
+      <strong>
+        delete
+      </strong>
+       the user?
+    </p>
+  </OpenCloseModal>
 </div>
 `;
 
@@ -182,70 +94,26 @@ exports[`Component: ConfirmButton ui only button: Component: ConfirmButton => ui
   >
     Delete user
   </Button>
-  <Modal
-    autoFocus={true}
-    backdrop={true}
-    backdropTransition={
-      Object {
-        "mountOnEnter": true,
-        "timeout": 150,
-      }
-    }
-    centered={false}
-    fade={true}
+  <OpenCloseModal
     isOpen={false}
-    keyboard={true}
-    modalTransition={
+    label="Confirmation"
+    onClose={[Function]}
+    onSave={[Function]}
+    text={
       Object {
-        "timeout": 300,
+        "cancel": "Cancel",
+        "save": "Confirm",
       }
     }
-    onClosed={[Function]}
-    onOpened={[Function]}
-    returnFocusAfterClose={true}
-    role="dialog"
-    scrollable={false}
-    toggle={[Function]}
-    unmountOnClose={true}
-    zIndex={1050}
   >
-    <ModalHeader
-      charCode={215}
-      closeAriaLabel="Close"
-      tag="h5"
-      toggle={[Function]}
-      wrapTag="div"
-    >
-      Confirmation
-    </ModalHeader>
-    <ModalBody
-      tag="div"
-    >
-      <p>
-        Are you sure you want to 
-        <strong>
-          delete
-        </strong>
-         the user?
-      </p>
-    </ModalBody>
-    <ModalFooter
-      tag="div"
-    >
-      <Button
-        color="secondary"
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-      <Button
-        color="primary"
-        onClick={[Function]}
-      >
-        Confirm
-      </Button>
-    </ModalFooter>
-  </Modal>
+    <p>
+      Are you sure you want to 
+      <strong>
+        delete
+      </strong>
+       the user?
+    </p>
+  </OpenCloseModal>
 </div>
 `;
 
@@ -263,70 +131,26 @@ exports[`Component: ConfirmButton ui only icon in progress: Component: ConfirmBu
     inProgress={true}
     onClick={[Function]}
   />
-  <Modal
-    autoFocus={true}
-    backdrop={true}
-    backdropTransition={
-      Object {
-        "mountOnEnter": true,
-        "timeout": 150,
-      }
-    }
-    centered={false}
-    fade={true}
+  <OpenCloseModal
     isOpen={false}
-    keyboard={true}
-    modalTransition={
+    label="Confirmation"
+    onClose={[Function]}
+    onSave={[Function]}
+    text={
       Object {
-        "timeout": 300,
+        "cancel": "Cancel",
+        "save": "Confirm",
       }
     }
-    onClosed={[Function]}
-    onOpened={[Function]}
-    returnFocusAfterClose={true}
-    role="dialog"
-    scrollable={false}
-    toggle={[Function]}
-    unmountOnClose={true}
-    zIndex={1050}
   >
-    <ModalHeader
-      charCode={215}
-      closeAriaLabel="Close"
-      tag="h5"
-      toggle={[Function]}
-      wrapTag="div"
-    >
-      Confirmation
-    </ModalHeader>
-    <ModalBody
-      tag="div"
-    >
-      <p>
-        Are you sure you want to 
-        <strong>
-          delete
-        </strong>
-         the user?
-      </p>
-    </ModalBody>
-    <ModalFooter
-      tag="div"
-    >
-      <Button
-        color="secondary"
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-      <Button
-        color="primary"
-        onClick={[Function]}
-      >
-        Confirm
-      </Button>
-    </ModalFooter>
-  </Modal>
+    <p>
+      Are you sure you want to 
+      <strong>
+        delete
+      </strong>
+       the user?
+    </p>
+  </OpenCloseModal>
 </div>
 `;
 
@@ -344,69 +168,25 @@ exports[`Component: ConfirmButton ui only icon: Component: ConfirmButton => ui =
     inProgress={false}
     onClick={[Function]}
   />
-  <Modal
-    autoFocus={true}
-    backdrop={true}
-    backdropTransition={
-      Object {
-        "mountOnEnter": true,
-        "timeout": 150,
-      }
-    }
-    centered={false}
-    fade={true}
+  <OpenCloseModal
     isOpen={false}
-    keyboard={true}
-    modalTransition={
+    label="Confirmation"
+    onClose={[Function]}
+    onSave={[Function]}
+    text={
       Object {
-        "timeout": 300,
+        "cancel": "Cancel",
+        "save": "Confirm",
       }
     }
-    onClosed={[Function]}
-    onOpened={[Function]}
-    returnFocusAfterClose={true}
-    role="dialog"
-    scrollable={false}
-    toggle={[Function]}
-    unmountOnClose={true}
-    zIndex={1050}
   >
-    <ModalHeader
-      charCode={215}
-      closeAriaLabel="Close"
-      tag="h5"
-      toggle={[Function]}
-      wrapTag="div"
-    >
-      Confirmation
-    </ModalHeader>
-    <ModalBody
-      tag="div"
-    >
-      <p>
-        Are you sure you want to 
-        <strong>
-          delete
-        </strong>
-         the user?
-      </p>
-    </ModalBody>
-    <ModalFooter
-      tag="div"
-    >
-      <Button
-        color="secondary"
-        onClick={[Function]}
-      >
-        Cancel
-      </Button>
-      <Button
-        color="primary"
-        onClick={[Function]}
-      >
-        Confirm
-      </Button>
-    </ModalFooter>
-  </Modal>
+    <p>
+      Are you sure you want to 
+      <strong>
+        delete
+      </strong>
+       the user?
+    </p>
+  </OpenCloseModal>
 </div>
 `;

--- a/src/core/OpenCloseModal/OpenCloseModal.stories.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.stories.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { OpenCloseModal } from './OpenCloseModal';
+import { Card } from 'reactstrap';
+import Button from '../Button/Button';
+import RadioGroup from '../../form/RadioGroup/RadioGroup';
+
+storiesOf('core|OpenCloseModal', module)
+  .add('basic', () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [choice, setChoice] = useState();
+
+    function onSave() {
+      action('save button was clicked');
+      setIsOpen(false);
+    }
+
+    function onClose() {
+      action('modal was closed');
+      setIsOpen(false);
+    }
+
+    return (
+      <Card body>
+        <Button onClick={() => setIsOpen(true)}>Start inquiry</Button>
+        <OpenCloseModal
+          isOpen={isOpen}
+          onClose={onClose}
+          onSave={onSave}
+          label="What are you doing?"
+        >
+          <RadioGroup
+            value={choice}
+            onChange={setChoice}
+            options={[
+              'Watching a movie',
+              'I work at 42, the most awesome company in the world!',
+              'Nothing'
+            ]}
+            optionForValue={option => option}
+          />
+        </OpenCloseModal>
+      </Card>
+    );
+  })
+  .add('without heading', () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <Card body>
+        <Button onClick={() => setIsOpen(true)}>Inspire me</Button>
+        <OpenCloseModal
+          isOpen={isOpen}
+          onSave={() => setIsOpen(false)}
+          onClose={() => setIsOpen(false)}
+          text={{ save: 'Yes', cancel: 'No' }}
+        >
+          <p>
+            You have to take a break once in a while. Did you go for a walk
+            outside to breathe some fresh air?
+          </p>
+        </OpenCloseModal>
+      </Card>
+    );
+  })
+  .add('without buttons', () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    function onClose() {
+      setIsOpen(false);
+    }
+
+    return (
+      <Card body>
+        <Button onClick={() => setIsOpen(true)}>What does Baymax say?</Button>
+        <OpenCloseModal
+          isOpen={isOpen}
+          onClose={onClose}
+          label="Your personal health companion"
+        >
+          <p>
+            You need to wash your hands if you want to prevent getting Corona
+            virus.
+          </p>
+        </OpenCloseModal>
+      </Card>
+    );
+  })
+  .add('custom button text', () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [choice, setChoice] = useState();
+
+    function onSave() {
+      alert(`You chose to ${choice.value} the diamond`);
+      setIsOpen(false);
+    }
+
+    function onClose() {
+      alert(
+        `Darn! You tricked and the diamond fell in an endless hole in the ground...`
+      );
+      setIsOpen(false);
+    }
+
+    return (
+      <Card body>
+        <p>You found a box!</p>
+        <Button onClick={() => setIsOpen(true)}>
+          Check what&apos;s inside
+        </Button>
+        <OpenCloseModal
+          isOpen={isOpen}
+          onClose={onClose}
+          onSave={onSave}
+          label="It's a special gift!"
+          text={{
+            save: 'Confirm',
+            cancel: ''
+          }}
+        >
+          <p>Inside the box you find a diamond. What do you want to do?</p>
+          <RadioGroup
+            value={choice}
+            onChange={setChoice}
+            options={[
+              { label: 'Sell it!', value: 'sell' },
+              { label: 'Put it in my pocket', value: 'store' }
+            ]}
+            optionForValue={option => option.label}
+          />
+        </OpenCloseModal>
+      </Card>
+    );
+  });

--- a/src/core/OpenCloseModal/OpenCloseModal.test.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import RadioGroup from '../../form/RadioGroup/RadioGroup';
+
+import { OpenCloseModal } from './OpenCloseModal';
+
+describe('Component: OpenCloseModal', () => {
+  let openCloseModal: ShallowWrapper;
+  let onCloseSpy: jest.Mock;
+  let onSaveSpy: jest.Mock;
+
+  function setup({
+    isOpen = false,
+    hasLabel = true,
+    hasCustomText = false,
+    hasButtons = true
+  }: {
+    isOpen?: boolean;
+    hasLabel?: boolean;
+    hasCustomText?: boolean;
+    hasButtons?: boolean;
+  }) {
+    onCloseSpy = jest.fn();
+    onSaveSpy = jest.fn();
+
+    const props = {
+      isOpen,
+      onClose: onCloseSpy,
+      text: hasCustomText
+        ? { cancel: 'Stop please', save: 'Select me' }
+        : undefined
+    };
+
+    if (hasButtons) {
+      // @ts-ignore
+      props.onSave = onSaveSpy;
+    }
+
+    const children = (
+      <RadioGroup
+        onChange={jest.fn()}
+        options={['local', 'development', 'test', 'acceptation', 'production']}
+        optionForValue={v => v}
+      />
+    );
+
+    if (hasLabel) {
+      openCloseModal = shallow(
+        <OpenCloseModal label="Choose something" {...props}>
+          {children}
+        </OpenCloseModal>
+      );
+    } else {
+      openCloseModal = shallow(
+        <OpenCloseModal {...props}>{children}</OpenCloseModal>
+      );
+    }
+  }
+
+  describe('ui', () => {
+    test('with label', () => {
+      setup({ isOpen: true });
+
+      expect(toJson(openCloseModal)).toMatchSnapshot(
+        'Component: OpenCloseModal => ui => with label'
+      );
+    });
+
+    test('without label', () => {
+      setup({ hasLabel: false });
+
+      expect(toJson(openCloseModal)).toMatchSnapshot(
+        'Component: OpenCloseModal => ui => without label'
+      );
+    });
+
+    test('without buttons', () => {
+      setup({ hasButtons: false });
+
+      expect(toJson(openCloseModal)).toMatchSnapshot(
+        'Component: OpenCloseModal => ui => without buttons'
+      );
+    });
+
+    test('custom button texts', () => {
+      setup({ hasCustomText: true });
+
+      expect(toJson(openCloseModal)).toMatchSnapshot(
+        'Component: OpenCloseModal => ui => custom button texts'
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('should call onClose when clicked outside modal', () => {
+      setup({});
+
+      // @ts-ignore
+      openCloseModal
+        .find('Modal')
+        .at(0)
+        .props()
+        // @ts-ignore
+        .toggle();
+
+      expect(onCloseSpy).toBeCalledTimes(1);
+    });
+
+    it('should call onClose when close button clicked', () => {
+      setup({});
+
+      // @ts-ignore
+      openCloseModal
+        .find('ModalHeader')
+        .at(0)
+        .props()
+        // @ts-ignore
+        .toggle();
+
+      expect(onCloseSpy).toBeCalledTimes(1);
+    });
+
+    it('should call onClose when cancel button clicked', () => {
+      setup({});
+
+      // @ts-ignore
+      openCloseModal
+        .find('Button')
+        .at(0)
+        .props()
+        // @ts-ignore
+        .onClick();
+
+      expect(onCloseSpy).toBeCalledTimes(1);
+    });
+
+    it('should call onSave when save button clicked', () => {
+      setup({});
+
+      // @ts-ignore
+      openCloseModal
+        .find('Button')
+        .at(1)
+        .props()
+        // @ts-ignore
+        .onClick();
+
+      expect(onSaveSpy).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/core/OpenCloseModal/OpenCloseModal.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
+import Button from '../Button/Button';
+import { t } from '../../utilities/translation/translation';
+import { BootstrapSize } from '../types';
+
+type Text = {
+  cancel?: string;
+  save?: string;
+};
+
+type Props = {
+  /**
+   * Whether or not the modal is open.
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback for when the modal should close.
+   */
+  onClose: () => void;
+
+  /**
+   * Callback for when the save button is clicked.
+   */
+  onSave?: () => void;
+
+  /**
+   * The content of the modal body.
+   */
+  children: React.ReactNode;
+
+  /**
+   * The label of the form element.
+   */
+  label?: React.ReactNode;
+
+  /**
+   * Optionally customized text within the component.
+   * This text should already be translated.
+   */
+  text?: Text;
+
+  /**
+   * Optionally the size (width) of the modal.
+   */
+  size?: BootstrapSize;
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
+};
+
+export function OpenCloseModal(props: Props) {
+  const {
+    isOpen,
+    onClose,
+    onSave,
+    children,
+    label,
+    text,
+    size,
+    className
+  } = props;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      toggle={() => onClose()}
+      size={size}
+      className={className}
+    >
+      {label ? (
+        <ModalHeader toggle={() => onClose()}>{label}</ModalHeader>
+      ) : null}
+      <ModalBody>{children}</ModalBody>
+      {onSave ? (
+        <ModalFooter>
+          <Button className="ml-1" color="secondary" onClick={() => onClose()}>
+            {t({
+              overrideText: text?.cancel,
+              key: 'OpenCloseModal.CANCEL',
+              fallback: 'Cancel'
+            })}
+          </Button>
+          <Button className="ml-1" color="primary" onClick={() => onSave()}>
+            {t({
+              overrideText: text?.save,
+              key: 'OpenCloseModal.SAVE',
+              fallback: 'Save'
+            })}
+          </Button>
+        </ModalFooter>
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
+++ b/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
@@ -1,0 +1,274 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseModal => ui => custom button texts 1`] = `
+<Modal
+  autoFocus={true}
+  backdrop={true}
+  backdropTransition={
+    Object {
+      "mountOnEnter": true,
+      "timeout": 150,
+    }
+  }
+  centered={false}
+  fade={true}
+  isOpen={false}
+  keyboard={true}
+  modalTransition={
+    Object {
+      "timeout": 300,
+    }
+  }
+  onClosed={[Function]}
+  onOpened={[Function]}
+  returnFocusAfterClose={true}
+  role="dialog"
+  scrollable={false}
+  toggle={[Function]}
+  unmountOnClose={true}
+  zIndex={1050}
+>
+  <ModalHeader
+    charCode={215}
+    closeAriaLabel="Close"
+    tag="h5"
+    toggle={[Function]}
+    wrapTag="div"
+  >
+    Choose something
+  </ModalHeader>
+  <ModalBody
+    tag="div"
+  >
+    <RadioGroup
+      onChange={[MockFunction]}
+      optionForValue={[Function]}
+      options={
+        Array [
+          "local",
+          "development",
+          "test",
+          "acceptation",
+          "production",
+        ]
+      }
+    />
+  </ModalBody>
+  <ModalFooter
+    tag="div"
+  >
+    <Button
+      className="ml-1"
+      color="secondary"
+      onClick={[Function]}
+    >
+      Stop please
+    </Button>
+    <Button
+      className="ml-1"
+      color="primary"
+      onClick={[Function]}
+    >
+      Select me
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => ui => with label 1`] = `
+<Modal
+  autoFocus={true}
+  backdrop={true}
+  backdropTransition={
+    Object {
+      "mountOnEnter": true,
+      "timeout": 150,
+    }
+  }
+  centered={false}
+  fade={true}
+  isOpen={true}
+  keyboard={true}
+  modalTransition={
+    Object {
+      "timeout": 300,
+    }
+  }
+  onClosed={[Function]}
+  onOpened={[Function]}
+  returnFocusAfterClose={true}
+  role="dialog"
+  scrollable={false}
+  toggle={[Function]}
+  unmountOnClose={true}
+  zIndex={1050}
+>
+  <ModalHeader
+    charCode={215}
+    closeAriaLabel="Close"
+    tag="h5"
+    toggle={[Function]}
+    wrapTag="div"
+  >
+    Choose something
+  </ModalHeader>
+  <ModalBody
+    tag="div"
+  >
+    <RadioGroup
+      onChange={[MockFunction]}
+      optionForValue={[Function]}
+      options={
+        Array [
+          "local",
+          "development",
+          "test",
+          "acceptation",
+          "production",
+        ]
+      }
+    />
+  </ModalBody>
+  <ModalFooter
+    tag="div"
+  >
+    <Button
+      className="ml-1"
+      color="secondary"
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+    <Button
+      className="ml-1"
+      color="primary"
+      onClick={[Function]}
+    >
+      Save
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`Component: OpenCloseModal ui without buttons: Component: OpenCloseModal => ui => without buttons 1`] = `
+<Modal
+  autoFocus={true}
+  backdrop={true}
+  backdropTransition={
+    Object {
+      "mountOnEnter": true,
+      "timeout": 150,
+    }
+  }
+  centered={false}
+  fade={true}
+  isOpen={false}
+  keyboard={true}
+  modalTransition={
+    Object {
+      "timeout": 300,
+    }
+  }
+  onClosed={[Function]}
+  onOpened={[Function]}
+  returnFocusAfterClose={true}
+  role="dialog"
+  scrollable={false}
+  toggle={[Function]}
+  unmountOnClose={true}
+  zIndex={1050}
+>
+  <ModalHeader
+    charCode={215}
+    closeAriaLabel="Close"
+    tag="h5"
+    toggle={[Function]}
+    wrapTag="div"
+  >
+    Choose something
+  </ModalHeader>
+  <ModalBody
+    tag="div"
+  >
+    <RadioGroup
+      onChange={[MockFunction]}
+      optionForValue={[Function]}
+      options={
+        Array [
+          "local",
+          "development",
+          "test",
+          "acceptation",
+          "production",
+        ]
+      }
+    />
+  </ModalBody>
+</Modal>
+`;
+
+exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal => ui => without label 1`] = `
+<Modal
+  autoFocus={true}
+  backdrop={true}
+  backdropTransition={
+    Object {
+      "mountOnEnter": true,
+      "timeout": 150,
+    }
+  }
+  centered={false}
+  fade={true}
+  isOpen={false}
+  keyboard={true}
+  modalTransition={
+    Object {
+      "timeout": 300,
+    }
+  }
+  onClosed={[Function]}
+  onOpened={[Function]}
+  returnFocusAfterClose={true}
+  role="dialog"
+  scrollable={false}
+  toggle={[Function]}
+  unmountOnClose={true}
+  zIndex={1050}
+>
+  <ModalBody
+    tag="div"
+  >
+    <RadioGroup
+      onChange={[MockFunction]}
+      optionForValue={[Function]}
+      options={
+        Array [
+          "local",
+          "development",
+          "test",
+          "acceptation",
+          "production",
+        ]
+      }
+    />
+  </ModalBody>
+  <ModalFooter
+    tag="div"
+  >
+    <Button
+      className="ml-1"
+      color="secondary"
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+    <Button
+      className="ml-1"
+      color="primary"
+      onClick={[Function]}
+    >
+      Save
+    </Button>
+  </ModalFooter>
+</Modal>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { default as AsyncPage } from './core/AsyncPage/AsyncPage';
 export { default as AsyncList } from './core/AsyncList/AsyncList';
 export { default as SearchInput } from './core/SearchInput/SearchInput';
 export { default as Pager } from './core/Pager/Pager';
+export { OpenCloseModal } from './core/OpenCloseModal/OpenCloseModal';
 
 // Form
 export { default as withJarb } from './form/withJarb/withJarb';


### PR DESCRIPTION
It would be nice to have a component that predefines the basics of a
modal so you only need 3 lines for the basics instead of 15.
Added OpenCloseModal component that predefines the basic layout of a
modal with cancel and save button.

Closes #384