### PR TITLE
improvement: OpenCloseModal now has icons and supports a sticky footer

### DIFF
--- a/src/core/OpenCloseModal/OpenCloseModal.scss
+++ b/src/core/OpenCloseModal/OpenCloseModal.scss
@@ -1,0 +1,19 @@
+.open-close-modal {
+  &--sticky {
+    .modal {
+      height: auto;
+      bottom: 1.75rem;
+      overflow-y: scroll !important;
+
+      .modal-dialog {
+        max-height: 100%;
+      }
+
+      .modal-footer {
+        background-color: $modal-content-bg;
+        position: sticky;
+        bottom: 0;
+      }
+    }
+  }
+}

--- a/src/core/OpenCloseModal/OpenCloseModal.stories.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.stories.tsx
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { Form } from 'react-final-form';
+import { Card } from 'reactstrap';
 
 import { OpenCloseModal } from './OpenCloseModal';
-import { Card } from 'reactstrap';
 import Button from '../Button/Button';
 import RadioGroup from '../../form/RadioGroup/RadioGroup';
+import { TotalForm } from '../../form/FormExample.stories';
+import { range } from 'lodash';
 
 storiesOf('core|OpenCloseModal', module)
   .add('basic', () => {
@@ -48,6 +51,59 @@ storiesOf('core|OpenCloseModal', module)
             ]}
             optionForValue={option => option}
           />
+        </OpenCloseModal>
+      </Card>
+    );
+  })
+  .add('with form', ModalForm)
+  .add('sticky', () => {
+    const [isOpenSticky, setIsOpenSticky] = useState(false);
+    const [isOpenSansSticky, setIsOpenSansSticky] = useState(false);
+
+    return (
+      <Card body>
+        <p>
+          <Button onClick={() => setIsOpenSticky(true)}>With sticky</Button>
+        </p>
+
+        <p>
+          <Button onClick={() => setIsOpenSansSticky(true)}>Sans sticky</Button>
+        </p>
+
+        <OpenCloseModal
+          stickyFooter={true}
+          isOpen={isOpenSticky}
+          onSave={() => setIsOpenSticky(false)}
+          onClose={() => setIsOpenSticky(false)}
+          label="Sticky footer"
+          size="sm"
+        >
+          {range(0, 10).map(number => (
+            <p key={number}>
+              Lorem ipsum, dolor sit amet consectetur adipisicing elit. Omnis
+              modi, facilis officia provident maiores voluptate minus officiis
+              tempora minima blanditiis. Distinctio rem iste omnis inventore
+              ratione facere voluptates quam suscipit!
+            </p>
+          ))}
+        </OpenCloseModal>
+
+        <OpenCloseModal
+          stickyFooter={false}
+          isOpen={isOpenSansSticky}
+          onSave={() => setIsOpenSansSticky(false)}
+          onClose={() => setIsOpenSansSticky(false)}
+          label="No sticky footer"
+          size="sm"
+        >
+          {range(0, 10).map(number => (
+            <p key={number}>
+              Lorem ipsum, dolor sit amet consectetur adipisicing elit. Omnis
+              modi, facilis officia provident maiores voluptate minus officiis
+              tempora minima blanditiis. Distinctio rem iste omnis inventore
+              ratione facere voluptates quam suscipit!
+            </p>
+          ))}
         </OpenCloseModal>
       </Card>
     );
@@ -95,7 +151,7 @@ storiesOf('core|OpenCloseModal', module)
       </Card>
     );
   })
