### PR TITLE
fix: restore all mocks after each test

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
     ],
     "transform": {
       "\\.tsx?$": "ts-jest"
-    }
+    },
+    "restoreMocks": true
   },
   "lint-staged": {
     "{src,tests}/**/*.{js,jsx,json,scss,ts,tsx}": [

--- a/src/form/DateTimeInput/DateTimeInput.test.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.test.tsx
@@ -76,7 +76,7 @@ describe('Component: DateTimeInput', () => {
     });
 
     test('with format error', () => {
-      const useHasFormatErrorSpy = jest
+      jest
         .spyOn(FormatError, 'useHasFormatError')
         .mockImplementation(() => [true, jest.fn()]);
 
@@ -85,8 +85,6 @@ describe('Component: DateTimeInput', () => {
       expect(toJson(dateTimeInput)).toMatchSnapshot(
         'Component: DateTimeInput => ui => with format error'
       );
-
-      useHasFormatErrorSpy.mockRestore();
     });
 
     test('with date picker in modal', () => {
@@ -263,7 +261,7 @@ describe('Component: DateTimeInput', () => {
     describe('toggle modal', () => {
       test('open modal on button click', () => {
         const setIsModalOpenSpy = jest.fn();
-        const useIsModalOpenSpy = jest
+        jest
           .spyOn(IsModalOpen, 'useIsModalOpen')
           .mockReturnValue([false, setIsModalOpenSpy]);
 
@@ -286,13 +284,11 @@ describe('Component: DateTimeInput', () => {
 
         expect(setIsModalOpenSpy).toBeCalledTimes(1);
         expect(setIsModalOpenSpy).toBeCalledWith(true);
-
-        useIsModalOpenSpy.mockRestore();
       });
 
       test('close modal', () => {
         const setIsModalOpenSpy = jest.fn();
-        const useIsModalOpenSpy = jest
+        jest
           .spyOn(IsModalOpen, 'useIsModalOpen')
           .mockReturnValue([true, setIsModalOpenSpy]);
 
@@ -307,13 +303,11 @@ describe('Component: DateTimeInput', () => {
 
         expect(setIsModalOpenSpy).toBeCalledTimes(1);
         expect(setIsModalOpenSpy).toBeCalledWith(false);
-
-        useIsModalOpenSpy.mockRestore();
       });
 
       test('close modal on clicking select button', () => {
         const setIsModalOpenSpy = jest.fn();
-        const useIsModalOpenSpy = jest
+        jest
           .spyOn(IsModalOpen, 'useIsModalOpen')
           .mockReturnValue([true, setIsModalOpenSpy]);
 
@@ -328,8 +322,6 @@ describe('Component: DateTimeInput', () => {
 
         expect(setIsModalOpenSpy).toBeCalledTimes(1);
         expect(setIsModalOpenSpy).toBeCalledWith(false);
-
-        useIsModalOpenSpy.mockRestore();
       });
     });
   });

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.test.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.test.tsx
@@ -47,9 +47,7 @@ describe('Component: DateTimeModal', () => {
   describe('events', () => {
     it('should update internal value when a date is selected', () => {
       const setValueSpy = jest.fn();
-      const useValueSpy = jest
-        .spyOn(Value, 'useValue')
-        .mockReturnValue(['', setValueSpy]);
+      jest.spyOn(Value, 'useValue').mockReturnValue(['', setValueSpy]);
       const { dateTimeModal } = setup({});
 
       const value = new Date(2020, 2, 1, 0, 0, 0);
@@ -63,8 +61,6 @@ describe('Component: DateTimeModal', () => {
 
       expect(setValueSpy).toBeCalledTimes(1);
       expect(setValueSpy).toBeCalledWith(value);
-
-      useValueSpy.mockRestore();
     });
 
     it('should not update external value when a date is selected', () => {


### PR DESCRIPTION
You don't want to have to restore all mocks manually after each test.
Changed restoreMocks in jest configuration.
Removed all mockRestore() calls.