### PR TITLE
fix: update RadioGroup options when options change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6303,9 +6303,9 @@
       }
     },
     "@testing-library/react-hooks": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz",
-      "integrity": "sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.3.0.tgz",
+      "integrity": "sha512-rE9geI1+HJ6jqXkzzJ6abREbeud6bLF8OmF+Vyc7gBoPwZAEVBYjbC1up5nNoVfYBhO5HUwdD4u9mTehAUeiyw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.4",
@@ -6686,9 +6686,9 @@
       }
     },
     "@types/react-test-renderer": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.1.tgz",
-      "integrity": "sha512-nCXQokZN1jp+QkoDNmDZwoWpKY8HDczqevIDO4Uv9/s9rbGPbSpy8Uaxa5ixHKkcm/Wt0Y9C3wCxZivh4Al+rQ==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz",
+      "integrity": "sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -6732,9 +6732,9 @@
       "dev": true
     },
     "@types/testing-library__react-hooks": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.1.0.tgz",
-      "integrity": "sha512-QJc1sgH9DD6jbfybzugnP0sY8wPzzIq8sHDBuThzCr2ZEbyHIaAvN9ytx/tHzcWL5MqmeZJqiUm/GsythaGx3g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz",
+      "integrity": "sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==",
       "dev": true,
       "requires": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@storybook/addon-docs": "5.3.13",
     "@storybook/preset-scss": "1.0.2",
     "@storybook/react": "5.3.13",
-    "@testing-library/react-hooks": "3.2.1",
+    "@testing-library/react-hooks": "3.3.0",
     "@types/classnames": "2.2.9",
     "@types/enzyme": "3.10.5",
     "@types/enzyme-adapter-react-16": "1.0.6",

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -5,7 +5,8 @@ import Checkbox, { JarbRadioGroup } from './RadioGroup';
 import { FinalForm, Form, resolveAfter } from '../story-utils';
 import { pageOfUsers, randomUser } from '../../test/fixtures';
 import { User } from '../../test/types';
