### PR TITLE
fix: RadioGroup label size

### DIFF
--- a/src/form/RadioGroup/RadioGroup.scss
+++ b/src/form/RadioGroup/RadioGroup.scss
@@ -1,0 +1,3 @@
+.radio-group > legend {
+  font-size: 1rem;
+}

--- a/src/form/RadioGroup/RadioGroup.tsx
+++ b/src/form/RadioGroup/RadioGroup.tsx
@@ -160,7 +160,11 @@ export default function RadioGroup<T>(props: Props<T>) {
   }
 
   return (
-    <FormGroup tag="fieldset" className={className} color={color}>
+    <FormGroup
+      tag="fieldset"
+      className={'radio-group ' + className}
+      color={color}
+    >
       {'label' in props && props.label ? <legend>{props.label}</legend> : null}
       {placeholder ? (
         <p className="text-muted">

--- a/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => horizontal 1`] = `
 <FormGroup
-  className=""
+  className="radio-group "
   tag="fieldset"
 >
   <legend>
@@ -111,7 +111,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
 
 exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => with value 1`] = `
 <FormGroup
-  className=""
+  className="radio-group "
   tag="fieldset"
 >
   <legend>
@@ -220,7 +220,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
 
 exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => without label 1`] = `
 <FormGroup
-  className=""
+  className="radio-group "
   tag="fieldset"
 >
   <p
@@ -326,7 +326,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
 
 exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => ui => without placeholder 1`] = `
 <FormGroup
-  className=""
+  className="radio-group "
   tag="fieldset"
 >
   <legend>

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -743,11 +743,11 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
     placeholder="Select your best friend"
   >
     <FormGroup
-      className=""
+      className="radio-group "
       tag="fieldset"
     >
       <fieldset
-        className="form-group"
+        className="radio-group  form-group"
       >
         <legend>
           Best friend

--- a/src/main.scss
+++ b/src/main.scss
@@ -42,6 +42,7 @@
 @import './form/Typeahead/Typeahead';
 @import './form/ColorPicker/ColorPicker';
 @import './form/withJarb/withJarb';
+@import './form/RadioGroup/RadioGroup';
 
 // Table
 @import './table/EpicTable/EpicTable';


### PR DESCRIPTION
The label of a radio group is too large. Other inputs have a smaller
label, so when put together, it doesn't look too well.
Added a bit of styling to match the size of the RadioGroup legend to the
labels of other form components.

Closes #387