### PR TITLE
fix: TextEditor only first line clickable

### DIFF
--- a/src/form/TextEditor/TextEditor.scss
+++ b/src/form/TextEditor/TextEditor.scss
@@ -1,5 +1,5 @@
 .quill {
-  .ql-container {
+  .ql-editor {
     min-height: 132px;
   }
 
@@ -13,7 +13,8 @@
   }
 
   &.is-invalid {
-    .ql-toolbar, .ql-container {
+    .ql-toolbar,
+    .ql-container {
       border-color: $danger;
     }
   }


### PR DESCRIPTION
You can only start typing when you click the first line of the
TextEditor. Clicking anywhere else in the editor block doesn't work.

Changed the min-height rule from container to editor.

Closes #430