### PR TITLE
improvement: LoadingPage now accepts custom height and style.

### DIFF
--- a/src/core/LoadingPage/LoadingPage.stories.tsx
+++ b/src/core/LoadingPage/LoadingPage.stories.tsx
@@ -7,4 +7,10 @@ storiesOf('core|LoadingPage', module)
   .addParameters({ component: LoadingPage })
   .add('default', () => {
     return <LoadingPage className="mt-0" />;
+  })
+  .add('custom height', () => {
+    return <LoadingPage height={200} />;
+  })
+  .add('custom style', () => {
+    return <LoadingPage style={{ backgroundColor: 'red' }} />;
   });

--- a/src/core/LoadingPage/LoadingPage.test.tsx
+++ b/src/core/LoadingPage/LoadingPage.test.tsx
@@ -1,49 +1,35 @@
-/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { act } from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import * as ShowAfter from '../useShowAfter/useShowAfter';
 
 import LoadingPage from './LoadingPage';
 
 describe('Component: LoadingPage', () => {
-  let container: HTMLElement;
+  function setup({ show, height }: { show: boolean; height?: number }) {
+    jest.spyOn(ShowAfter, 'useShowAfter').mockReturnValue(show);
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-    container = document.createElement('div');
-    document.body.appendChild(container);
-  });
+    return shallow(<LoadingPage height={height} />);
+  }
 
