### PR TITLE
feat: input with password strength

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -166,6 +166,17 @@ Here is a JSON notation containing all keys and default translations:
   },
   "DateTimeModal": {
     "SELECT": "Select"
+  },
+  "NewPasswordInput": {
+    "NOT_STRONG_ENOUGH": "Password does not follow rules"
+  },
+  "PasswordStrength": {
+    "LOWERCASE": "Must contain at least one lowercase letter",
+    "UPPERCASE": "Must contain at least one lowercase letter",
+    "NUMBER": "Must contain at least one number",
+    "SPECIAL_CHARACTER": "Must contain at least one special character ({{specialChars}})",
+    "MINIMUM_LENGTH": "Must contain at least {{minimumLength}} characters",
+    "NO_SPACE": "Must not contain any space"
   }
 }
 ```

--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -6,6 +6,7 @@ import { Moment } from 'moment';
 import { JarbInput } from './Input/Input';
 import { FinalForm } from './story-utils';
 import {
+  isStrongPassword,
   JarbCheckboxMultipleSelect,
   JarbDateRangePicker,
   JarbDateTimeInput,
@@ -29,6 +30,7 @@ import { User } from '../test/types';
 import { JarbColorPicker } from './ColorPicker/ColorPicker';
 import { JarbCheckbox } from './Checkbox/Checkbox';
 import { JarbRadioGroup } from './RadioGroup/RadioGroup';
+import { JarbNewPasswordInput } from './NewPasswordInput/NewPasswordInput';
 
 function sleep(ms: number) {
   return new Promise(resolve => {
@@ -193,6 +195,27 @@ storiesOf('Form|Example', module).add('jarb form', () => {
         label="User name"
         placeholder="Please enter your user name"
         validators={requiredValidator}
+      />
+
+      <JarbNewPasswordInput
+        name="password"
+        jarb={{ validator: 'User.password', label: 'Password' }}
+        id="password"
+        label="Password"
+        placeholder="Please enter your password"
+        validators={[
+          isStrongPassword(
+            [
+              'lowercase',
+              'uppercase',
+              'number',
+              'specialChar',
+              'minimumLength',
+              'noSpace'
+            ],
+            10
+          )
+        ]}
       />
 
       <JarbDateTimeInput

--- a/src/form/NewPasswordInput/NewPasswordInput.stories.tsx
+++ b/src/form/NewPasswordInput/NewPasswordInput.stories.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { FinalForm, Form } from '../story-utils';
+import NewPasswordInput, {
+  isStrongPassword,
+  JarbNewPasswordInput
+} from './NewPasswordInput';
+import { Icon, Tooltip } from '../../index';
+
+storiesOf('Form|NewPasswordInput', module)
+  .add('basic', () => {
+    const [password, setPassword] = useState('');
+
+    return (
+      <Form>
+        <NewPasswordInput
+          id="password"
+          label="Password"
+          placeholder="Please enter your password"
+          value={password}
+          onChange={setPassword}
+        />
+      </Form>
+    );
+  })
+  .add('icon', () => {
+    const [password, setPassword] = useState('');
+
+    return (
+      <Form>
+        <NewPasswordInput
+          id="password"
+          label="Password"
+          placeholder="Please enter your password"
+          value={password}
+          onChange={setPassword}
+          addon={{
+            icon: 'lock',
+            position: 'left'
+          }}
+        />
+      </Form>
+    );
+  })
+  .add('without placeholder', () => {
+    const [password, setPassword] = useState('');
+
+    return (
+      <Form>
+        <NewPasswordInput
+          id="password"
+          label="Password"
+          value={password}
+          onChange={setPassword}
+        />
+      </Form>
+    );
+  })
+  .add('without label', () => {
+    const [password, setPassword] = useState('');
+
+    return (
+      <Form>
+        <NewPasswordInput
+          placeholder="Please enter your password"
+          value={password}
+          onChange={setPassword}
+        />
+      </Form>
+    );
+  })
+  .add('with custom label', () => {
+    const [password, setPassword] = useState('');
+
+    return (
+      <Form>
+        <NewPasswordInput
+          id="password"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>Password</span>
+              <Tooltip
+                className="ml-1"
+                content="Your password should be secret"
+              >
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please enter your password"
+          value={password}
+          onChange={setPassword}
+        />
+      </Form>
+    );
+  })
+  .add('without meter', () => {
+    const [password, setPassword] = useState('');
+
+    return (
+      <Form>
+        <NewPasswordInput
+          id="password"
+          label="Password"
+          placeholder="Please enter your password"
+          value={password}
+          onChange={setPassword}
+          showMeter={false}
+        />
+      </Form>
+    );
+  })
+  .add('jarb', () => {
+    return (
+      <FinalForm>
+        <JarbNewPasswordInput
+          name="password"
+          jarb={{ validator: 'User.password', label: 'Password' }}
+          id="password"
+          label="password"
+          placeholder="Please enter your password"
+          validators={[
+            isStrongPassword(
+              [
+                'lowercase',
+                'uppercase',
+                'number',
+                'specialChar',
+                'minimumLength',
+                'noSpace'
+              ],
+              10
+            )
+          ]}
+        />
+      </FinalForm>
+    );
+  });

--- a/src/form/NewPasswordInput/NewPasswordInput.test.tsx
+++ b/src/form/NewPasswordInput/NewPasswordInput.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import NewPasswordInput, { isStrongPassword } from './NewPasswordInput';
+
+describe('Component: NewPasswordInput', () => {
+  function setup(props: {
+    value?: string;
+    lowercase?: boolean;
+    uppercase?: boolean;
+    number?: boolean;
+    specialCharacter?: boolean;
+    minimumLength?: number;
+    noSpace?: boolean;
+  }) {
+    const newPasswordInput = shallow(
+      <NewPasswordInput onChange={jest.fn()} {...props} />
+    );
+    return { newPasswordInput };
+  }
+
+  test('ui', () => {
+    const { newPasswordInput } = setup({ value: 'test' });
+    expect(toJson(newPasswordInput)).toMatchSnapshot(
+      'Component: NewPasswordInput => ui => default'
+    );
+  });
+
+  test('default all rules enabled', () => {
+    const { newPasswordInput } = setup({});
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual([
+      'lowercase',
+      'uppercase',
+      'number',
+      'specialChar',
+      'minimumLength',
+      'noSpace'
+    ]);
+  });
+
+  test('disable lowercase check', () => {
+    const { newPasswordInput } = setup({ lowercase: false });
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual([
+      'uppercase',
+      'number',
+      'specialChar',
+      'minimumLength',
+      'noSpace'
+    ]);
+  });
+
+  test('disable uppercase check', () => {
+    const { newPasswordInput } = setup({ uppercase: false });
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual([
+      'lowercase',
+      'number',
+      'specialChar',
+      'minimumLength',
+      'noSpace'
+    ]);
+  });
+
+  test('disable number check', () => {
+    const { newPasswordInput } = setup({ number: false });
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual([
+      'lowercase',
+      'uppercase',
+      'specialChar',
+      'minimumLength',
+      'noSpace'
+    ]);
+  });
+
+  test('disable special character check', () => {
+    const { newPasswordInput } = setup({ specialCharacter: false });
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual(['lowercase', 'uppercase', 'number', 'minimumLength', 'noSpace']);
+  });
+
+  test('disable minimum length check', () => {
+    const { newPasswordInput } = setup({ minimumLength: 0 });
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual(['lowercase', 'uppercase', 'number', 'specialChar', 'noSpace']);
+  });
+
+  test('disable no space check', () => {
+    const { newPasswordInput } = setup({ noSpace: false });
+    expect(
+      // @ts-ignore
+      newPasswordInput.find('PasswordStrength').props().rules
+    ).toEqual([
+      'lowercase',
+      'uppercase',
+      'number',
+      'specialChar',
+      'minimumLength'
+    ]);
+  });
+
+  describe('isStrongPassword', () => {
+    it('should return undefined when validator passes', () => {
+      const validator = isStrongPassword(
+        [
+          'lowercase',
+          'uppercase',
+          'number',
+          'specialChar',
+          'minimumLength',
+          'noSpace'
+        ],
+        10
+      );
+      expect(validator('Pa$$w0rd42', {}, undefined)).toBe(undefined);
+    });
+
+    it('should return translatable when validator fails', () => {
+      const validator = isStrongPassword(
+        [
+          'lowercase',
+          'uppercase',
+          'number',
+          'specialChar',
+          'minimumLength',
+          'noSpace'
+        ],
+        10
+      );
+      expect(validator('password', {}, undefined)).toEqual({
+        key: 'NewPasswordInput.NOT_STRONG_ENOUGH',
+        fallback: 'Password does not follow rules'
+      });
+    });
+  });
+});

--- a/src/form/NewPasswordInput/NewPasswordInput.tsx
+++ b/src/form/NewPasswordInput/NewPasswordInput.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { omit, pick } from 'lodash';
+import { FieldValidator } from 'final-form';
+
+import { Translation } from '../../utilities/translation/translator';
+import Input, { Props as InputProps } from '../Input/Input';
+import withJarb from '../withJarb/withJarb';
+import PasswordStrength from './PasswordStrength/PasswordStrength';
+import {
+  hasLowercase,
+  hasMinimumLength,
+  hasNoSpaces,
+  hasNumber,
+  hasSpecialChar,
+  hasUppercase,
+  Rule
+} from './PasswordStrength/rules';
+
+interface PasswordProps {
+  /**
+   * Whether or not the password should contain at least one lowercase letter.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  lowercase?: boolean;
+
+  /**
+   * Whether or not the password should contain at least one uppercase letter.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  uppercase?: boolean;
+
+  /**
+   * Whether or not the password should contain at least one number.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  number?: boolean;
+
+  /**
+   * Whether or not the password should contain at least one special character.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  specialCharacter?: boolean;
+
+  /**
+   * Optionally the minimum length of the password.
+   * Defaults to 10.
+   *
+   * @default 10
+   */
+  minimumLength?: number;
+
+  /**
+   * Whether or not the password should not contain any space.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  noSpace?: boolean;
+
+  /**
+   * Whether or not to display a meter or only a list of rules.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  showMeter?: boolean;
+}
+
+export type Props = Omit<InputProps, 'type'> & PasswordProps;
+
+export default function NewPasswordInput(props: Props) {
+  const rules = getRulesFromProps(props);
+  const inputProps = omit(props, [
+    'lowercase',
+    'uppercase',
+    'number',
+    'specialCharacter',
+    'minimumLength',
+    'noSpace',
+    'showMeter'
+  ]) as InputProps;
+  inputProps.type = 'password';
+  const passwordStrengthProps = pick(props, ['minimumLength', 'showMeter']);
+
+  return (
+    <>
+      <Input {...inputProps} />
+      <PasswordStrength
+        password={inputProps.value ?? ''}
+        rules={rules}
+        {...passwordStrengthProps}
+      />
+    </>
+  );
+}
+
+function getRulesFromProps(props: PasswordProps) {
+  const {
+    lowercase = true,
+    uppercase = true,
+    number = true,
+    specialCharacter = true,
+    minimumLength = 10,
+    noSpace = true
+  } = props;
+
+  const rules: Rule[] = [];
+  if (lowercase) {
+    rules.push('lowercase');
+  }
+  if (uppercase) {
+    rules.push('uppercase');
+  }
+  if (number) {
+    rules.push('number');
+  }
+  if (specialCharacter) {
+    rules.push('specialChar');
+  }
+  if (minimumLength > 0) {
+    rules.push('minimumLength');
+  }
+  if (noSpace) {
+    rules.push('noSpace');
+  }
+
+  return rules;
+}
+
+/**
+ * Variant of the FileInput which can be used in a Jarb context.
+ */
+export const JarbNewPasswordInput = withJarb<string, string, Props>(
+  NewPasswordInput
+);
+
+/**
+ * A PasswordValidator is a FieldValidator which checks if the password
+ * is valid.
+ */
+type PasswordValidator = FieldValidator<string | undefined>;
+
+/**
+ * Takes `rules` and a minimum length and returns a validator which can check if the
+ * the password complies to the rules.
+ *
+ * @export
+ * @param {Rule[]} rules The rules the password should comply to.
+ * @param {number} minimumLength The minimum length of the password.
+ * @returns {(FieldValidator<string | undefined>)}
+ */
+export function isStrongPassword(
+  rules: Rule[],
+  minimumLength: number
+): PasswordValidator {
+  return (value?: string): Translation | undefined => {
+    const compliant = rules.map(rule => {
+      switch (rule) {
+        case 'lowercase':
+          return hasLowercase(value);
+        case 'uppercase':
+          return hasUppercase(value);
+        case 'number':
+          return hasNumber(value);
+        case 'specialChar':
+          return hasSpecialChar(value);
+        case 'minimumLength':
+          return hasMinimumLength(minimumLength, value);
+        case 'noSpace':
+          return hasNoSpaces(value);
+      }
+    });
+
+    if (compliant.every(value => value)) {
+      return undefined;
+    }
+
+    return {
+      key: 'NewPasswordInput.NOT_STRONG_ENOUGH',
+      fallback: 'Password does not follow rules'
+    };
+  };
+}

--- a/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.test.tsx
+++ b/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import * as MeterWidth from './useMeterWidth/useMeterWidth';
+import * as Rules from './useRules/useRules';
+
+import PasswordStrength from './PasswordStrength';
+
+describe('Component: PasswordStrength', () => {
+  function setup({
+    password = '',
+    showMeter
+  }: {
+    password?: string;
+    showMeter?: boolean;
+  }) {
+    const passwordStrength = shallow(
+      <PasswordStrength
+        password={password}
+        rules={['lowercase', 'minimumLength']}
+        showMeter={showMeter}
+      />
+    );
+
+    return { passwordStrength };
+  }
+
+  describe('ui', () => {
+    it('default', () => {
+      const { passwordStrength } = setup({});
+      expect(toJson(passwordStrength)).toMatchSnapshot(
+        'Component: PasswordStrength => ui => default'
+      );
+    });
+
+    it('without meter', () => {
+      const { passwordStrength } = setup({ showMeter: false });
+      expect(toJson(passwordStrength)).toMatchSnapshot(
+        'Component: PasswordStrength => ui => without meter'
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('should display the progress bar in color warning when password strength 75%', () => {
+      jest.spyOn(MeterWidth, 'useMeterWidth').mockReturnValue(75);
+
+      const { passwordStrength } = setup({});
+
+      expect(passwordStrength.find('Progress').props().color).toBe('warning');
+    });
+
+    it('should display the progress bar in color warning when password strength 100%', () => {
+      jest.spyOn(MeterWidth, 'useMeterWidth').mockReturnValue(100);
+
+      const { passwordStrength } = setup({});
+
+      expect(passwordStrength.find('Progress').props().color).toBe('success');
+    });
+
+    it('should display the rule with a red cross', () => {
+      const { passwordStrength } = setup({});
+
+      expect(
+        passwordStrength
+          .find('Icon')
+          .at(0)
+          // @ts-ignore
+          .props().icon
+      ).toBe('cancel');
+      expect(
+        passwordStrength
+          .find('Icon')
+          .at(0)
+          .props().color
+      ).toBe('danger');
+    });
+
+    it('should display the rule with a green checkmark', () => {
+      jest.spyOn(Rules, 'useRules').mockReturnValue({ lowercase: true });
+
+      const { passwordStrength } = setup({});
+
+      expect(
+        passwordStrength
+          .find('Icon')
+          .at(0)
+          // @ts-ignore
+          .props().icon
+      ).toBe('check_circle');
+      expect(
+        passwordStrength
+          .find('Icon')
+          .at(0)
+          .props().color
+      ).toBe('success');
+    });
+  });
+});

--- a/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
+++ b/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+import { t } from '../../../utilities/translation/translation';
+import Icon from '../../../core/Icon/Icon';
+import { useMeterWidth } from './useMeterWidth/useMeterWidth';
+import { useRules } from './useRules/useRules';
+import { Rule } from './rules';
+
+type Props = {
+  /**
+   * The password to match the rule to.
+   */
+  password: string;
+
+  /**
+   * The list of rules to be matched.
+   */
+  rules: Rule[];
+
+  /**
+   * Optionally the minimum length of the password.
+   */
+  minimumLength?: number;
+
+  /**
+   * Whether or not to display a meter or only a list of rules.
+   * Defaults to true.
+   *
+   * @default true
+   */
+  showMeter?: boolean;
+};
+
+export default function PasswordStrength(props: Props) {
+  const { password, rules, minimumLength = 10, showMeter = true } = props;
+
+  const compliant = useRules(rules, password, minimumLength);
+  const meterWidth = useMeterWidth(compliant);
+
+  return (
+    <>
+      {showMeter ? (
+        <Progress
+          color={
+            meterWidth >= 100
+              ? 'success'
+              : meterWidth >= 75
+              ? 'warning'
+              : 'danger'
+          }
+          value={meterWidth}
+          className="mb-2"
+          style={{ height: 5 }}
+        />
+      ) : null}
+      <div className="mb-2">
+        {rules.map(rule => {
+          const isCompliant = compliant[rule];
+          return (
+            <div key={rule}>
+              <Icon
+                icon={isCompliant ? 'check_circle' : 'cancel'}
+                color={isCompliant ? 'success' : 'danger'}
+                size={16}
+                className="align-bottom mb-1 mr-3"
+              />
+              {t(labelForRule(rule, minimumLength))}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export function labelForRule(rule: Rule, minimumLength: number) {
+  switch (rule) {
+    case 'lowercase':
+      return {
+        key: 'PasswordStrength.LOWERCASE',
+        fallback: 'Must contain at least one lowercase letter'
+      };
+    case 'uppercase':
+      return {
+        key: 'PasswordStrength.UPPERCASE',
+        fallback: 'Must contain at least one uppercase letter'
+      };
+    case 'number':
+      return {
+        key: 'PasswordStrength.NUMBER',
+        fallback: 'Must contain at least one number'
+      };
+    case 'specialChar':
+      return {
+        key: 'PasswordStrength.SPECIAL_CHAR',
+        data: { specialCharacters: '@#$%^&+=.,?!' },
+        fallback: 'Must contain at least one special character (@#$%^&+=.,?!)'
+      };
+    case 'minimumLength':
+      return {
+        key: 'PasswordStrength.MINIMUM_LENGTH',
+        data: { minimumLength },
+        fallback: `Must contain at least ${minimumLength} characters`
+      };
+    case 'noSpace':
+      return {
+        key: 'PasswordStrength.NO_SPACE',
+        fallback: 'Must not contain any space'
+      };
+  }
+}

--- a/src/form/NewPasswordInput/PasswordStrength/__snapshots__/PasswordStrength.test.tsx.snap
+++ b/src/form/NewPasswordInput/PasswordStrength/__snapshots__/PasswordStrength.test.tsx.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: PasswordStrength ui default: Component: PasswordStrength => ui => default 1`] = `
+<Fragment>
+  <Progress
+    className="mb-2"
+    color="danger"
+    max={100}
+    style={
+      Object {
+        "height": 5,
+      }
+    }
+    tag="div"
+    value={0}
+  />
+  <div
+    className="mb-2"
+  >
+    <div
+      key="lowercase"
+    >
+      <Icon
+        className="align-bottom mb-1 mr-3"
+        color="danger"
+        icon="cancel"
+        size={16}
+      />
+      Must contain at least one lowercase letter
+    </div>
+    <div
+      key="minimumLength"
+    >
+      <Icon
+        className="align-bottom mb-1 mr-3"
+        color="danger"
+        icon="cancel"
+        size={16}
+      />
+      Must contain at least 10 characters
+    </div>
+  </div>
+</Fragment>
+`;
+
+exports[`Component: PasswordStrength ui without meter: Component: PasswordStrength => ui => without meter 1`] = `
+<Fragment>
+  <div
+    className="mb-2"
+  >
+    <div
+      key="lowercase"
+    >
+      <Icon
+        className="align-bottom mb-1 mr-3"
+        color="danger"
+        icon="cancel"
+        size={16}
+      />
+      Must contain at least one lowercase letter
+    </div>
+    <div
+      key="minimumLength"
+    >
+      <Icon
+        className="align-bottom mb-1 mr-3"
+        color="danger"
+        icon="cancel"
+        size={16}
+      />
+      Must contain at least 10 characters
+    </div>
+  </div>
+</Fragment>
+`;

