### PR TITLE
improvement: RadioGroup, and the modalpickers can now clear the value.

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -110,7 +110,10 @@ Here is a JSON notation containing all keys and default translations:
   "ModalPicker": {
     "SEARCH": "Search...",
     "CANCEL": "Cancel",
-    "SELECT": "Select"
+    "SELECT": "Select",
+  },
+  "ModalPickerOpener": {
+    "CLEAR": "Clear",
   },
   "Select": {
     "LOADING": "Loading..."
@@ -158,7 +161,8 @@ Here is a JSON notation containing all keys and default translations:
     "LOADING": "Loading...",
   },
   "RadioGroup": {
-    "LOADING": "Loading..."
+    "LOADING": "Loading...",
+    "CLEAR": "Clear"
   },
   "OpenCloseModal": {
     "CANCEL": "Cancel",

--- a/src/core/TextButton/TextButton.stories.tsx
+++ b/src/core/TextButton/TextButton.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import TextButton from './TextButton';
+
+storiesOf('core|buttons/TextButton', module)
+  .addParameters({ component: TextButton })
+  .add('default', () => {
+    return (
+      <div className="text-center mt-5">
+        <TextButton onClick={action('onClick')}>Clear</TextButton>
+      </div>
+    );
+  });

--- a/src/core/TextButton/TextButton.test.tsx
+++ b/src/core/TextButton/TextButton.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import TextButton from './TextButton';
+
+describe('component: TextButton', () => {
+  function setup({ className }: { className?: string }) {
+    const onClickSpy = jest.fn();
+    const textButton = shallow(
+      <TextButton onClick={onClickSpy} className={className}>
+        Clear
+      </TextButton>
+    );
+
+    return {
+      textButton,
+      onClickSpy
+    };
+  }
+
+  describe('ui', () => {
+    test('standard', () => {
+      const { textButton } = setup({});
+
+      expect(toJson(textButton)).toMatchSnapshot();
+    });
+
+    test('with custom classname', () => {
+      const { textButton } = setup({ className: 'yolo' });
+
+      expect(toJson(textButton)).toMatchSnapshot();
+    });
+  });
+
+  describe('events', () => {
+    it('should when clicked call the onClick callback prop', () => {
+      const { textButton, onClickSpy } = setup({});
+
+      const event = new Event('click');
+
+      // @ts-ignore
+      textButton
+        .find('u')
+        .props()
+        // @ts-ignore
+        .onClick(event);
+
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+      expect(onClickSpy).toHaveBeenCalledWith(event);
+    });
+  });
+});

--- a/src/core/TextButton/TextButton.tsx
+++ b/src/core/TextButton/TextButton.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from 'react';
+
+type Props = {
+  /**
+   * Callback for what needs to happen when the button is clicked.
+   */
+  onClick: (event: React.MouseEvent<HTMLElement>) => any;
+
+  /**
+   * The text of the TextButton
+   */
+  children: ReactNode;
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
+};
+
+/**
+ * The TextButton component is a special type of button which shows
+ * like a styled text.
+ */
+export default function TextButton({ onClick, children, className }: Props) {
+  return (
+    <u
+      role="button"
+      className={`align-self-center clickable font-weight-lighter ${className ??
+        ''}`}
+      onClick={onClick}
+    >
+      {children}
+    </u>
+  );
+}

--- a/src/core/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/src/core/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`component: TextButton ui standard 1`] = `
+<u
+  className="align-self-center clickable font-weight-lighter "
+  onClick={[MockFunction]}
+  role="button"
+>
+  Clear
+</u>
+`;
+
+exports[`component: TextButton ui with custom classname 1`] = `
+<u
+  className="align-self-center clickable font-weight-lighter yolo"
+  onClick={[MockFunction]}
+  role="button"
+>
+  Clear
+</u>
+`;

