### PR TITLE
fix: modal closed when valuepicker total elements narrowed by search

### DIFF
--- a/src/form/ValuePicker/ValuePicker.tsx
+++ b/src/form/ValuePicker/ValuePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Color } from '../types';
 import { FetchOptionsCallback, OptionEqual, OptionForValue } from '../option';
 import withJarb from '../withJarb/withJarb';
@@ -179,26 +179,16 @@ export default function ValuePicker<T>(props: Props<T>) {
   const [booting, setBooting] = useState(true);
   const [totalElements, setTotalElements] = useState(0);
 
-  const fetchOptionsCallback = useCallback(
-    async (query: string, pageNumber: number, size: number) => {
-      const page = await fetchOptions(query, pageNumber, size);
-
-      setTotalElements(page.totalElements);
-
-      return page;
-    },
-    [fetchOptions]
-  );
-
   useEffect(() => {
     async function boot() {
-      await fetchOptionsCallback('', 1, 1);
+      const page = await fetchOptions('', 1, 1);
+      setTotalElements(page.totalElements);
 
       setBooting(false);
     }
 
     boot();
-  }, [fetchOptionsCallback]);
+  }, [fetchOptions]);
 
   // Until we know the number of totalElements the ValuePicker is booting.
   // and we do not shown anything to the user yet.
@@ -223,30 +213,22 @@ export default function ValuePicker<T>(props: Props<T>) {
     if (totalElements < 11) {
       return (
         <CheckboxMultipleSelect
-          options={() => fetchOptionsCallback('', 1, 10)}
+          options={() => fetchOptions('', 1, 10)}
           {...rest}
         />
       );
     } else {
-      return (
-        <ModalPickerMultiple fetchOptions={fetchOptionsCallback} {...rest} />
-      );
+      return <ModalPickerMultiple fetchOptions={fetchOptions} {...rest} />;
     }
   } else {
     const { fetchOptions, multiple, ...rest } = props;
 
     if (totalElements < 4) {
-      return (
-        <RadioGroup options={() => fetchOptionsCallback('', 1, 3)} {...rest} />
-      );
+      return <RadioGroup options={() => fetchOptions('', 1, 3)} {...rest} />;
     } else if (totalElements < 11) {
-      return (
-        <Select options={() => fetchOptionsCallback('', 1, 10)} {...rest} />
-      );
+      return <Select options={() => fetchOptions('', 1, 10)} {...rest} />;
     } else {
-      return (
-        <ModalPickerSingle fetchOptions={fetchOptionsCallback} {...rest} />
-      );
+      return <ModalPickerSingle fetchOptions={fetchOptions} {...rest} />;
     }
   }
 }

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -313,7 +313,32 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
 >
   <ModalPickerMultiple
     canSearch={true}
-    fetchOptions={[Function]}
+    fetchOptions={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "",
+            1,
+            1,
+          ],
+          Array [
+            "",
+            1,
+            10,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      }
+    }
     id="bestFriend"
     label="Best friend"
     onBlur={[MockFunction]}
@@ -553,7 +578,32 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
 >
   <ModalPickerSingle
     canSearch={true}
-    fetchOptions={[Function]}
+    fetchOptions={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "",
+            1,
+            1,
+          ],
+          Array [
+            "",
+            1,
+            10,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      }
+    }
     id="bestFriend"
     label="Best friend"
     onBlur={[MockFunction]}


### PR DESCRIPTION
When you have a ModalPickerMultiple component with a lot of options and you try to narrow the number of options down by using the search option, the modal closes sometimes.
This seems to happen when you narrow it down too much.

The cause of this problem lies in the containing ValuePicker component.
This component wraps several other components and displays the right one
based on the total options. When the ModalPicker narrows the number of
options, the value of the total options in the ValuePicker was also
changed. The ValuePicker wraps the given optionFetcherCallback in its
own callback function. In this function it updates the total number of
options. And this callback function is passed to its child components.

Moved setting the total elements to the boot function to prevent total
elements from being changed by a query.

Closes #412