--- a/src/form/NewPasswordInput/PasswordStrength/rules.test.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/rules.test.ts
@@ -1,0 +1,44 @@
+import {
+  hasLowercase,
+  hasMinimumLength,
+  hasNoSpaces,
+  hasNumber,
+  hasSpecialChar,
+  hasUppercase
+} from './rules';
+
+test('hasLowercase', () => {
+  expect(hasLowercase(undefined)).toBe(false);
+  expect(hasLowercase('')).toBe(false);
+  expect(hasLowercase('lowercase')).toBe(true);
+});
+
+test('hasUppercase', () => {
+  expect(hasUppercase(undefined)).toBe(false);
+  expect(hasUppercase('')).toBe(false);
+  expect(hasUppercase('UPPERCASE')).toBe(true);
+});
+
+test('hasNumber', () => {
+  expect(hasNumber(undefined)).toBe(false);
+  expect(hasNumber('')).toBe(false);
+  expect(hasNumber('12345678')).toBe(true);
+});
+
+test('hasMinimumLength', () => {
+  expect(hasMinimumLength(10, undefined)).toBe(false);
+  expect(hasMinimumLength(10, '')).toBe(false);
+  expect(hasMinimumLength(10, 'longenough')).toBe(true);
+});
+
+test('hasSpecialChar', () => {
+  expect(hasSpecialChar(undefined)).toBe(false);
+  expect(hasSpecialChar('')).toBe(false);
+  expect(hasSpecialChar('!@#$%^&*')).toBe(true);
+});
+
+test('hasNoSpaces', () => {
+  expect(hasNoSpaces(undefined)).toBe(true);
+  expect(hasNoSpaces('with a space')).toBe(false);
+  expect(hasNoSpaces('withoutspace')).toBe(true);
+});