--- a/src/form/ColorPicker/ColorPicker.test.tsx
+++ b/src/form/ColorPicker/ColorPicker.test.tsx
@@ -185,7 +185,7 @@ describe('Component: ColorPicker', () => {
 
       // @ts-ignore
       colorPicker
-        .find('u')
+        .find('TextButton')
         .props()
         // @ts-ignore
         .onClick();

--- a/src/form/ColorPicker/ColorPicker.tsx
+++ b/src/form/ColorPicker/ColorPicker.tsx
@@ -8,6 +8,7 @@ import { Color } from '../types';
 import { doBlur } from '../utils';
 import { t } from '../../utilities/translation/translation';
 import Popover from '../../core/Popover/Popover';
+import TextButton from '../../core/TextButton/TextButton';
 
 interface Text {
   /**
@@ -129,17 +130,16 @@ export default function ColorPicker(props: Props) {
                 style={{ backgroundColor: value, width: 42 }}
               />
             </div>
-            <u
-              role="button"
-              className="align-self-center mx-3 clickable font-weight-lighter"
+            <TextButton
               onClick={() => onColorSelected(undefined)}
+              className="mx-3"
             >
               {t({
                 key: 'ColorPicker.CLEAR',
                 fallback: 'Clear',
                 overrideText: text.clear
               })}
-            </u>
+            </TextButton>
           </div>
         ) : null}
         <Popover

--- a/src/form/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/src/form/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -41,13 +41,12 @@ exports[`Component: ColorPicker ui with selected value 1`] = `
           }
         />
       </div>
-      <u
-        className="align-self-center mx-3 clickable font-weight-lighter"
+      <TextButton
+        className="mx-3"
         onClick={[Function]}
-        role="button"
       >
         Clear
-      </u>
+      </TextButton>
     </div>
     <Popover
       isOpen={false}

--- a/src/form/IconPicker/IconPicker.test.tsx
+++ b/src/form/IconPicker/IconPicker.test.tsx
@@ -187,7 +187,7 @@ describe('Component: IconPicker', () => {
       const { iconPicker, onBlurSpy, onChangeSpy } = setup({ value: 'home' });
 
       iconPicker
-        .find('u')
+        .find('TextButton')
         .props()
         // @ts-ignore
         .onClick();

--- a/src/form/IconPicker/IconPicker.tsx
+++ b/src/form/IconPicker/IconPicker.tsx
@@ -20,6 +20,7 @@ import ContentState from '../../core/ContentState/ContentState';
 import { t } from '../../utilities/translation/translation';
 import Tooltip from '../../core/Tooltip/Tooltip';
 import Popover from '../../core/Popover/Popover';
+import TextButton from '../../core/TextButton/TextButton';
 
 interface Text {
   /**
@@ -162,17 +163,16 @@ export default function IconPicker(props: Props) {
             {value ? (
               <div className="d-flex justify-content-between">
                 <Icon id="icon-picker-value" className="pt-2" icon={value} />
-                <u
-                  role="button"
-                  className="align-self-center mx-3 clickable font-weight-lighter"
+                <TextButton
                   onClick={() => onIconSelected(undefined)}
+                  className="mx-3"
                 >
                   {t({
                     key: 'IconPicker.CLEAR',
                     fallback: 'Clear',
                     overrideText: text.clear
                   })}
-                </u>
+                </TextButton>
               </div>
             ) : null}
             <Popover

--- a/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
+++ b/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
@@ -120,13 +120,12 @@ exports[`Component: IconPicker ui with selected value 1`] = `
         icon="3d_rotation"
         id="icon-picker-value"
       />
-      <u
-        className="align-self-center mx-3 clickable font-weight-lighter"
+      <TextButton
+        className="mx-3"
         onClick={[Function]}
-        role="button"
       >
         Clear
-      </u>
+      </TextButton>
     </div>
     <Popover
       isOpen={false}

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
@@ -19,6 +19,8 @@ describe('Component: ModalPickerOpener', () => {
     hasDisplayValues?: boolean;
   }) {
     const openModalSpy = jest.fn();
+    const onClearSpy = jest.fn();
+
     const values = hasValues ? adminUser.email : undefined;
 
     jest
@@ -30,6 +32,7 @@ describe('Component: ModalPickerOpener', () => {
         openModal={openModalSpy}
         label="Best friend"
         values={values}
+        onClear={onClearSpy}
         alignButton={alignButton}
         displayValues={
           hasDisplayValues
@@ -39,7 +42,7 @@ describe('Component: ModalPickerOpener', () => {
       />
     );
 
-    return { modalPickerOpener, openModalSpy };
+    return { modalPickerOpener, openModalSpy, onClearSpy };
   }
 
   describe('ui', () => {
@@ -125,6 +128,19 @@ describe('Component: ModalPickerOpener', () => {
         .onClick();
 
       expect(openModalSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClear when the clear button is clicked', () => {
+      const { modalPickerOpener, onClearSpy } = setup({ hasValues: true });
+
+      // @ts-ignore
+      modalPickerOpener
+        .find('TextButton')
+        .props()
+        // @ts-ignore
+        .onClick();
+
+      expect(onClearSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -4,10 +4,16 @@ import Tooltip from '../../../core/Tooltip/Tooltip';
 import { useComponentOverflow } from './useComponentOverflow/useComponentOverflow';
 import { ButtonAlignment } from '../types';
 import classNames from 'classnames';
+import { t } from '../../../utilities/translation/translation';
+import TextButton from '../../../core/TextButton/TextButton';
 
 export type DisplayValues<T> = (
   values?: T | T[] | React.ReactNode
 ) => React.ReactNode;
+
+interface Text {
+  clear?: string;
+}
 
 interface Props<T> {
   /**
@@ -19,6 +25,11 @@ interface Props<T> {
    * The label to display on the button.
    */
   label: React.ReactNode;
+
+  /**
+   * Optionally: what needs to happen when the clear button is pressed
+   */
+  onClear?: () => void;
 
   /**
    * The selected item(s).
@@ -36,10 +47,24 @@ interface Props<T> {
    * within it's container.
    */
   alignButton?: ButtonAlignment;
+
+  /**
+   * Optionally customized text within the component.
+   * This text should already be translated.
+   */
+  text?: Text;
 }
 
 export function ModalPickerOpener<T>(props: Props<T>) {
-  const { openModal, label, values, displayValues, alignButton } = props;
+  const {
+    openModal,
+    label,
+    values,
+    displayValues,
+    alignButton,
+    onClear,
+    text = {}
+  } = props;
 
   const ref = useRef<HTMLElement>(null);
 
@@ -75,6 +100,17 @@ export function ModalPickerOpener<T>(props: Props<T>) {
           {values}
         </span>
       ) : null}
+
+      {values && onClear ? (
+        <TextButton onClick={onClear} className="mx-3">
+          {t({
+            overrideText: text.clear,
+            key: 'ModalPickerOpener.CLEAR',
+            fallback: 'Clear'
+          })}
+        </TextButton>
+      ) : null}
+
       <Button color="primary" onClick={openModal} className={buttonClassName}>
         {label}
       </Button>

--- a/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
+++ b/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
@@ -9,6 +9,12 @@ exports[`Component: ModalPickerOpener ui button aligned left with values: Compon
   >
     admin@42.nl
   </span>
+  <TextButton
+    className="mx-3"
+    onClick={[MockFunction]}
+  >
+    Clear
+  </TextButton>
   <Button
     className="flex-grow-0 flex-shrink-0 mr-1"
     color="primary"
@@ -44,6 +50,12 @@ exports[`Component: ModalPickerOpener ui button aligned right with values: Compo
   >
     admin@42.nl
   </span>
+  <TextButton
+    className="mx-3"
+    onClick={[MockFunction]}
+  >
+    Clear
+  </TextButton>
   <Button
     className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"
@@ -77,6 +89,12 @@ exports[`Component: ModalPickerOpener ui custom display values: Component: Modal
   <span>
     ADMIN@42.NL
   </span>
+  <TextButton
+    className="mx-3"
+    onClick={[MockFunction]}
+  >
+    Clear
+  </TextButton>
   <Button
     className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"
@@ -104,6 +122,12 @@ exports[`Component: ModalPickerOpener ui tooltip: Component: ModalPickerOpener =
     </Tooltip>
     admin@42.nl
   </span>
+  <TextButton
+    className="mx-3"
+    onClick={[MockFunction]}
+  >
+    Clear
+  </TextButton>
   <Button
     className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"
@@ -124,6 +148,12 @@ exports[`Component: ModalPickerOpener ui with values: Component: ModalPickerOpen
   >
     admin@42.nl
   </span>
+  <TextButton
+    className="mx-3"
+    onClick={[MockFunction]}
+  >
+    Clear
+  </TextButton>
   <Button
     className="flex-grow-0 flex-shrink-0 ml-1"
     color="primary"

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -427,6 +427,24 @@ describe('Component: ModalPickerMultiple', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([adminUser, userUser]);
     });
 
+    it('should when the user clicks the clear button clear the value', () => {
+      const value = [adminUser, userUser];
+      setup({ value, showAddButton: false });
+
+      modalPickerMultiple.setState({ isOpen: true });
+      modalPickerMultiple.setState({ selected: value });
+
+      // @ts-ignore
+      modalPickerMultiple
+        .find('ModalPickerOpener')
+        .props()
+        // @ts-ignore
+        .onClear();
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+      expect(onChangeSpy).toHaveBeenCalledWith(undefined);
+    });
+
     it('should when the user selects an option store the value', () => {
       setup({ value: [adminUser, coordinatorUser], showAddButton: false });
       modalPickerMultiple.setState({

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -64,7 +64,7 @@ interface BaseProps<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T[]) => void;
+  onChange: (value?: T[]) => void;
 
   /**
    * Optional callback for when the form element is blurred.
@@ -266,6 +266,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
       label: placeholder,
       alignButton,
       displayValues,
+      onClear: () => this.props.onChange(undefined),
       values:
         value && value.length > 0 ? (
           displayValues ? (
@@ -431,6 +432,6 @@ export default class ModalPickerMultiple<T> extends React.Component<
  */
 export const JarbModalPickerMultiple = withJarb<
   any[],
-  any[] | null,
+  any[] | null | undefined,
   Props<any>
 >(ModalPickerMultiple);

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
   <ModalPickerOpener
     alignButton="left"
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values={
       <React.Fragment>
@@ -113,6 +114,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
   <ModalPickerOpener
     alignButton="right"
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values={
       <React.Fragment>
@@ -202,6 +204,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
   <ModalPickerOpener
     alignButton="right"
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
   />
   Some error
@@ -276,6 +279,7 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
 >
   <ModalPickerOpener
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values={
       <React.Fragment>
@@ -364,6 +368,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
   </Label>
   <ModalPickerOpener
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values={
       <React.Fragment>
@@ -453,6 +458,7 @@ exports[`Component: ModalPickerMultiple ui should use custom display function to
   <ModalPickerOpener
     displayValues={[Function]}
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values={
       Array [

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -332,6 +332,23 @@ describe('Component: ModalPickerSingle', () => {
       expect(onChangeSpy).toHaveBeenCalledWith(adminUser);
     });
 
+    it('should when the user clicks the clear button clear the value', () => {
+      setup({ value: adminUser, showAddButton: false });
+
+      modalPickerSingle.setState({ isOpen: true });
+      modalPickerSingle.setState({ selected: adminUser });
+
+      // @ts-ignore
+      modalPickerSingle
+        .find('ModalPickerOpener')
+        .props()
+        // @ts-ignore
+        .onClear();
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+      expect(onChangeSpy).toHaveBeenCalledWith(undefined);
+    });
+
     it('should when the user selects an option store the value', () => {
       setup({ value: adminUser, showAddButton: false });
       modalPickerSingle.setState({

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -63,7 +63,7 @@ interface BaseProps<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T) => void;
+  onChange: (value?: T) => void;
 
   /**
    * Optional callback for when the form element is blurred.
@@ -257,6 +257,7 @@ export default class ModalPickerSingle<T> extends React.Component<
       label: placeholder,
       alignButton,
       displayValues,
+      onClear: () => this.props.onChange(undefined),
       values: displayValues
         ? selected
         : selected

--- a/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
+++ b/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
   <ModalPickerOpener
     alignButton="left"
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values="admin@42.nl"
   />
@@ -109,6 +110,7 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
   <ModalPickerOpener
     alignButton="right"
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values="admin@42.nl"
   />
@@ -194,6 +196,7 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
   <ModalPickerOpener
     alignButton="right"
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
   />
   Some error
@@ -262,6 +265,7 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
 >
   <ModalPickerOpener
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values="admin@42.nl"
   />
@@ -346,6 +350,7 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
   </Label>
   <ModalPickerOpener
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values="admin@42.nl"
   />
@@ -431,6 +436,7 @@ exports[`Component: ModalPickerSingle ui should use custom display function to r
   <ModalPickerOpener
     displayValues={[Function]}
     label="Select your best friend"
+    onClear={[Function]}
     openModal={[Function]}
     values={
       Object {

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -73,8 +73,70 @@ storiesOf('Form|RadioGroup', module)
       </Form>
     );
   })
+  .add('horizontal with clear', () => {
+    const [subject, setSubject] = useState<SubjectOption | undefined>(
+      undefined
+    );
+
+    return (
+      <Form>
+        <Checkbox<SubjectOption>
+          id="subject"
+          label="Subject"
+          placeholder="Please enter your subject"
+          optionForValue={(option: SubjectOption) => option.label}
+          isOptionEnabled={option => option.value !== 'awesome'}
+          options={[
+            { value: 'awesome', label: 'Awesome shit' },
+            { value: 'super', label: 'Super shit' },
+            { value: 'great', label: 'Great shit' },
+            { value: 'good', label: 'good shit' }
+          ]}
+          value={subject}
+          onChange={setSubject}
+          horizontal={true}
+          canClear={true}
+        />
+
+        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+
+        <p>
+          <strong>Disclaimer:</strong> horizontal mode works best when there are
+          not too many items
+        </p>
+      </Form>
+    );
+  })
+  .add('with clear button', () => {
+    const [subject, setSubject] = useState<SubjectOption | undefined>(
+      undefined
+    );
+
+    return (
+      <Form>
+        <Checkbox<SubjectOption>
+          id="subject"
+          label="Subject"
+          placeholder="Please enter your subject"
+          optionForValue={(option: SubjectOption) => option.label}
+          isOptionEnabled={option => option.value !== 'awesome'}
+          options={[
+            { value: 'awesome', label: 'Awesome shit' },
+            { value: 'super', label: 'Super shit' },
+            { value: 'great', label: 'Great shit' },
+            { value: 'good', label: 'good shit' }
+          ]}
+          value={subject}
+          onChange={setSubject}
+          canClear={true}
+        />
+
+        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+      </Form>
+    );
+  })
   .add('fetched options', () => {
-    const [subject, setSubject] = useState<User>(randomUser());
+    const [subject, setSubject] = useState<User | undefined>(randomUser());
 
     return (
       <Form>
@@ -227,7 +289,7 @@ storiesOf('Form|RadioGroup', module)
     );
   })
   .add('default option', () => {
-    const [subject, setSubject] = useState({
+    const [subject, setSubject] = useState<SubjectOption | undefined>({
       value: 'great',
       label: 'Great shit'
     });

--- a/src/form/RadioGroup/RadioGroup.tsx
+++ b/src/form/RadioGroup/RadioGroup.tsx
@@ -15,6 +15,7 @@ import {
 import { doBlur } from '../utils';
 import Loading from '../../core/Loading/Loading';
 import { useOptions } from '../useOptions';
+import TextButton from '../../core/TextButton/TextButton';
 
 export interface Text {
   /**
@@ -22,6 +23,11 @@ export interface Text {
    * to `loading...`
    */
   loadingMessage?: string;
+
+  /**
+   * The text of the clear button
+   */
+  clear?: string;
 }
 
 interface BaseProps<T> {
@@ -38,7 +44,7 @@ interface BaseProps<T> {
   /**
    * Callback for when the form element changes.
    */
-  onChange: (value: T) => void;
+  onChange: (value?: T) => void;
 
   /**
    * Optional callback for when the form element is blurred.
@@ -111,6 +117,13 @@ interface BaseProps<T> {
    * Defaults to `false`
    */
   horizontal?: boolean;
+
+  /**
+   * Whether or not to show a "clear" button.
+   *
+   * Defaults to `false`
+   */
+  canClear?: boolean;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -142,7 +155,8 @@ export default function RadioGroup<T>(props: Props<T>) {
     onBlur,
     optionForValue,
     isOptionEqual,
-    horizontal = false
+    horizontal = false,
+    canClear = false
   } = props;
 
   const { options, loading } = useOptions({
@@ -171,6 +185,7 @@ export default function RadioGroup<T>(props: Props<T>) {
           <em>{placeholder}</em>
         </p>
       ) : null}
+
       {loading ? (
         <Loading>
           {t({
@@ -180,29 +195,43 @@ export default function RadioGroup<T>(props: Props<T>) {
           })}
         </Loading>
       ) : (
-        options.map(option => {
-          const label = optionForValue(option);
+        <>
+          {canClear && value ? (
+            <div className="mb-1">
+              <TextButton onClick={() => onChange(undefined)}>
+                {t({
+                  key: 'RadioGroup.CLEAR',
+                  fallback: 'Clear',
+                  overrideText: text.clear
+                })}
+              </TextButton>
+            </div>
+          ) : null}
 
-          return (
-            <FormGroup key={label} check inline={horizontal}>
-              <Label check>
-                <Input
-                  type="radio"
-                  value={label}
-                  checked={isOptionSelected({
-                    option,
-                    optionForValue,
-                    isOptionEqual,
-                    value
-                  })}
-                  disabled={!isOptionEnabled(option)}
-                  onChange={() => onRadioClicked(option)}
-                />{' '}
-                {label}
-              </Label>
-            </FormGroup>
-          );
-        })
+          {options.map(option => {
+            const label = optionForValue(option);
+
+            return (
+              <FormGroup key={label} check inline={horizontal}>
+                <Label check>
+                  <Input
+                    type="radio"
+                    value={label}
+                    checked={isOptionSelected({
+                      option,
+                      optionForValue,
+                      isOptionEqual,
+                      value
+                    })}
+                    disabled={!isOptionEnabled(option)}
+                    onChange={() => onRadioClicked(option)}
+                  />{' '}
+                  {label}
+                </Label>
+              </FormGroup>
+            );
+          })}
+        </>
       )}
 
       {error}

--- a/src/form/ValuePicker/ValuePicker.tsx
+++ b/src/form/ValuePicker/ValuePicker.tsx
@@ -224,7 +224,13 @@ export default function ValuePicker<T>(props: Props<T>) {
     const { fetchOptions, multiple, ...rest } = props;
 
     if (totalElements < 4) {
-      return <RadioGroup options={() => fetchOptions('', 1, 3)} {...rest} />;
+      return (
+        <RadioGroup
+          options={() => fetchOptions('', 1, 3)}
+          canClear={true}
+          {...rest}
+        />
+      );
     } else if (totalElements < 11) {
       return <Select options={() => fetchOptions('', 1, 10)} {...rest} />;
     } else {

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -375,6 +375,7 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
         </Label>
         <ModalPickerOpener
           label="Select your best friend"
+          onClear={[Function]}
           openModal={[Function]}
         >
           <div
@@ -646,6 +647,7 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
         </Label>
         <ModalPickerOpener
           label="Select your best friend"
+          onClear={[Function]}
           openModal={[Function]}
         >
           <div
@@ -795,6 +797,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
   placeholder="Select your best friend"
 >
   <RadioGroup
+    canClear={true}
     canSearch={true}
     id="bestFriend"
     label="Best friend"

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { default as SearchInput } from './core/SearchInput/SearchInput';
 export { default as Pager } from './core/Pager/Pager';
 export { OpenCloseModal } from './core/OpenCloseModal/OpenCloseModal';
 export { default as Popover } from './core/Popover/Popover';
+export { default as TextButton } from './core/TextButton/TextButton';
 export { useShowAfter } from './core/useShowAfter/useShowAfter';
 
 // Form


### PR DESCRIPTION
The clear behavior in the `ModalPickerMultiple` and `ModalPickerSingle`
acts and looks and acts the same as the `IconPicker` and `ColorPicker`.

The `RadioGroup` renders the clear button above the radio inputs. But
only when the new `canClear` props is set to `true`.

The `ValuePicker`'s `RadioGroup` will set the `canClear` props to
`true`. This way all `ValuePicker` variants van clear the selection.

Extracted the shared "clear" button into a `TextButton` component which
is also exposed.

Closes #428