-  .add('custom button text', () => {
+  .add('custom button text and icons', () => {
     const [isOpen, setIsOpen] = useState(false);
     const [choice, setChoice] = useState();
 
@@ -106,7 +162,7 @@ storiesOf('core|OpenCloseModal', module)
 
     function onClose() {
       alert(
-        `Darn! You tricked and the diamond fell in an endless hole in the ground...`
+        `Darn! You tripped and the diamond fell in an endless hole in the ground...`
       );
       setIsOpen(false);
     }
@@ -120,7 +176,10 @@ storiesOf('core|OpenCloseModal', module)
         <OpenCloseModal
           isOpen={isOpen}
           onClose={onClose}
+          cancelIcon="360"
           onSave={onSave}
+          saveIcon="attach_money"
+          modalBodyClassName="bg-warning"
           label="It's a special gift!"
           text={{
             save: 'Confirm',
@@ -141,3 +200,57 @@ storiesOf('core|OpenCloseModal', module)
       </Card>
     );
   });
+
+export function ModalForm() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  async function onSave() {
+    action('save button was clicked');
+
+    await new Promise(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, 2000);
+    });
+
+    setIsOpen(false);
+  }
+
+  function onClose() {
+    action('modal was closed');
+    setIsOpen(false);
+  }
+
+  return (
+    <Card body>
+      <Button onClick={() => setIsOpen(true)}>Open form</Button>
+
+      <Form onSubmit={onSave}>
+        {({ submitting, handleSubmit }) => (
+          <OpenCloseModal
+            isOpen={isOpen}
+            inProgress={submitting}
+            onClose={onClose}
+            onSave={handleSubmit}
+            label="Form example"
+            size="lg"
+          >
+            <TotalForm />
+          </OpenCloseModal>
+        )}
+      </Form>
+
+      <p className="mt-2">
+        Note: the <pre className="d-inline text-info">Form</pre> element should
+        wrap the <pre className="d-inline text-info">OpenCloseModal</pre>
+        not the other way around. Otherwise you cannot use the inProgress prop,
+        and you cannot use submit in onSave.
+      </p>
+
+      <p className="mt-2">
+        Also try to keep the modal forms limited. Sometimes it is better to just
+        create a create / edit page if a form is very large.
+      </p>
+    </Card>
+  );
+}