--- a/src/form/NewPasswordInput/PasswordStrength/rules.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/rules.ts
@@ -1,0 +1,31 @@
+export type Rule =
+  | 'lowercase'
+  | 'uppercase'
+  | 'number'
+  | 'specialChar'
+  | 'minimumLength'
+  | 'noSpace';
+
+export function hasLowercase(value?: string) {
+  return !!value && /(?=.*[a-z])/.test(value);
+}
+
+export function hasUppercase(value?: string) {
+  return !!value && /(?=.*[A-Z])/.test(value);
+}
+
+export function hasNumber(value?: string) {
+  return !!value && /(?=.*[0-9])/.test(value);
+}
+
+export function hasSpecialChar(value?: string) {
+  return !!value && /(?=.*[@#$%^&+=.,?!])/.test(value);
+}
+
+export function hasMinimumLength(length: number, value?: string) {
+  return !!value && new RegExp(`.{${length},}`).test(value);
+}
+
+export function hasNoSpaces(value?: string) {
+  return /^\S*$/.test(value ?? '');
+}

--- a/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.test.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.test.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { useMeterWidth } from './useMeterWidth';
+
+describe('Hook: useMeterWidth', () => {
+  it('should set meter width based on rules', () => {
+    jest.spyOn(React, 'useEffect').mockImplementation(fn => fn());
+
+    const setMeterWidthSpy = jest.fn();
+    jest.spyOn(React, 'useState').mockReturnValue([0, setMeterWidthSpy]);
+
+    useMeterWidth({ lowercase: true });
+
+    expect(setMeterWidthSpy).toBeCalledTimes(1);
+    expect(setMeterWidthSpy).toBeCalledWith(100);
+  });
+});

--- a/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { Rule } from '../rules';
+
+export function useMeterWidth(compliant: { [key in Rule]?: boolean }) {
+  const [meterWidth, setMeterWidth] = useState(0);
+
+  useEffect(() => {
+    const values = Object.values(compliant);
+    const noCompliantRules = values.filter(value => value).length;
+    const noRules = values.length;
+
+    setMeterWidth((noCompliantRules / noRules) * 100);
+  }, [compliant, setMeterWidth]);
+
+  return meterWidth;
+}

--- a/src/form/NewPasswordInput/PasswordStrength/useRules/useRules.test.tsx
+++ b/src/form/NewPasswordInput/PasswordStrength/useRules/useRules.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PasswordStrength from '../PasswordStrength';
+
+describe('Hook: useRules', () => {
+  it('should set compliant for each rule based on password', () => {
+    jest.spyOn(React, 'useEffect').mockImplementation(fn => fn());
+
+    const setCompliantSpy = jest.fn();
+    jest
+      .spyOn(React, 'useState')
+      .mockReturnValueOnce([{ lowercase: false }, setCompliantSpy]);
+    jest.spyOn(React, 'useState').mockReturnValue([0, jest.fn()]);
+
+    shallow(
+      <PasswordStrength
+        rules={[
+          'lowercase',
+          'uppercase',
+          'number',
+          'specialChar',
+          'minimumLength',
+          'noSpace'
+        ]}
+        password="password"
+        minimumLength={10}
+      />
+    );
+
+    expect(setCompliantSpy).toBeCalledTimes(1);
+    expect(setCompliantSpy).toBeCalledWith({
+      lowercase: true,
+      uppercase: false,
+      number: false,
+      specialChar: false,
+      minimumLength: false,
+      noSpace: true
+    });
+  });
+});

--- a/src/form/NewPasswordInput/PasswordStrength/useRules/useRules.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/useRules/useRules.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import {
+  hasLowercase,
+  hasMinimumLength,
+  hasNoSpaces,
+  hasNumber,
+  hasSpecialChar,
+  hasUppercase,
+  Rule
+} from '../rules';
+
+export function useRules(
+  rules: Rule[],
+  password: string,
+  minimumLength: number
+) {
+  const [compliant, setCompliant] = useState<{ [key in Rule]?: boolean }>(
+    rules.reduce(
+      (obj, rule) => checkRule(obj, rule, password, minimumLength),
+      {}
+    )
+  );
+
+  useEffect(() => {
+    setCompliant(
+      rules.reduce(
+        (obj, rule) => checkRule(obj, rule, password, minimumLength),
+        {}
+      )
+    );
+  }, [password, rules, setCompliant, minimumLength]);
+
+  return compliant;
+}
+
+export function checkRule(
+  obj: Record<string, boolean>,
+  rule: Rule,
+  value: string,
+  minimumLength: number
+) {
+  switch (rule) {
+    case 'lowercase':
+      return { ...obj, [rule]: hasLowercase(value) };
+    case 'uppercase':
+      return { ...obj, [rule]: hasUppercase(value) };
+    case 'number':
+      return { ...obj, [rule]: hasNumber(value) };
+    case 'specialChar':
+      return { ...obj, [rule]: hasSpecialChar(value) };
+    case 'minimumLength':
+      return { ...obj, [rule]: hasMinimumLength(minimumLength, value) };
+    case 'noSpace':
+      return { ...obj, [rule]: hasNoSpaces(value) };
+  }
+}

--- a/src/form/NewPasswordInput/__snapshots__/NewPasswordInput.test.tsx.snap
+++ b/src/form/NewPasswordInput/__snapshots__/NewPasswordInput.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: NewPasswordInput ui: Component: NewPasswordInput => ui => default 1`] = `
+<Fragment>
+  <Input
+    onChange={[MockFunction]}
+    type="password"
+    value="test"
+  />
+  <PasswordStrength
+    password="test"
+    rules={
+      Array [
+        "lowercase",
+        "uppercase",
+        "number",
+        "specialChar",
+        "minimumLength",
+        "noSpace",
+      ]
+    }
+  />
+</Fragment>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,11 @@ export {
   default as RadioGroup,
   JarbRadioGroup
 } from './form/RadioGroup/RadioGroup';
+export {
+  default as NewPasswordInput,
+  JarbNewPasswordInput,
+  isStrongPassword
+} from './form/NewPasswordInput/NewPasswordInput';
 
 // Table
 export { EpicTable } from './table/EpicTable/EpicTable';


### PR DESCRIPTION
There should be an input element that displays the strength of a 
password using some kind of progress bar and a list of requirements for 
the password.

Added NewPasswordInput component.

Closes #418