-import { Icon, Tooltip } from '../..';
+import { Icon, pageOf, Tooltip } from '../..';
+import Toggle from '../Toggle/Toggle';
 
 interface SubjectOption {
   value: string;
@@ -261,6 +262,90 @@ storiesOf('Form|RadioGroup', module)
         />
 
         {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('value based options', () => {
+    const [subject, setSubject] = useState<SubjectOption | undefined>(
+      undefined
+    );
+    const [filtered, setFiltered] = useState(false);
+
+    const allOptions = [
+      { value: 'awesome', label: 'Awesome shit' },
+      { value: 'super', label: 'Super shit' },
+      { value: 'great', label: 'Great shit' },
+      { value: 'good', label: 'good shit' }
+    ];
+
+    const filteredOptions = allOptions.filter(
+      option => option.value !== 'awesome'
+    );
+
+    return (
+      <Form>
+        <div className="mb-3">
+          <Toggle
+            color="primary"
+            onChange={setFiltered}
+            value={filtered}
+            className="mr-2"
+          />
+          Filter options
+        </div>
+        <Checkbox<SubjectOption>
+          id="subject"
+          label="Subject"
+          placeholder="Please enter your subject"
+          optionForValue={(option: SubjectOption) => option.label}
+          isOptionEnabled={option => option.value !== 'awesome'}
+          options={filtered ? filteredOptions : allOptions}
+          value={subject}
+          onChange={setSubject}
+        />
+
+        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('value based async options', () => {
+    const [brand, setBrand] = useState<string>();
+    const [model, setModel] = useState<string>();
+
+    const allOptions = {
+      Audi: ['A1', 'A2', 'A3', 'M5'],
+      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
+      Mercedes: ['Viano', 'Vito', 'Sprinter']
+    };
+
+    return (
+      <Form>
+        <Checkbox
+          id="brand"
+          label="Brand"
+          placeholder="Please select your brand"
+          optionForValue={option => option}
+          options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
+          value={brand}
+          onChange={value => {
+            setBrand(value);
+            setModel(undefined);
+          }}
+        />
+        <Checkbox
+          id="model"
+          label="Model"
+          placeholder={
+            brand ? 'Please select your model' : 'Please select a brand first'
+          }
+          optionForValue={(option: string) => option}
+          options={() =>
+            resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
+          }
+          value={model}
+          onChange={setModel}
+          watch={brand}
+        />
       </Form>
     );
   })

--- a/src/form/RadioGroup/RadioGroup.tsx
+++ b/src/form/RadioGroup/RadioGroup.tsx
@@ -124,6 +124,12 @@ interface BaseProps<T> {
    * Defaults to `false`
    */
   canClear?: boolean;
+
+  /**
+   * Optionally a value to detect changes and trigger
+   * the optionsFetcher to reload the options.
+   */
+  watch?: any;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -156,14 +162,16 @@ export default function RadioGroup<T>(props: Props<T>) {
     optionForValue,
     isOptionEqual,
     horizontal = false,
-    canClear = false
+    canClear = false,
+    watch
   } = props;
 
   const { options, loading } = useOptions({
     optionsOrFetcher: props.options,
     value,
     isOptionEqual,
-    optionForValue
+    optionForValue,
+    watch
   });
 
   const isOptionEnabled = get(props, 'isOptionEnabled', constant(true));

--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -6,7 +6,7 @@ import Select, { JarbSelect } from './Select';
 import { FinalForm, Form, resolveAfter } from '../story-utils';
 import { pageOfUsers, userUser, randomUser } from '../../test/fixtures';
 import { User } from '../../test/types';
-import { Icon, Tooltip } from '../..';
+import { Icon, pageOf, Tooltip } from '../..';
 
 interface SubjectOption {
   value: string;
@@ -128,6 +128,85 @@ storiesOf('Form|Select', module)
             { value: 'good', label: 'good shit' }
           ]}
           onChange={value => action(`You entered ${value}`)}
+        />
+      </Form>
+    );
+  })
+  .add('value based options', () => {
+    const [brand, setBrand] = useState<string>();
+    const [model, setModel] = useState<string>();
+
+    const allOptions = {
+      Audi: ['A1', 'A2', 'A3', 'M5'],
+      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
+      Mercedes: ['Viano', 'Vito', 'Sprinter']
+    };
+
+    return (
+      <Form>
+        <Select
+          id="brand"
+          label="Brand"
+          placeholder="Please select your brand"
+          optionForValue={option => option}
+          options={Object.keys(allOptions)}
+          onChange={value => {
+            setBrand(value);
+            setModel(undefined);
+          }}
+          value={brand}
+        />
+        <Select
+          id="model"
+          label="Model"
+          placeholder={
+            brand ? 'Please select your model' : 'Please select a brand first'
+          }
+          optionForValue={(option: string) => option}
+          options={brand ? allOptions[brand] : []}
+          onChange={value => setModel(value)}
+          value={model}
+        />
+      </Form>
+    );
+  })
+  .add('value based async options', () => {
+    const [brand, setBrand] = useState<string>();
+    const [model, setModel] = useState<string>();
+
+    const allOptions = {
+      Audi: ['A1', 'A2', 'A3', 'M5'],
+      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
+      Mercedes: ['Viano', 'Vito', 'Sprinter']
+    };
+
+    return (
+      <Form>
+        <Select
+          id="brand"
+          label="Brand"
+          placeholder="Please select your brand"
+          optionForValue={option => option}
+          options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
+          onChange={value => {
+            setBrand(value);
+            setModel(undefined);
+          }}
+          value={brand}
+        />
+        <Select
+          id="model"
+          label="Model"
+          placeholder={
+            brand ? 'Please select your model' : 'Please select a brand first'
+          }
+          optionForValue={(option: string) => option}
+          options={() =>
+            resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
+          }
+          onChange={(value: string) => setModel(value)}
+          value={model}
+          watch={brand}
         />
       </Form>
     );

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -99,6 +99,12 @@ interface BaseProps<T> {
    * This text should already be translated.
    */
   text?: Text;
+
+  /**
+   * Optionally a value to detect changes and trigger
+   * the optionsFetcher to reload the options.
+   */
+  watch?: any;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -136,14 +142,16 @@ export default function Select<T>(props: Props<T>) {
     onChange,
     onBlur,
     optionForValue,
-    isOptionEqual
+    isOptionEqual,
+    watch
   } = props;
 
   const { options, loading } = useOptions({
     optionsOrFetcher: props.options,
     value,
     isOptionEqual,
-    optionForValue
+    optionForValue,
+    watch
   });
 
   function selectDefaultOption(option?: HTMLOptionElement | null) {


### PR DESCRIPTION
In Select and RadioGroup, when the options property is an array, the 
options displayed are not updated when the options array changes.
When the options property is an OptionsFetcher that uses an external 
value, there is no possibility to reload the options.

Changed behaviour of options when it's an array.
Added watch property to RadioGroup and Select to watch for external 
changes that influence the result of the OptionsFetcher and trigger the 
fetcher when the value changes.