--- a/src/core/OpenCloseModal/OpenCloseModal.test.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.test.tsx
@@ -16,13 +16,15 @@ describe('Component: OpenCloseModal', () => {
     hasLabel = true,
     hasCustomText = false,
     hasButtons = true,
-    inProgress = undefined
+    inProgress = undefined,
+    stickyFooter = undefined
   }: {
     isOpen?: boolean;
     hasLabel?: boolean;
     hasCustomText?: boolean;
     hasButtons?: boolean;
     inProgress?: boolean;
+    stickyFooter?: boolean;
   }) {
     onCloseSpy = jest.fn();
     onSaveSpy = jest.fn();
@@ -30,6 +32,7 @@ describe('Component: OpenCloseModal', () => {
     const props = {
       isOpen,
       inProgress,
+      stickyFooter,
       onClose: onCloseSpy,
       text: hasCustomText
         ? { cancel: 'Stop please', save: 'Select me' }
@@ -100,6 +103,14 @@ describe('Component: OpenCloseModal', () => {
 
       expect(toJson(openCloseModal)).toMatchSnapshot(
         'Component: OpenCloseModal => ui => in progress'
+      );
+    });
+
+    test('sans sticky footer', () => {
+      setup({ stickyFooter: false });
+
+      expect(toJson(openCloseModal)).toMatchSnapshot(
+        'Component: OpenCloseModal => ui => sans sticky'
       );
     });
   });

--- a/src/core/OpenCloseModal/OpenCloseModal.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.tsx
@@ -4,6 +4,7 @@ import Button from '../Button/Button';
 import { t } from '../../utilities/translation/translation';
 import { BootstrapSize } from '../types';
 import { useBodyFixOnModalClose } from '../useBodyFixOnModalClose/useBodyFixOnModalClose';
+import { IconType } from '../Icon';
 
 type Text = {
   cancel?: string;
@@ -27,6 +28,20 @@ type Props = {
    * Callback for when the modal should close.
    */
   onClose: () => void;
+
+  /**
+   * Optionally the icon of the save button.
+   *
+   * Defaults to `save`
+   */
+  saveIcon?: IconType;
+
+  /**
+   * Optionally icon of the cancel button.
+   *
+   * Defaults to `cancel`
+   */
+  cancelIcon?: IconType;
 
   /**
    * Callback for when the save button is clicked.
@@ -55,10 +70,24 @@ type Props = {
   size?: BootstrapSize;
 
   /**
+   * Whether the footer should stick to the bottom of the modal.
+   * This allows the user to always click the close and save buttons.
+   *
+   * Defaults to `true`.
+   */
+  stickyFooter?: boolean;
+
+  /**
    * Optional extra CSS class you want to add to the component.
    * Useful for styling the component.
    */
   className?: string;
+
+  /**
+   * Optional extra CSS class you want to add to the <ModalBody>.
+   * Useful for styling the component.
+   */
+  modalBodyClassName?: string;
 };
 
 export function OpenCloseModal(props: Props) {
@@ -71,13 +100,20 @@ export function OpenCloseModal(props: Props) {
     label,
     text,
     size,
-    className
+    className,
+    saveIcon = 'save',
+    cancelIcon = 'cancel',
+    stickyFooter = true,
+    modalBodyClassName
   } = props;
 
   useBodyFixOnModalClose(isOpen);
 
   return (
     <Modal
+      wrapClassName={`open-close-modal ${
+        stickyFooter ? 'open-close-modal--sticky' : ''
+      }`}
       isOpen={isOpen}
       toggle={() => onClose()}
       size={size}
@@ -86,10 +122,15 @@ export function OpenCloseModal(props: Props) {
       {label ? (
         <ModalHeader toggle={() => onClose()}>{label}</ModalHeader>
       ) : null}
-      <ModalBody>{children}</ModalBody>
+      <ModalBody className={modalBodyClassName}>{children}</ModalBody>
       {onSave ? (
         <ModalFooter>
-          <Button className="ml-1" color="secondary" onClick={() => onClose()}>
+          <Button
+            className="ml-1"
+            color="secondary"
+            icon={cancelIcon}
+            onClick={() => onClose()}
+          >
             {t({
               overrideText: text?.cancel,
               key: 'OpenCloseModal.CANCEL',
@@ -100,6 +141,7 @@ export function OpenCloseModal(props: Props) {
             className="ml-1"
             color="primary"
             inProgress={inProgress}
+            icon={saveIcon}
             onClick={() => onSave()}
           >
             {t({

--- a/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
+++ b/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseM
   scrollable={false}
   toggle={[Function]}
   unmountOnClose={true}
+  wrapClassName="open-close-modal open-close-modal--sticky"
   zIndex={1050}
 >
   <ModalHeader
@@ -60,6 +61,7 @@ exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseM
     <Button
       className="ml-1"
       color="secondary"
+      icon="cancel"
       onClick={[Function]}
     >
       Stop please
@@ -67,6 +69,7 @@ exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseM
     <Button
       className="ml-1"
       color="primary"
+      icon="save"
       onClick={[Function]}
     >
       Select me
@@ -101,6 +104,7 @@ exports[`Component: OpenCloseModal ui in progress: Component: OpenCloseModal => 
   scrollable={false}
   toggle={[Function]}
   unmountOnClose={true}
+  wrapClassName="open-close-modal open-close-modal--sticky"
   zIndex={1050}
 >
   <ModalHeader
@@ -135,6 +139,7 @@ exports[`Component: OpenCloseModal ui in progress: Component: OpenCloseModal => 
     <Button
       className="ml-1"
       color="secondary"
+      icon="cancel"
       onClick={[Function]}
     >
       Cancel
@@ -142,7 +147,86 @@ exports[`Component: OpenCloseModal ui in progress: Component: OpenCloseModal => 
     <Button
       className="ml-1"
       color="primary"
+      icon="save"
       inProgress={true}
+      onClick={[Function]}
+    >
+      Save
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`Component: OpenCloseModal ui sans sticky footer: Component: OpenCloseModal => ui => sans sticky 1`] = `
+<Modal
+  autoFocus={true}
+  backdrop={true}
+  backdropTransition={
+    Object {
+      "mountOnEnter": true,
+      "timeout": 150,
+    }
+  }
+  centered={false}
+  fade={true}
+  isOpen={false}
+  keyboard={true}
+  modalTransition={
+    Object {
+      "timeout": 300,
+    }
+  }
+  onClosed={[Function]}
+  onOpened={[Function]}
+  returnFocusAfterClose={true}
+  role="dialog"
+  scrollable={false}
+  toggle={[Function]}
+  unmountOnClose={true}
+  wrapClassName="open-close-modal "
+  zIndex={1050}
+>
+  <ModalHeader
+    charCode={215}
+    closeAriaLabel="Close"
+    tag="h5"
+    toggle={[Function]}
+    wrapTag="div"
+  >
+    Choose something
+  </ModalHeader>
+  <ModalBody
+    tag="div"
+  >
+    <RadioGroup
+      onChange={[MockFunction]}
+      optionForValue={[Function]}
+      options={
+        Array [
+          "local",
+          "development",
+          "test",
+          "acceptation",
+          "production",
+        ]
+      }
+    />
+  </ModalBody>
+  <ModalFooter
+    tag="div"
+  >
+    <Button
+      className="ml-1"
+      color="secondary"
+      icon="cancel"
+      onClick={[Function]}
+    >
+      Cancel
+    </Button>
+    <Button
+      className="ml-1"
+      color="primary"
+      icon="save"
       onClick={[Function]}
     >
       Save
@@ -177,6 +261,7 @@ exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => u
   scrollable={false}
   toggle={[Function]}
   unmountOnClose={true}
+  wrapClassName="open-close-modal open-close-modal--sticky"
   zIndex={1050}
 >
   <ModalHeader
@@ -211,6 +296,7 @@ exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => u
     <Button
       className="ml-1"
       color="secondary"
+      icon="cancel"
       onClick={[Function]}
     >
       Cancel
@@ -218,6 +304,7 @@ exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => u
     <Button
       className="ml-1"
       color="primary"
+      icon="save"
       onClick={[Function]}
     >
       Save
@@ -252,6 +339,7 @@ exports[`Component: OpenCloseModal ui without buttons: Component: OpenCloseModal
   scrollable={false}
   toggle={[Function]}
   unmountOnClose={true}
+  wrapClassName="open-close-modal open-close-modal--sticky"
   zIndex={1050}
 >
   <ModalHeader
@@ -309,6 +397,7 @@ exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal =
   scrollable={false}
   toggle={[Function]}
   unmountOnClose={true}
+  wrapClassName="open-close-modal open-close-modal--sticky"
   zIndex={1050}
 >
   <ModalBody
@@ -334,6 +423,7 @@ exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal =
     <Button
       className="ml-1"
       color="secondary"
+      icon="cancel"
       onClick={[Function]}
     >
       Cancel
@@ -341,6 +431,7 @@ exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal =
     <Button
       className="ml-1"
       color="primary"
+      icon="save"
       onClick={[Function]}
     >
       Save

--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -7,9 +7,13 @@ import { JarbInput } from './Input/Input';
 import { FinalForm } from './story-utils';
 import {
   isStrongPassword,
+  JarbCheckbox,
   JarbCheckboxMultipleSelect,
+  JarbColorPicker,
   JarbDateRangePicker,
+  JarbRadioGroup,
   JarbDateTimeInput,
+  JarbNewPasswordInput,
   JarbFileInput,
   JarbIconPicker,
   JarbImageUpload,
@@ -27,10 +31,7 @@ import {
 } from '..';
 import { pageOfUsers } from '../test/fixtures';
 import { User } from '../test/types';
-import { JarbColorPicker } from './ColorPicker/ColorPicker';
-import { JarbCheckbox } from './Checkbox/Checkbox';
-import { JarbRadioGroup } from './RadioGroup/RadioGroup';
-import { JarbNewPasswordInput } from './NewPasswordInput/NewPasswordInput';
+import { ModalForm } from '../core/OpenCloseModal/OpenCloseModal.stories';
 
 function sleep(ms: number) {
   return new Promise(resolve => {
@@ -123,9 +124,19 @@ export function userAsOption(user: User): string {
   return user.email;
 }
 
-storiesOf('Form|Example', module).add('jarb form', () => {
+storiesOf('Form|Example', module)
+  .add('jarb form', () => {
+    return (
+      <FinalForm>
+        <TotalForm />
+      </FinalForm>
+    );
+  })
+  .add('jarb form in modal', ModalForm);
+
+export function TotalForm() {
   return (
-    <FinalForm>
+    <>
       <JarbInput
         name="firstName"
         jarb={{ validator: 'User.email', label: 'First name' }}
@@ -376,6 +387,6 @@ storiesOf('Form|Example', module).add('jarb form', () => {
         placeholder="Do you agree to the terms?"
         validators={requiredValidator}
       />
-    </FinalForm>
+    </>
   );
-});
+}

--- a/src/main.scss
+++ b/src/main.scss
@@ -31,6 +31,7 @@
 @import './core/Spinner/Spinner';
 @import './core/Tag/Tag';
 @import './core/Popover/Popover';
+@import './core/OpenCloseModal/OpenCloseModal';
 
 // Form components
 @import './form/ImageUpload/ImageUpload';


### PR DESCRIPTION
The sticky footer is enabled by default but can be disabled. When
enabled it will make the footer stay with the user, this way the user
can always press the save and cancel buttons.

The save and cancel buttons also have an icon by default now. The
icons can optionally be changed by the user. The default icons are
`save` and `cancel`.

Also added a story on how to properly use a final-form `Form` inside
of the `OpenCloseModal`. It uses the same form as the `FormExample`
which exports it now. Added it on two locations: with the `FormExample`
and the `OpenCloseModal`, so it can be found more easily.

Closes #452