### PR TITLE
improvement: optional callback to display selected item(s) in ModalPicker

### DIFF
--- a/src/core/AsyncList/__snapshots__/AsyncList.test.tsx.snap
+++ b/src/core/AsyncList/__snapshots__/AsyncList.test.tsx.snap
@@ -10,7 +10,9 @@ exports[`Component: Async|AsyncList ui 1`] = `
         Object {
           "active": true,
           "email": "admin@42.nl",
+          "firstName": "admin",
           "id": 42,
+          "lastName": "user",
           "roles": Array [
             "ADMIN",
           ],
@@ -18,7 +20,9 @@ exports[`Component: Async|AsyncList ui 1`] = `
         Object {
           "active": false,
           "email": "coordinator@42.nl",
+          "firstName": "coordinator",
           "id": 777,
+          "lastName": "user",
           "roles": Array [
             "ADMIN",
             "USER",
@@ -27,7 +31,9 @@ exports[`Component: Async|AsyncList ui 1`] = `
         Object {
           "active": false,
           "email": "user@42.nl",
+          "firstName": "test",
           "id": 1337,
+          "lastName": "user",
           "roles": Array [
             "USER",
           ],

--- a/src/core/AsyncPage/__snapshots__/AsyncPage.test.tsx.snap
+++ b/src/core/AsyncPage/__snapshots__/AsyncPage.test.tsx.snap
@@ -11,7 +11,9 @@ exports[`Component: AsyncPage ui 1`] = `
           Object {
             "active": true,
             "email": "admin@42.nl",
+            "firstName": "admin",
             "id": 42,
+            "lastName": "user",
             "roles": Array [
               "ADMIN",
             ],
@@ -19,7 +21,9 @@ exports[`Component: AsyncPage ui 1`] = `
           Object {
             "active": false,
             "email": "coordinator@42.nl",
+            "firstName": "coordinator",
             "id": 777,
+            "lastName": "user",
             "roles": Array [
               "ADMIN",
               "USER",
@@ -28,7 +32,9 @@ exports[`Component: AsyncPage ui 1`] = `
           Object {
             "active": false,
             "email": "user@42.nl",
+            "firstName": "test",
             "id": 1337,
+            "lastName": "user",
             "roles": Array [
               "USER",
             ],

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
@@ -10,11 +10,13 @@ describe('Component: ModalPickerOpener', () => {
   function setup({
     hasValues = false,
     withTooltip = false,
-    alignButton
+    alignButton,
+    hasDisplayValues = false
   }: {
     hasValues?: boolean;
     withTooltip?: boolean;
     alignButton?: ButtonAlignment;
+    hasDisplayValues?: boolean;
   }) {
     const openModalSpy = jest.fn();
     const values = hasValues ? adminUser.email : undefined;
@@ -29,6 +31,11 @@ describe('Component: ModalPickerOpener', () => {
         label="Best friend"
         values={values}
         alignButton={alignButton}
+        displayValues={
+          hasDisplayValues
+            ? (value: string) => <span>{value.toUpperCase()}</span>
+            : undefined
+        }
       />
     );
 
@@ -92,6 +99,16 @@ describe('Component: ModalPickerOpener', () => {
       });
       expect(toJson(modalPickerOpener)).toMatchSnapshot(
         'Component: ModalPickerOpener => ui => button aligned left with values'
+      );
+    });
+
+    test('custom display values', () => {
+      const { modalPickerOpener } = setup({
+        hasValues: true,
+        hasDisplayValues: true
+      });
+      expect(toJson(modalPickerOpener)).toMatchSnapshot(
+        'Component: ModalPickerOpener => ui => custom display values'
       );
     });
   });

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -5,7 +5,11 @@ import { useComponentOverflow } from './useComponentOverflow/useComponentOverflo
 import { ButtonAlignment } from '../types';
 import classNames from 'classnames';
 
-interface Props {
+export type DisplayValues<T> = (
+  values?: T | T[] | React.ReactNode
+) => React.ReactNode;
+
+interface Props<T> {
   /**
    * Function to open the modal, called when the button is clicked.
    */
@@ -17,9 +21,15 @@ interface Props {
   label: React.ReactNode;
 
   /**
-   * The display of selected item(s).
+   * The selected item(s).
    */
-  values?: React.ReactNode;
+  values?: T | T[] | React.ReactNode;
+
+  /**
+   * Optionally callback to display the selected item(s).
+   * @param values
+   */
+  displayValues?: DisplayValues<T>;
 
   /**
    * Optionally the position the button should be aligned to
@@ -28,8 +38,8 @@ interface Props {
   alignButton?: ButtonAlignment;
 }
 
-export function ModalPickerOpener(props: Props) {
-  const { openModal, label, values, alignButton } = props;
+export function ModalPickerOpener<T>(props: Props<T>) {
+  const { openModal, label, values, displayValues, alignButton } = props;
 
   const ref = useRef<HTMLElement>(null);
 
@@ -42,15 +52,17 @@ export function ModalPickerOpener(props: Props) {
       alignButton === 'left' || (alignButton === 'right' && !values)
   });
 
-  const truncatorClassName = classNames('text-truncate', 'position-relative', {
-    'ml-1': alignButton === 'left',
-    'mr-1': alignButton !== 'left'
+  const buttonClassName = classNames('flex-grow-0', 'flex-shrink-0', {
+    'mr-1': values && alignButton === 'left',
+    'ml-1': values && alignButton !== 'left'
   });
 
   return (
     <div className={wrapperClassName}>
-      {values ? (
-        <span className={truncatorClassName} ref={ref}>
+      {displayValues ? (
+        displayValues(values)
+      ) : values ? (
+        <span className="text-truncate position-relative" ref={ref}>
           {isOverflowing ? (
             <Tooltip
               content={values}
@@ -63,11 +75,7 @@ export function ModalPickerOpener(props: Props) {
           {values}
         </span>
       ) : null}
-      <Button
-        color="primary"
-        onClick={openModal}
-        className="flex-grow-0 flex-shrink-0"
-      >
+      <Button color="primary" onClick={openModal} className={buttonClassName}>
         {label}
       </Button>
     </div>

--- a/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
+++ b/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Component: ModalPickerOpener ui button aligned left with values: Compon
   className="d-flex align-items-center flex-row-reverse justify-content-end"
 >
   <span
-    className="text-truncate position-relative ml-1"
+    className="text-truncate position-relative"
   >
     admin@42.nl
   </span>
   <Button
-    className="flex-grow-0 flex-shrink-0"
+    className="flex-grow-0 flex-shrink-0 mr-1"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -40,12 +40,12 @@ exports[`Component: ModalPickerOpener ui button aligned right with values: Compo
   className="d-flex align-items-center justify-content-between"
 >
   <span
-    className="text-truncate position-relative mr-1"
+    className="text-truncate position-relative"
   >
     admin@42.nl
   </span>
   <Button
-    className="flex-grow-0 flex-shrink-0"
+    className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -70,12 +70,30 @@ exports[`Component: ModalPickerOpener ui button aligned right without values: Co
 </div>
 `;
 
+exports[`Component: ModalPickerOpener ui custom display values: Component: ModalPickerOpener => ui => custom display values 1`] = `
+<div
+  className="d-flex align-items-center"
+>
+  <span>
+    ADMIN@42.NL
+  </span>
+  <Button
+    className="flex-grow-0 flex-shrink-0 ml-1"
+    color="primary"
+    onClick={[MockFunction]}
+    tag="button"
+  >
+    Best friend
+  </Button>
+</div>
+`;
+
 exports[`Component: ModalPickerOpener ui tooltip: Component: ModalPickerOpener => ui => with tooltip 1`] = `
 <div
   className="d-flex align-items-center"
 >
   <span
-    className="text-truncate position-relative mr-1"
+    className="text-truncate position-relative"
   >
     <Tooltip
       className="w-100 h-100 position-absolute"
@@ -87,7 +105,7 @@ exports[`Component: ModalPickerOpener ui tooltip: Component: ModalPickerOpener =
     admin@42.nl
   </span>
   <Button
-    className="flex-grow-0 flex-shrink-0"
+    className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -102,12 +120,12 @@ exports[`Component: ModalPickerOpener ui with values: Component: ModalPickerOpen
   className="d-flex align-items-center"
 >
   <span
-    className="text-truncate position-relative mr-1"
+    className="text-truncate position-relative"
   >
     admin@42.nl
   </span>
   <Button
-    className="flex-grow-0 flex-shrink-0"
+    className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"
     onClick={[MockFunction]}
     tag="button"

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -257,6 +257,44 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
       </Form>
     );
   })
+  .add('display values', () => {
+    const [value, setValue] = useState<User[] | undefined>([]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple<User>
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          fetchOptions={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+          }
+          optionForValue={(user: User) => user.email}
+          value={value}
+          onChange={setValue}
+          displayValues={(users?: User[]) => {
+            return users ? (
+              <>
+                {users.map((user, index) => (
+                  <>
+                    {index > 0 ? ', ' : ''}
+                    {user.roles.some(role => role === 'ADMIN') ? (
+                      <Icon icon="supervised_user_circle" />
+                    ) : (
+                      <Icon icon="supervisor_account" />
+                    )}
+                    {user.firstName}
+                    <b>{user.lastName}</b>
+                  </>
+                ))}
+              </>
+            ) : null;
+          }}
+        />
+      </Form>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -33,7 +33,8 @@ describe('Component: ModalPickerMultiple', () => {
     canSearch = undefined,
     hasLabel = true,
     spyOnRenderOptions,
-    alignButton
+    alignButton,
+    hasDisplayValues = false
   }: {
     value?: User[];
     showAddButton: boolean;
@@ -41,6 +42,7 @@ describe('Component: ModalPickerMultiple', () => {
     hasLabel?: boolean;
     spyOnRenderOptions?: boolean;
     alignButton?: ButtonAlignment;
+    hasDisplayValues?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -77,7 +79,14 @@ describe('Component: ModalPickerMultiple', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      alignButton
+      alignButton,
+      displayValues: hasDisplayValues
+        ? (users?: User[]) => (
+            <span>
+              {users ? users.map(user => user.id).join(', ') : 'none selected'}
+            </span>
+          )
+        : undefined
     };
 
     if (hasLabel) {
@@ -228,21 +237,32 @@ describe('Component: ModalPickerMultiple', () => {
     it('should render button left', () => {
       setup({ value: [adminUser], showAddButton: false, alignButton: 'left' });
       expect(toJson(modalPickerMultiple)).toMatchSnapshot(
-        'Component: ModalPickerSingle => ui => should render button left'
+        'Component: ModalPickerMultiple => ui => should render button left'
       );
     });
 
     it('should render button right without value', () => {
       setup({ value: undefined, showAddButton: false, alignButton: 'right' });
       expect(toJson(modalPickerMultiple)).toMatchSnapshot(
-        'Component: ModalPickerSingle => ui => should render button right without value'
+        'Component: ModalPickerMultiple => ui => should render button right without value'
       );
     });
 
     it('should render button right with value', () => {
       setup({ value: [adminUser], showAddButton: false, alignButton: 'right' });
       expect(toJson(modalPickerMultiple)).toMatchSnapshot(
-        'Component: ModalPickerSingle => ui => should render button right with value'
+        'Component: ModalPickerMultiple => ui => should render button right with value'
+      );
+    });
+
+    it('should use custom display function to render values', () => {
+      setup({
+        value: [adminUser],
+        showAddButton: false,
+        hasDisplayValues: true
+      });
+      expect(toJson(modalPickerMultiple)).toMatchSnapshot(
+        'Component: ModalPickerMultiple => ui => should use custom display function to render values'
       );
     });
   });

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -17,7 +17,10 @@ import {
   RenderOptions,
   RenderOptionsOption
 } from '../../option';
-import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
+import {
+  DisplayValues,
+  ModalPickerOpener
+} from '../ModalPickerOpener/ModalPickerOpener';
 
 interface BaseProps<T> {
   /**
@@ -94,6 +97,11 @@ interface BaseProps<T> {
    * within it's container.
    */
   alignButton?: ButtonAlignment;
+
+  /**
+   * Optionally callback to display the selected items.
+   */
+  displayValues?: DisplayValues<T>;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -249,8 +257,26 @@ export default class ModalPickerMultiple<T> extends React.Component<
       className = '',
       optionForValue,
       alignButton,
+      displayValues,
       ...props
     } = this.props;
+
+    const modalPickerOpenerProps = {
+      openModal: () => this.openModal(),
+      label: placeholder,
+      alignButton,
+      displayValues,
+      values:
+        value && value.length > 0 ? (
+          displayValues ? (
+            value
+          ) : (
+            <>{value.map(optionForValue).join(', ')}</>
+          )
+        ) : (
+          undefined
+        )
+    };
 
     return (
       <FormGroup className={className} color={color}>
@@ -258,18 +284,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
           <Label for={props.id}>{props.label}</Label>
         ) : null}
 
-        <ModalPickerOpener
-          openModal={() => this.openModal()}
-          label={placeholder}
-          values={
-            value && value.length > 0 ? (
-              <>{value.map(optionForValue).join(', ')}</>
-            ) : (
-              undefined
-            )
-          }
-          alignButton={alignButton}
-        />
+        <ModalPickerOpener {...modalPickerOpenerProps} />
 
         {error}
         {this.renderModal()}

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: ModalPickerMultiple ui should render button left: Component: ModalPickerSingle => ui => should render button left 1`] = `
+exports[`Component: ModalPickerMultiple ui should render button left: Component: ModalPickerMultiple => ui => should render button left 1`] = `
 <FormGroup
   className=""
   color="success"
@@ -89,7 +89,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
 </FormGroup>
 `;
 
-exports[`Component: ModalPickerMultiple ui should render button right with value: Component: ModalPickerSingle => ui => should render button right with value 1`] = `
+exports[`Component: ModalPickerMultiple ui should render button right with value: Component: ModalPickerMultiple => ui => should render button right with value 1`] = `
 <FormGroup
   className=""
   color="success"
@@ -178,7 +178,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
 </FormGroup>
 `;
 
-exports[`Component: ModalPickerMultiple ui should render button right without value: Component: ModalPickerSingle => ui => should render button right without value 1`] = `
+exports[`Component: ModalPickerMultiple ui should render button right without value: Component: ModalPickerMultiple => ui => should render button right without value 1`] = `
 <FormGroup
   className=""
   color="success"
@@ -369,6 +369,104 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
       <React.Fragment>
         admin@42.nl, user@42.nl
       </React.Fragment>
+    }
+  />
+  Some error
+  <ModalPicker
+    canSearch={true}
+    closeModal={[Function]}
+    fetchOptions={[Function]}
+    isOpen={false}
+    modalSaved={[Function]}
+    page={
+      Object {
+        "content": Array [],
+        "first": true,
+        "last": true,
+        "number": 0,
+        "numberOfElements": 0,
+        "size": 0,
+        "totalElements": 0,
+        "totalPages": 0,
+      }
+    }
+    pageChanged={[Function]}
+    placeholder="Select your best friend"
+    query=""
+    saveButtonEnabled={true}
+  >
+    <Row
+      className="mt-3"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <EmptyModal
+          userHasSearched={false}
+        />
+      </Col>
+    </Row>
+  </ModalPicker>
+</FormGroup>
+`;
+
+exports[`Component: ModalPickerMultiple ui should use custom display function to render values: Component: ModalPickerMultiple => ui => should use custom display function to render values 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best Friend
+  </Label>
+  <ModalPickerOpener
+    displayValues={[Function]}
+    label="Select your best friend"
+    openModal={[Function]}
+    values={
+      Array [
+        Object {
+          "active": true,
+          "email": "admin@42.nl",
+          "firstName": "admin",
+          "id": 42,
+          "lastName": "user",
+          "roles": Array [
+            "ADMIN",
+          ],
+        },
+      ]
     }
   />
   Some error

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -239,6 +239,39 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
       </Form>
     );
   })
+  .add('display values', () => {
+    const [value, setValue] = useState<User | undefined>(undefined);
+
+    return (
+      <Form>
+        <ModalPickerSingle
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          optionForValue={(user: User) => user.email}
+          fetchOptions={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+          }
+          value={value}
+          onChange={setValue}
+          displayValues={(user?: User) => {
+            return user ? (
+              <>
+                {user.roles.some(role => role === 'ADMIN') ? (
+                  <Icon icon="supervised_user_circle" />
+                ) : (
+                  <Icon icon="supervisor_account" />
+                )}
+                {user.firstName}
+                <b>{user.lastName}</b>
+              </>
+            ) : null;
+          }}
+        />
+      </Form>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -32,7 +32,8 @@ describe('Component: ModalPickerSingle', () => {
     canSearch = undefined,
     hasLabel = true,
     spyOnRenderOptions,
-    alignButton
+    alignButton,
+    hasDisplayValues = false
   }: {
     value?: User;
     showAddButton: boolean;
@@ -40,6 +41,7 @@ describe('Component: ModalPickerSingle', () => {
     hasLabel?: boolean;
     spyOnRenderOptions?: boolean;
     alignButton?: ButtonAlignment;
+    hasDisplayValues?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -76,7 +78,10 @@ describe('Component: ModalPickerSingle', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      alignButton
+      alignButton,
+      displayValues: hasDisplayValues
+        ? (user?: User) => <span>{user ? user.id : 'none selected'}</span>
+        : undefined
     };
 
     if (hasLabel) {
@@ -196,6 +201,13 @@ describe('Component: ModalPickerSingle', () => {
       setup({ value: adminUser, showAddButton: false, alignButton: 'right' });
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should render button right with value'
+      );
+    });
+
+    it('should use custom display function to render values', () => {
+      setup({ value: adminUser, showAddButton: false, hasDisplayValues: true });
+      expect(toJson(modalPickerSingle)).toMatchSnapshot(
+        'Component: ModalPickerSingle => ui => should use custom display function to render values'
       );
     });
   });

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -16,7 +16,10 @@ import {
   RenderOptions,
   RenderOptionsOption
 } from '../../option';
-import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
+import {
+  DisplayValues,
+  ModalPickerOpener
+} from '../ModalPickerOpener/ModalPickerOpener';
 
 interface BaseProps<T> {
   /**
@@ -93,6 +96,11 @@ interface BaseProps<T> {
    * within it's container.
    */
   alignButton?: ButtonAlignment;
+
+  /**
+   * Optionally callback to display the selected item.
+   */
+  displayValues?: DisplayValues<T>;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -240,8 +248,21 @@ export default class ModalPickerSingle<T> extends React.Component<
       optionForValue,
       className = '',
       alignButton,
+      displayValues,
       ...props
     } = this.props;
+
+    const modalPickerOpenerProps = {
+      openModal: () => this.openModal(),
+      label: placeholder,
+      alignButton,
+      displayValues,
+      values: displayValues
+        ? selected
+        : selected
+        ? optionForValue(selected)
+        : undefined
+    };
 
     return (
       <FormGroup className={className} color={color}>
@@ -249,12 +270,7 @@ export default class ModalPickerSingle<T> extends React.Component<
           <Label for={props.id}>{props.label}</Label>
         ) : null}
 
-        <ModalPickerOpener
-          openModal={() => this.openModal()}
-          label={placeholder}
-          alignButton={alignButton}
-          values={selected ? optionForValue(selected) : undefined}
-        />
+        <ModalPickerOpener {...modalPickerOpenerProps} />
 
         {error}
 

--- a/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
+++ b/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
@@ -406,3 +406,99 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
   </ModalPicker>
 </FormGroup>
 `;
+
+exports[`Component: ModalPickerSingle ui should use custom display function to render values: Component: ModalPickerSingle => ui => should use custom display function to render values 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best Friend
+  </Label>
+  <ModalPickerOpener
+    displayValues={[Function]}
+    label="Select your best friend"
+    openModal={[Function]}
+    values={
+      Object {
+        "active": true,
+        "email": "admin@42.nl",
+        "firstName": "admin",
+        "id": 42,
+        "lastName": "user",
+        "roles": Array [
+          "ADMIN",
+        ],
+      }
+    }
+  />
+  Some error
+  <ModalPicker
+    canSearch={true}
+    closeModal={[Function]}
+    fetchOptions={[Function]}
+    isOpen={false}
+    modalSaved={[Function]}
+    page={
+      Object {
+        "content": Array [],
+        "first": true,
+        "last": true,
+        "number": 0,
+        "numberOfElements": 0,
+        "size": 0,
+        "totalElements": 0,
+        "totalPages": 0,
+      }
+    }
+    pageChanged={[Function]}
+    placeholder="Select your best friend"
+    query=""
+    saveButtonEnabled={false}
+  >
+    <Row
+      className="mt-3"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <EmptyModal
+          userHasSearched={false}
+        />
+      </Col>
+    </Row>
+  </ModalPicker>
+</FormGroup>
+`;

--- a/src/form/RadioGroup/RadioGroup.test.tsx
+++ b/src/form/RadioGroup/RadioGroup.test.tsx
@@ -66,6 +66,8 @@ describe('Component: RadioGroup', () => {
         value: {
           id: -1,
           email: 'none',
+          firstName: 'none',
+          lastName: 'none',
           active: false,
           roles: []
         },

--- a/src/form/Select/Select.test.tsx
+++ b/src/form/Select/Select.test.tsx
@@ -71,6 +71,8 @@ describe('Component: Select', () => {
         value: {
           id: -1,
           email: 'none',
+          firstName: 'none',
+          lastName: 'none',
           active: false,
           roles: []
         },

--- a/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
+++ b/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
@@ -33,7 +33,9 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
             Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -57,7 +59,9 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -89,7 +93,9 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
             Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -113,7 +119,9 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -161,7 +169,9 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
             Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -184,7 +194,9 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -95,7 +97,9 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],
@@ -157,7 +161,9 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
+              "firstName": "admin",
               "id": 42,
+              "lastName": "user",
               "roles": Array [
                 "ADMIN",
               ],

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -409,7 +409,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": true,
                   "email": "admin@42.nl",
+                  "firstName": "admin",
                   "id": 42,
+                  "lastName": "user",
                   "roles": Array [
                     "ADMIN",
                   ],
@@ -417,7 +419,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": false,
                   "email": "coordinator@42.nl",
+                  "firstName": "coordinator",
                   "id": 777,
+                  "lastName": "user",
                   "roles": Array [
                     "ADMIN",
                     "USER",
@@ -426,7 +430,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": false,
                   "email": "user@42.nl",
+                  "firstName": "test",
                   "id": 1337,
+                  "lastName": "user",
                   "roles": Array [
                     "USER",
                   ],
@@ -674,7 +680,9 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": true,
                   "email": "admin@42.nl",
+                  "firstName": "admin",
                   "id": 42,
+                  "lastName": "user",
                   "roles": Array [
                     "ADMIN",
                   ],
@@ -682,7 +690,9 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": false,
                   "email": "coordinator@42.nl",
+                  "firstName": "coordinator",
                   "id": 777,
+                  "lastName": "user",
                   "roles": Array [
                     "ADMIN",
                     "USER",
@@ -691,7 +701,9 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": false,
                   "email": "user@42.nl",
+                  "firstName": "test",
                   "id": 1337,
+                  "lastName": "user",
                   "roles": Array [
                     "USER",
                   ],

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -19,6 +19,8 @@ export function randomUser(): User {
   return {
     id,
     email: `user-${id}@42.nl`,
+    firstName: `user-${id}`,
+    lastName: 'random',
     active: true,
     roles: [UserRole.ADMIN]
   };
@@ -27,6 +29,8 @@ export function randomUser(): User {
 const admin = {
   id: 42,
   email: 'admin@42.nl',
+  firstName: 'admin',
+  lastName: 'user',
   active: true,
   roles: [UserRole.ADMIN]
 };
@@ -36,6 +40,8 @@ export const adminUser = Object.freeze(admin);
 const user = {
   id: 1337,
   email: 'user@42.nl',
+  firstName: 'test',
+  lastName: 'user',
   active: false,
   roles: [UserRole.USER]
 };
@@ -45,6 +51,8 @@ export const userUser = Object.freeze(user);
 const coordinator = {
   id: 777,
   email: 'coordinator@42.nl',
+  firstName: 'coordinator',
+  lastName: 'user',
   active: false,
   roles: [UserRole.ADMIN, UserRole.USER]
 };
@@ -54,6 +62,8 @@ export const coordinatorUser = Object.freeze(coordinator);
 const nobody = {
   id: 999,
   email: 'nobody@42.nl',
+  firstName: 'no',
+  lastName: 'body',
   active: false,
   roles: []
 };

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -1,6 +1,8 @@
 export type User = {
   id: number;
   email: string;
+  firstName: string;
+  lastName: string;
   active: boolean;
   roles: UserRole[];
 };


### PR DESCRIPTION
In some cases you only want to display the button to open the modal of a
ModalPicker, or you want to display another value than you see in the
options (optionForValue).

Added an optional callback property to customize the selected values
display.