-  afterEach(() => {
-    document.body.removeChild(container);
-    // @ts-ignore
-    container = null;
-  });
+  describe('ui', () => {
+    test('default', () => {
+      const loadingPage = setup({ show: true });
 
-  it('should render loading page and show the spinner after 200 milliseconds', () => {
-    act(() => {
-      ReactDOM.render(<LoadingPage />, container);
+      expect(toJson(loadingPage)).toMatchSnapshot();
     });
 
-    expect(container.querySelector('svg')).toBe(null);
+    test('with no spinner because it is not after the timeout', () => {
+      const loadingPage = setup({ show: false });
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
+      expect(toJson(loadingPage)).toMatchSnapshot();
     });
 
-    expect(container.querySelector('svg')).not.toBe(null);
-  });
+    test('with custom height', () => {
+      const loadingPage = setup({ show: true, height: 200 });
 
-  it('should when unmounting cancel the timeout', () => {
-    jest.spyOn(window, 'setTimeout');
-    jest.spyOn(window, 'clearTimeout');
-
-    act(() => {
-      ReactDOM.render(<LoadingPage />, container);
+      expect(toJson(loadingPage)).toMatchSnapshot();
     });
-
-    ReactDOM.unmountComponentAtNode(container);
-
-    expect(window.clearTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/LoadingPage/LoadingPage.tsx
+++ b/src/core/LoadingPage/LoadingPage.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
+import React, { CSSProperties } from 'react';
 import Spinner from '../Spinner/Spinner';
+import { useShowAfter } from '../useShowAfter/useShowAfter';
 
 interface Props {
   /**
@@ -8,6 +9,18 @@ interface Props {
    * Useful for styling the component.
    */
   className?: string;
+
+  /**
+   * Optional extra CSSProperties you want to add to the component.
+   * Useful for styling the component.
+   */
+  style?: CSSProperties;
+
+  /**
+   * Optionally a height, by default this will be the full height
+   * of the view port.
+   */
+  height?: number;
 }
 
 /**
@@ -15,25 +28,22 @@ interface Props {
  *
  * Use this for showing a loading indicator when navigating to pages that fetch data.
  */
-export default function LoadingPage({ className }: Props) {
+export default function LoadingPage({ className, style, height }: Props) {
   const size = 150;
 
-  const [showSpinner, setShowSpinner] = useState(false);
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setShowSpinner(true);
-    }, 200);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, []);
+  const showSpinner = useShowAfter(200);
 
   return (
-    <div className={classNames('loading-page', className)}>
+    <div className={classNames('loading-page', className)} style={style}>
       <div
-        className="vh-100 d-flex flex-column justify-content-center align-items-center"
-        style={{ marginTop: -(size / 2) }}
+        className={classNames(
+          'd-flex flex-column justify-content-center align-items-center',
+          { 'vh-100': height === undefined }
+        )}
+        style={{
+          marginTop: height === undefined ? -(size / 2) : undefined,
+          height
+        }}
       >
         {showSpinner && <Spinner size={size} color="#f0ad4e" />}
       </div>

--- a/src/core/LoadingPage/__snapshots__/LoadingPage.test.tsx.snap
+++ b/src/core/LoadingPage/__snapshots__/LoadingPage.test.tsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: LoadingPage ui default 1`] = `
+<div
+  className="loading-page"
+>
+  <div
+    className="d-flex flex-column justify-content-center align-items-center vh-100"
+    style={
+      Object {
+        "height": undefined,
+        "marginTop": -75,
+      }
+    }
+  >
+    <Spinner
+      color="#f0ad4e"
+      size={150}
+    />
+  </div>
+</div>
+`;
+
+exports[`Component: LoadingPage ui with custom height 1`] = `
+<div
+  className="loading-page"
+>
+  <div
+    className="d-flex flex-column justify-content-center align-items-center"
+    style={
+      Object {
+        "height": 200,
+        "marginTop": undefined,
+      }
+    }
+  >
+    <Spinner
+      color="#f0ad4e"
+      size={150}
+    />
+  </div>
+</div>
+`;
+
+exports[`Component: LoadingPage ui with no spinner because it is not after the timeout 1`] = `
+<div
+  className="loading-page"
+>
+  <div
+    className="d-flex flex-column justify-content-center align-items-center vh-100"
+    style={
+      Object {
+        "height": undefined,
+        "marginTop": -75,
+      }
+    }
+  />
+</div>
+`;

--- a/src/core/useShowAfter/useShowAfter.test.tsx
+++ b/src/core/useShowAfter/useShowAfter.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { useShowAfter } from './useShowAfter';
+
+describe('useShowAfter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  test('that the  useShowAfter starts with false but changes to true after the after parameter amount of milliseconds', () => {
+    const { result } = renderHook(() => useShowAfter(200), {
+      initialProps: false
+    });
+
+    expect(result.current).toBe(false);
+
+    // Should after 199 milliseconds still be false
+    act(() => {
+      jest.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe(false);
+
+    // Should after 200 milliseconds become true
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  test('cleanup: that window clearTimeout is called', () => {
+    const { unmount } = renderHook(() => useShowAfter(200));
+
+    const spy = jest.spyOn(window, 'clearTimeout');
+
+    unmount();
+
+    expect(window.clearTimeout).toHaveBeenCalledTimes(1);
+
+    (spy as jest.Mock).mockClear();
+  });
+});

--- a/src/core/useShowAfter/useShowAfter.tsx
+++ b/src/core/useShowAfter/useShowAfter.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns `false` but after a predetermined `after` time returns
+ * `true`.
+ *
+ * Useful for wanting to show content only after a time. For example
+ * to not show a loading spinner to soon, only
+ * after it takes a while.
+ *
+ * @param number after The amount of time in milliseconds after which the return value should become `true`.
+ */
+export function useShowAfter(after: number): boolean {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setShow(true);
+    }, after);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [after]);
+
+  return show;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { default as SearchInput } from './core/SearchInput/SearchInput';
 export { default as Pager } from './core/Pager/Pager';
 export { OpenCloseModal } from './core/OpenCloseModal/OpenCloseModal';
 export { default as Popover } from './core/Popover/Popover';
+export { useShowAfter } from './core/useShowAfter/useShowAfter';
 
 // Form
 export { default as withJarb } from './form/withJarb/withJarb';


### PR DESCRIPTION
When the new height property is optional. When it is provided the height
of the popover is no longer the fullscreen.

Refactored the hook `LoadingPage` used to its own file, and called if
`useShowAfter`. Also exposing the `useShowAfter` hook now so users of
our library can use it as well.

Closes #431