### PR TITLE
improvement: Button / ConfirmButton now support fullWidth

### DIFF
--- a/src/core/Button/Button.stories.tsx
+++ b/src/core/Button/Button.stories.tsx
@@ -127,6 +127,87 @@ storiesOf('core|buttons/Button', module)
       </Row>
     );
   })
+  .add('sizes', () => {
+    return (
+      <Row>
+        <Col xs={12}>
+          <h4>Button</h4>
+          <Button onClick={action('Button clicked')} color="primary" size="sm">
+            sm
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="secondary"
+            size="md"
+          >
+            md
+          </Button>
+          <Button onClick={action('Button clicked')} color="success" size="lg">
+            lg
+          </Button>
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Button in progress</h4>
+          <Button
+            onClick={action('Button clicked')}
+            inProgress={true}
+            color="primary"
+            size="sm"
+          >
+            primary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            inProgress={true}
+            color="secondary"
+            size="md"
+          >
+            secondary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            inProgress={true}
+            color="success"
+            size="lg"
+          >
+            success
+          </Button>
+
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Button disabled</h4>
+          <Button
+            onClick={action('Button clicked')}
+            color="primary"
+            disabled={true}
+            size="sm"
+          >
+            primary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="secondary"
+            disabled={true}
+            size="md"
+          >
+            secondary
+          </Button>
+          <Button
+            onClick={action('Button clicked')}
+            color="success"
+            disabled={true}
+            size="lg"
+          >
+            success
+          </Button>
+
+          <hr />
+        </Col>
+      </Row>
+    );
+  })
   .add('as button with icon', () => {
     return (
       <Row>
@@ -969,6 +1050,47 @@ storiesOf('core|buttons/Button', module)
             color="danger"
             disabled={true}
           />
+          <hr />
+        </Col>
+      </Row>
+    );
+  })
+  .add('full width', () => {
+    return (
+      <Row>
+        <Col xs={12}>
+          <h4>Button</h4>
+          <Button
+            onClick={action('Button clicked')}
+            color="primary"
+            fullWidth={true}
+          >
+            primary
+          </Button>
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Button in progress</h4>
+          <Button
+            onClick={action('Button clicked')}
+            inProgress={true}
+            color="primary"
+            fullWidth={true}
+          >
+            primary
+          </Button>
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <h4>Button disabled</h4>
+          <Button
+            onClick={action('Button clicked')}
+            color="primary"
+            disabled={true}
+            fullWidth={true}
+          >
+            primary
+          </Button>
           <hr />
         </Col>
       </Row>

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -92,6 +92,16 @@ describe('Component: Button', () => {
           expect(toJson(button)).toMatchSnapshot();
         });
       });
+
+      test('full-width', () => {
+        const button = shallow(
+          <Button onClick={jest.fn()} fullWidth={true}>
+            Save
+          </Button>
+        );
+
+        expect(toJson(button)).toMatchSnapshot();
+      });
     });
 
     describe('button with icon', () => {

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -5,7 +5,9 @@ import Spinner from '../Spinner/Spinner';
 import { Icon, IconType } from '../Icon';
 import useShowSpinner from './useShowSpinner';
 
-import { BootstrapSize, Color } from '../types';
+import { Color } from '../types';
+
+export type ButtonSize = 'sm' | 'md' | 'lg';
 
 export type IconPosition = 'left' | 'right';
 
@@ -74,11 +76,19 @@ interface WithIconAndText extends BaseProps {
   outline?: boolean;
 
   /**
-   * Optionally the size of the button, defaults to md.
+   * Optionally the size of the button.
    *
    * Defaults to 'md'.
    */
-  size?: BootstrapSize;
+  size?: ButtonSize;
+
+  /**
+   * Optionally whether or not the button should take the full width
+   * available.
+   *
+   * Defauts to `false`
+   */
+  fullWidth?: boolean;
 }
 
 interface WithIcon extends BaseProps {
@@ -97,6 +107,7 @@ interface WithIcon extends BaseProps {
   children?: never;
   outline?: never;
   size?: never;
+  fullWidth?: never;
 }
 
 interface WithText extends BaseProps {
@@ -111,11 +122,19 @@ interface WithText extends BaseProps {
   outline?: boolean;
 
   /**
-   * Optionally the size of the button, defaults to md.
+   * Optionally the size of the button.
    *
    * Defaults to 'md'.
    */
-  size?: BootstrapSize;
+  size?: ButtonSize;
+
+  /**
+   * Optionally whether or not the button should take the full width
+   * available.
+   *
+   * Defauts to `false`
+   */
+  fullWidth?: boolean;
 
   icon?: never;
   iconPosition?: never;
@@ -158,12 +177,14 @@ export default function Button({
     const children = props.children;
     const outline = 'outline' in props ? props.outline : undefined;
     const size = 'size' in props ? props.size : 'md';
+    const fullWidth = 'fullWidth' in props ? props.fullWidth : false;
 
     const buttonProps = {
       type,
       size,
       color,
-      outline
+      outline,
+      block: fullWidth
     };
 
     return (

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Component: Button ui button disabled is disabled 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     disabled={true}
     onClick={[Function]}
@@ -22,8 +23,26 @@ exports[`Component: Button ui button disabled is enabled 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     disabled={false}
+    onClick={[Function]}
+    size="md"
+    tag="button"
+    type="button"
+  >
+    Save
+  </Button>
+</span>
+`;
+
+exports[`Component: Button ui button full-width 1`] = `
+<span
+  className="button  primary"
+>
+  <Button
+    block={true}
+    color="primary"
     onClick={[Function]}
     size="md"
     tag="button"
@@ -39,6 +58,7 @@ exports[`Component: Button ui button normal inProgress is false 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     size="md"
@@ -55,6 +75,7 @@ exports[`Component: Button ui button normal inProgress is true 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     disabled={true}
     onClick={[Function]}
@@ -76,6 +97,7 @@ exports[`Component: Button ui button outline inProgress is false 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     outline={true}
@@ -93,6 +115,7 @@ exports[`Component: Button ui button outline inProgress is true 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     disabled={true}
     onClick={[Function]}
@@ -115,6 +138,7 @@ exports[`Component: Button ui button size can override size 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     size="sm"
@@ -131,6 +155,7 @@ exports[`Component: Button ui button size use md by default 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     size="md"
@@ -147,6 +172,7 @@ exports[`Component: Button ui button with icon normal inProgress is false 1`] = 
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     size="md"
@@ -167,6 +193,7 @@ exports[`Component: Button ui button with icon normal inProgress is true 1`] = `
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     disabled={true}
     onClick={[Function]}
@@ -188,6 +215,7 @@ exports[`Component: Button ui button with icon normal with icon on the right 1`]
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     size="md"
@@ -208,6 +236,7 @@ exports[`Component: Button ui button with icon outline inProgress is false 1`] =
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     onClick={[Function]}
     outline={true}
@@ -229,6 +258,7 @@ exports[`Component: Button ui button with icon outline inProgress is true 1`] = 
   className="button  primary"
 >
   <Button
+    block={false}
     color="primary"
     disabled={true}
     onClick={[Function]}

--- a/src/core/ConfirmButton/ConfirmButton.stories.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.stories.tsx
@@ -197,4 +197,38 @@ storiesOf('core|buttons/ConfirmButton', module)
         </ConfirmButton>
       </div>
     );
+  })
+  .add('full width', () => {
+    return (
+      <div className="text-center">
+        <p>When not in progress:</p>
+        <ConfirmButton
+          fullWidth={true}
+          onConfirm={action('Accept clicked')}
+          dialogText={
+            <p>
+              Are you sure you want to <strong>delete</strong> the user?
+            </p>
+          }
+        >
+          Delete user
+        </ConfirmButton>
+
+        <hr />
+
+        <p>When in progress:</p>
+        <ConfirmButton
+          fullWidth={true}
+          onConfirm={action('Accept clicked')}
+          inProgress={true}
+          dialogText={
+            <p>
+              Are you sure you want to <strong>delete</strong> the user?
+            </p>
+          }
+        >
+          Delete user
+        </ConfirmButton>
+      </div>
+    );
   });

--- a/src/core/ConfirmButton/ConfirmButton.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.tsx
@@ -5,7 +5,8 @@ import Button, {
   isWithIcon,
   isWithIconAndText,
   isWithText,
-  Props as ButtonProps
+  Props as ButtonProps,
+  ButtonSize
 } from '../Button/Button';
 import { Color } from '../types';
 import IconType from '../Icon/types';
@@ -93,6 +94,21 @@ interface WithIconAndText extends BaseProps {
    * Optionally the text of the button.
    */
   children: React.ReactNode;
+
+  /**
+   * Optionally the size of the button.
+   *
+   * Defaults to 'md'.
+   */
+  size?: ButtonSize;
+
+  /**
+   * Optionally whether or not the button should take the full width
+   * available.
+   *
+   * Defauts to `false`
+   */
+  fullWidth?: boolean;
 }
 
 interface WithIcon extends BaseProps {
@@ -107,6 +123,8 @@ interface WithIcon extends BaseProps {
   iconSize?: number;
 
   children?: never;
+  size?: never;
+  fullWidth?: never;
 }
 
 interface WithText extends BaseProps {
@@ -114,6 +132,21 @@ interface WithText extends BaseProps {
    * Optionally the text of the button.
    */
   children: React.ReactNode;
+
+  /**
+   * Optionally the size of the button.
+   *
+   * Defaults to 'md'.
+   */
+  size?: ButtonSize;
+
+  /**
+   * Optionally whether or not the button should take the full width
+   * available.
+   *
+   * Defauts to `false`
+   */
+  fullWidth?: boolean;
 
   icon?: never;
   iconSize?: never;
@@ -168,6 +201,8 @@ export default function ConfirmButton({
       const withText = buttonProps as WithText | WithIconAndText;
 
       withText.children = props.children;
+      withText.fullWidth = props.fullWidth;
+      withText.size = props.size;
     }
 
     return buttonProps as ButtonProps;

--- a/src/core/SubmitButton/SubmitButton.tsx
+++ b/src/core/SubmitButton/SubmitButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import Button from '../Button/Button';
-import { BootstrapSize } from '../types';
+import Button, { ButtonSize } from '../Button/Button';
 
 export interface Props {
   /**
@@ -11,11 +10,11 @@ export interface Props {
   className?: string;
 
   /**
-   * Optionally the size of the button, defaults to md.
+   * Optionally the size of the button
    *
-   * @default md
+   * Defaults to 'md'.
    */
-  size?: BootstrapSize;
+  size?: ButtonSize;
 
   /**
    * Optional callback for what needs to happen when the button is clicked.


### PR DESCRIPTION
Also improved the type of the `Button` size. It does not support all
bootstrap sizes, it only supports `'sm' | 'md' | 'lg'` the type now
reflects this.

Also added a story for the sizes of the button.

Closes #443