### PR TITLE
fix: ImageUpload handle File as initial value

### DIFF
--- a/src/form/ImageUpload/ImageUpload.stories.tsx
+++ b/src/form/ImageUpload/ImageUpload.stories.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ImageUpload, { JarbImageUpload, requireImage } from './ImageUpload';
 import { Form, FinalForm } from '../story-utils';
 import { Tooltip, Icon } from '../..';
+import FileInput from '../FileInput/FileInput';
 
 storiesOf('Form|ImageUpload', module)
   .add('rect', () => {
@@ -77,6 +78,32 @@ storiesOf('Form|ImageUpload', module)
           }}
           onChange={value => action(`You entered ${value}`)}
         />
+      </Form>
+    );
+  })
+  .add('File as initial value', () => {
+    const [file, setFile] = useState<File | null>();
+    return (
+      <Form>
+        <FileInput
+          id="image-uploader"
+          label="Choose an image"
+          accept="image/*"
+          onChange={setFile}
+        />
+        {file ? (
+          <ImageUpload
+            id="image-uploader"
+            label="Profile photo"
+            crop={{
+              type: 'rect',
+              width: 500,
+              height: 400
+            }}
+            value={file}
+            onChange={setFile}
+          />
+        ) : null}
       </Form>
     );
   })

--- a/src/form/ImageUpload/ImageUpload.test.tsx
+++ b/src/form/ImageUpload/ImageUpload.test.tsx
@@ -103,6 +103,28 @@ describe('Component: ImageUpload', () => {
         imageSrc: 'maarten.png'
       });
     });
+
+    test('it should show the image when the value is a File', () => {
+      // @ts-ignore
+      const imgUpload = new ImageUpload();
+
+      imgUpload.props = { value: new File([''], 'maarten.png') };
+      jest.spyOn(imgUpload, 'setState').mockImplementation(() => undefined);
+      jest
+        .spyOn(imgUpload, 'readFile')
+        .mockImplementation((file: File, callback: (result: string) => void) =>
+          callback('test')
+        );
+
+      imgUpload.componentDidMount();
+
+      expect(imgUpload.setState).toHaveBeenCalledTimes(1);
+      expect(imgUpload.setState).toHaveBeenCalledWith({
+        mode: 'file-selected',
+        fileName: 'maarten.png',
+        imageSrc: 'test'
+      });
+    });
   });
 
   describe('ui', () => {

--- a/src/form/ImageUpload/ImageUpload.tsx
+++ b/src/form/ImageUpload/ImageUpload.tsx
@@ -178,7 +178,25 @@ export default class ImageUpload extends Component<Props, State> {
         mode: Mode.FILE_SELECTED,
         imageSrc
       });
+    } else if (imageSrc) {
+      this.readFile(imageSrc, (result: string) =>
+        this.setState({
+          mode: Mode.FILE_SELECTED,
+          imageSrc: result,
+          fileName: imageSrc.name
+        })
+      );
     }
+  }
+
+  readFile(file: File, callback: (result: string) => void) {
+    reader.onloadend = () => {
+      /* istanbul ignore else */
+      if (typeof reader.result === 'string') {
+        callback(reader.result);
+      }
+    };
+    reader.readAsDataURL(file);
   }
 
   imgSelected({ target: { files } }: React.ChangeEvent<HTMLInputElement>) {
@@ -186,20 +204,15 @@ export default class ImageUpload extends Component<Props, State> {
     if (files) {
       const file = files[0];
 
-      reader.onloadend = () => {
-        /* istanbul ignore else */
-        if (typeof reader.result === 'string') {
-          this.setState({
-            imageSrc: reader.result,
-            mode: Mode.EDIT,
-            fileName: file.name,
-            rotate: 0,
-            scale: 1
-          });
-        }
-      };
-
-      reader.readAsDataURL(file);
+      this.readFile(file, (result: string) =>
+        this.setState({
+          imageSrc: result,
+          mode: Mode.EDIT,
+          fileName: file.name,
+          rotate: 0,
+          scale: 1
+        })
+      );
     }
   }
 


### PR DESCRIPTION
When ImageUpload is rendered conditionally, the initial value could be
an instance of File. Currently, when that happens, a preview of the
image is not displayed.

Modified componentDidMount to handle File as initial value.