### PR TITLE
fix: CheckboxMultipleSelect, and ModalPickerMultiple deselect was broken

### DIFF
--- a/src/core/AsyncList/AsyncList.stories.tsx
+++ b/src/core/AsyncList/AsyncList.stories.tsx
@@ -13,7 +13,7 @@ import { action } from '@storybook/addon-actions';
 function loadData(): Promise<User[]> {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve(pageOfUsers.content);
+      resolve(pageOfUsers().content);
     }, 1000);
   });
 }

--- a/src/core/AsyncList/AsyncList.test.tsx
+++ b/src/core/AsyncList/AsyncList.test.tsx
@@ -39,7 +39,7 @@ describe('Component: Async|AsyncList', () => {
     const state = {
       isLoading: false,
       isFulfilled: true,
-      data: pageOfUsers.content
+      data: pageOfUsers().content
     };
 
     const { asyncList } = setup({ state });
@@ -54,6 +54,6 @@ describe('isEmpty', () => {
   });
 
   it('should consider it empty when the totalElements is zero', () => {
-    expect(isEmpty(pageOfUsers.content)).toBe(false);
+    expect(isEmpty(pageOfUsers().content)).toBe(false);
   });
 });

--- a/src/core/AsyncPage/AsyncPage.stories.tsx
+++ b/src/core/AsyncPage/AsyncPage.stories.tsx
@@ -14,7 +14,7 @@ import { action } from '@storybook/addon-actions';
 function loadData(): Promise<Page<User>> {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve(pageOfUsers);
+      resolve(pageOfUsers());
     }, 1000);
   });
 }

--- a/src/core/AsyncPage/AsyncPage.test.tsx
+++ b/src/core/AsyncPage/AsyncPage.test.tsx
@@ -40,7 +40,7 @@ describe('Component: AsyncPage', () => {
     const state = {
       isLoading: false,
       isFulfilled: true,
-      data: pageOfUsers
+      data: pageOfUsers()
     };
 
     const { asyncPage } = setup({ state });
@@ -55,6 +55,6 @@ describe('isEmpty', () => {
   });
 
   it('should consider it empty when the totalElements is zero', () => {
-    expect(isEmpty(pageOfUsers)).toBe(false);
+    expect(isEmpty(pageOfUsers())).toBe(false);
   });
 });

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -77,7 +77,7 @@ storiesOf('Form|CheckboxMultipleSelect', module)
           label="Subject"
           placeholder="Please select your subjects"
           optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers)}
+          options={() => Promise.resolve(pageOfUsers())}
           value={value}
           onChange={setValue}
         />
@@ -85,7 +85,7 @@ storiesOf('Form|CheckboxMultipleSelect', module)
     );
   })
   .add('custom isOptionEqual', () => {
-    const [value, setValue] = useState<User[] | undefined>([userUser]);
+    const [value, setValue] = useState<User[] | undefined>([userUser()]);
 
     return (
       <Form>
@@ -94,7 +94,7 @@ storiesOf('Form|CheckboxMultipleSelect', module)
           label="Subject"
           placeholder="Please select your subjects"
           optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers)}
+          options={() => Promise.resolve(pageOfUsers())}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={value}
           onChange={setValue}

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
@@ -24,14 +24,18 @@ describe('Component: CheckboxMultipleSelect', () => {
     text,
     hasPlaceholder = true,
     hasLabel = true,
-    horizontal
+    horizontal,
+    hasIsOptionEqual = false,
+    options
   }: {
     value?: User[];
     isOptionEnabled?: OptionEnabledCallback<User>;
+    options?: User[];
     text?: Text;
     hasPlaceholder?: boolean;
     hasLabel?: boolean;
     horizontal?: boolean;
+    hasIsOptionEqual?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -41,12 +45,15 @@ describe('Component: CheckboxMultipleSelect', () => {
       text,
       isOptionEnabled,
       optionForValue: (user: User) => user.email,
-      options: [adminUser, coordinatorUser, userUser],
+      options: options ? options : [adminUser(), coordinatorUser(), userUser()],
       value,
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      horizontal
+      horizontal,
+      isOptionEqual: hasIsOptionEqual
+        ? (a: User, b: User) => a.id === b.id
+        : undefined
     };
 
     if (hasLabel) {
@@ -60,7 +67,7 @@ describe('Component: CheckboxMultipleSelect', () => {
 
   describe('ui', () => {
     test('with value', () => {
-      setup({ value: [adminUser] });
+      setup({ value: [adminUser()] });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => with value'
@@ -70,7 +77,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     describe('loading', () => {
       test('with custom text', () => {
         setup({
-          value: [adminUser],
+          value: [adminUser()],
           text: { loadingMessage: 'Custom loading' }
         });
 
@@ -84,7 +91,7 @@ describe('Component: CheckboxMultipleSelect', () => {
       });
 
       test('with default text', () => {
-        setup({ value: [adminUser] });
+        setup({ value: [adminUser()] });
 
         // @ts-ignore
         checkboxMultipleSelect.setState({ loading: true });
@@ -95,7 +102,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     });
 
     test('without placeholder', () => {
-      setup({ value: [adminUser], hasPlaceholder: false });
+      setup({ value: [adminUser()], hasPlaceholder: false });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => without placeholder'
@@ -103,7 +110,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     });
 
     test('without label', () => {
-      setup({ value: [adminUser], hasLabel: false });
+      setup({ value: [adminUser()], hasLabel: false });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => without label'
@@ -111,7 +118,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     });
 
     test('horizontal', () => {
-      setup({ value: [adminUser], horizontal: true });
+      setup({ value: [adminUser()], horizontal: true });
 
       expect(toJson(checkboxMultipleSelect)).toMatchSnapshot(
         'Component: CheckboxMultipleSelect => ui => horizontal'
@@ -123,12 +130,12 @@ describe('Component: CheckboxMultipleSelect', () => {
     test('when options is an array use that options and set loading to false', () => {
       // @ts-ignore
       const checkboxMultipleSelect = new CheckboxMultipleSelect({
-        options: [adminUser]
+        options: [adminUser()]
       });
 
       expect(checkboxMultipleSelect.state).toEqual({
         loading: false,
-        options: [adminUser]
+        options: [adminUser()]
       });
     });
 
@@ -151,7 +158,7 @@ describe('Component: CheckboxMultipleSelect', () => {
 
       // @ts-ignore
       const checkboxMultipleSelect = new CheckboxMultipleSelect({
-        options: [adminUser, coordinatorUser, userUser],
+        options: [adminUser(), coordinatorUser(), userUser()],
         onChange
       });
 
@@ -175,7 +182,7 @@ describe('Component: CheckboxMultipleSelect', () => {
 
     test('when options is a function set options to empty and loading to true', async done => {
       const onChange = jest.fn();
-      const options = () => Promise.resolve(pageOfUsers);
+      const options = () => Promise.resolve(pageOfUsers());
 
       // @ts-ignore
       const checkboxMultipleSelect = new CheckboxMultipleSelect({
@@ -193,7 +200,7 @@ describe('Component: CheckboxMultipleSelect', () => {
         expect(checkboxMultipleSelect.setState).toHaveBeenCalledTimes(1);
         expect(checkboxMultipleSelect.setState).toHaveBeenCalledWith({
           loading: false,
-          options: [adminUser, coordinatorUser, userUser]
+          options: [adminUser(), coordinatorUser(), userUser()]
         });
 
         done();
@@ -205,64 +212,133 @@ describe('Component: CheckboxMultipleSelect', () => {
   });
 
   describe('events', () => {
-    test('onChange', () => {
-      let value: User[] | undefined = undefined;
+    describe('onChange', () => {
+      it('should when there is no isOptionEqual fall back to simple equality check', () => {
+        const admin = adminUser();
+        const coordinator = coordinatorUser();
+        const user = userUser();
 
-      setup({ value, isOptionEnabled: undefined });
+        let value: User[] | undefined = undefined;
 
-      // First lets click on the admin it should be added
-      let checkbox = checkboxMultipleSelect.find('Input').at(0);
-      // @ts-ignore
-      checkbox.props().onChange();
+        setup({
+          value,
+          isOptionEnabled: undefined,
+          hasIsOptionEqual: false,
+          options: [admin, coordinator, user]
+        });
 
-      expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith([adminUser]);
+        // First lets click on the admin it should be added
+        let checkbox = checkboxMultipleSelect.find('Input').at(0);
+        // @ts-ignore
+        checkbox.props().onChange();
 
-      // Check that selected is a copy of value
-      expect(onChangeSpy.mock.calls[0][0]).not.toBe(value);
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeSpy).toHaveBeenCalledWith([admin]);
 
-      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+        // Check that selected is a copy of value
+        expect(onChangeSpy.mock.calls[0][0]).not.toBe(value);
 
-      // Manually set the value since it is external
-      value = [adminUser];
-      checkboxMultipleSelect.setProps({ value });
+        expect(onBlurSpy).toHaveBeenCalledTimes(1);
 
-      // Now lets click on the coordinator it should be added
-      checkbox = checkboxMultipleSelect.find('Input').at(1);
+        // Manually set the value since it is external
+        value = [admin];
+        checkboxMultipleSelect.setProps({ value });
 
-      // @ts-ignore
-      checkbox.props().onChange();
+        // Now lets click on the coordinator it should be added
+        checkbox = checkboxMultipleSelect.find('Input').at(1);
 
-      expect(onChangeSpy).toHaveBeenCalledTimes(2);
-      expect(onChangeSpy).toHaveBeenCalledWith([adminUser, coordinatorUser]);
+        // @ts-ignore
+        checkbox.props().onChange();
 
-      // Check that selected is a copy of value
-      expect(onChangeSpy.mock.calls[1][0]).not.toBe(value);
+        expect(onChangeSpy).toHaveBeenCalledTimes(2);
+        expect(onChangeSpy).toHaveBeenCalledWith([admin, coordinator]);
 
-      expect(onBlurSpy).toHaveBeenCalledTimes(2);
+        // Check that selected is a copy of value
+        expect(onChangeSpy.mock.calls[1][0]).not.toBe(value);
 
-      // Manually set the value since it is external
-      value = [adminUser, coordinatorUser];
-      checkboxMultipleSelect.setProps({ value });
+        expect(onBlurSpy).toHaveBeenCalledTimes(2);
 
-      // Now lets click on the admin again it should be removed
-      checkbox = checkboxMultipleSelect.find('Input').at(0);
+        // Manually set the value since it is external
+        value = [admin, coordinator];
+        checkboxMultipleSelect.setProps({ value });
 
-      // @ts-ignore
-      checkbox.props().onChange();
+        // Now lets click on the admin again it should be removed
+        checkbox = checkboxMultipleSelect.find('Input').at(0);
 
-      expect(onChangeSpy).toHaveBeenCalledTimes(3);
-      expect(onChangeSpy).toHaveBeenCalledWith([coordinatorUser]);
+        // @ts-ignore
+        checkbox.props().onChange();
 
-      // Check that selected is a copy of value
-      expect(onChangeSpy.mock.calls[2][0]).not.toBe(value);
+        expect(onChangeSpy).toHaveBeenCalledTimes(3);
+        expect(onChangeSpy).toHaveBeenCalledWith([coordinator]);
 
-      expect(onBlurSpy).toHaveBeenCalledTimes(3);
+        // Check that selected is a copy of value
+        expect(onChangeSpy.mock.calls[2][0]).not.toBe(value);
+
+        expect(onBlurSpy).toHaveBeenCalledTimes(3);
+      });
+
+      it('should when there is a custom isOptionEqual use that for the equality check', () => {
+        let value: User[] | undefined = undefined;
+
+        setup({ value, isOptionEnabled: undefined, hasIsOptionEqual: true });
+
+        // First lets click on the admin it should be added
+        let checkbox = checkboxMultipleSelect.find('Input').at(0);
+        // @ts-ignore
+        checkbox.props().onChange();
+
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeSpy).toHaveBeenCalledWith([adminUser()]);
+
+        // Check that selected is a copy of value
+        expect(onChangeSpy.mock.calls[0][0]).not.toBe(value);
+
+        expect(onBlurSpy).toHaveBeenCalledTimes(1);
+
+        // Manually set the value since it is external
+        value = [adminUser()];
+        checkboxMultipleSelect.setProps({ value });
+
+        // Now lets click on the coordinator it should be added
+        checkbox = checkboxMultipleSelect.find('Input').at(1);
+
+        // @ts-ignore
+        checkbox.props().onChange();
+
+        expect(onChangeSpy).toHaveBeenCalledTimes(2);
+        expect(onChangeSpy).toHaveBeenCalledWith([
+          adminUser(),
+          coordinatorUser()
+        ]);
+
+        // Check that selected is a copy of value
+        expect(onChangeSpy.mock.calls[1][0]).not.toBe(value);
+
+        expect(onBlurSpy).toHaveBeenCalledTimes(2);
+
+        // Manually set the value since it is external
+        value = [adminUser(), coordinatorUser()];
+        checkboxMultipleSelect.setProps({ value });
+
+        // Now lets click on the admin again it should be removed
+        checkbox = checkboxMultipleSelect.find('Input').at(0);
+
+        // @ts-ignore
+        checkbox.props().onChange();
+
+        expect(onChangeSpy).toHaveBeenCalledTimes(3);
+        expect(onChangeSpy).toHaveBeenCalledWith([coordinatorUser()]);
+
+        // Check that selected is a copy of value
+        expect(onChangeSpy.mock.calls[2][0]).not.toBe(value);
+
+        expect(onBlurSpy).toHaveBeenCalledTimes(3);
+      });
     });
 
     describe('isOptionEnabled', () => {
       it('should when "isOptionEnabled" is not defined always be true', () => {
-        setup({ value: [adminUser], isOptionEnabled: undefined });
+        setup({ value: [adminUser()], isOptionEnabled: undefined });
 
         const checkboxes = checkboxMultipleSelect.find('Input');
         expect(checkboxes.length).toBe(3);
@@ -289,9 +365,9 @@ describe('Component: CheckboxMultipleSelect', () => {
 
         expect(isOptionEnabledSpy).toHaveBeenCalledTimes(3);
         expect(isOptionEnabledSpy.mock.calls).toEqual([
-          [adminUser],
-          [coordinatorUser],
-          [userUser]
+          [adminUser()],
+          [coordinatorUser()],
+          [userUser()]
         ]);
       });
     });
@@ -299,7 +375,7 @@ describe('Component: CheckboxMultipleSelect', () => {
 
   describe('value changes', () => {
     test('becomes empty', () => {
-      setup({ value: [userUser], isOptionEnabled: undefined });
+      setup({ value: [userUser()], isOptionEnabled: undefined });
 
       let checkbox = checkboxMultipleSelect.find('Input').at(2);
       expect(checkbox.props().checked).toBe(true);
@@ -316,7 +392,7 @@ describe('Component: CheckboxMultipleSelect', () => {
       let checkbox = checkboxMultipleSelect.find('Input').at(1);
       expect(checkbox.props().checked).toBe(false);
 
-      checkboxMultipleSelect.setProps({ value: [coordinatorUser] });
+      checkboxMultipleSelect.setProps({ value: [coordinatorUser()] });
 
       checkbox = checkboxMultipleSelect.find('Input').at(1);
       expect(checkbox.props().checked).toBe(true);

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -180,7 +180,13 @@ export default class CheckboxMultipleSelect<T> extends Component<
     let selected = isArray(value) ? [...value] : [];
 
     if (isChecked) {
-      selected = selected.filter(v => v !== option);
+      const { isOptionEqual } = this.props;
+
+      const filterFn = isOptionEqual
+        ? (v: T) => !isOptionEqual(option, v)
+        : (v: T) => v !== option;
+
+      selected = selected.filter(filterFn);
     } else {
       selected.push(option);
     }

--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -289,7 +289,7 @@ export function TotalForm() {
         label="Worst enemy"
         placeholder="Select your nemesis"
         optionForValue={userAsOption}
-        options={() => Promise.resolve(pageOfUsers)}
+        options={() => Promise.resolve(pageOfUsers())}
         validators={requiredValidator}
       />
 
@@ -300,7 +300,7 @@ export function TotalForm() {
         label="Best friend"
         placeholder="Select your best friend"
         optionForValue={userAsOption}
-        options={() => Promise.resolve(pageOfUsers)}
+        options={() => Promise.resolve(pageOfUsers())}
         validators={requiredValidator}
       />
 
@@ -311,7 +311,7 @@ export function TotalForm() {
         label="Best friend"
         optionForValue={userAsOption}
         placeholder="Please provide your best friend"
-        fetchOptions={() => Promise.resolve(pageOfUsers)}
+        fetchOptions={() => Promise.resolve(pageOfUsers())}
       />
 
       <JarbModalPickerSingle
@@ -322,7 +322,7 @@ export function TotalForm() {
         placeholder="Select your best friend"
         canSearch={true}
         optionForValue={userAsOption}
-        fetchOptions={() => Promise.resolve(pageOfUsers)}
+        fetchOptions={() => Promise.resolve(pageOfUsers())}
         validators={requiredValidator}
       />
 
@@ -333,7 +333,7 @@ export function TotalForm() {
         label="Friends"
         optionForValue={userAsOption}
         placeholder="Please provide all your friends"
-        fetchOptions={() => Promise.resolve(pageOfUsers)}
+        fetchOptions={() => Promise.resolve(pageOfUsers())}
         validators={requiredValidator}
       />
 
@@ -344,7 +344,7 @@ export function TotalForm() {
         label="Friends"
         placeholder="Please provide all your friends"
         optionForValue={userAsOption}
-        fetchOptions={() => Promise.resolve(pageOfUsers)}
+        fetchOptions={() => Promise.resolve(pageOfUsers())}
         canSearch={true}
         validators={requiredValidator}
       />
@@ -356,7 +356,7 @@ export function TotalForm() {
         label="Friends"
         placeholder="Please provide all your friends"
         optionForValue={userAsOption}
-        options={() => Promise.resolve(pageOfUsers)}
+        options={() => Promise.resolve(pageOfUsers())}
         canSearch={true}
         validators={requiredValidator}
       />

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
@@ -19,7 +19,7 @@ describe('Component: ModalPickerOpener', () => {
     const openModalSpy = jest.fn();
     const onClearSpy = jest.fn();
 
-    const values = hasValues ? adminUser.email : undefined;
+    const values = hasValues ? adminUser().email : undefined;
 
     jest
       .spyOn(useComponentOverflow, 'useComponentOverflow')

--- a/src/form/ModalPicker/ModalPickerValueTruncator/ModalPickerValueTruncator.test.tsx
+++ b/src/form/ModalPicker/ModalPickerValueTruncator/ModalPickerValueTruncator.test.tsx
@@ -16,9 +16,9 @@ describe('Component: ModalPickerValueTruncator', () => {
     const optionForValueSpy = jest.fn(user => user.email);
 
     const values = hasSingleValue
-      ? userUser
+      ? userUser()
       : hasMultipleValues
-      ? [adminUser, userUser]
+      ? [adminUser(), userUser()]
       : undefined;
 
     const modalPickerValueTruncator = shallow(

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -26,7 +26,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -47,7 +49,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser]))
+            Promise.resolve(pageWithContentAndExactSize([userUser()]))
           }
           addButton={{
             label: 'Create friend',
@@ -57,7 +59,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
               // to create the friend.
               return new Promise(resolve => {
                 setTimeout(() => {
-                  resolve(adminUser);
+                  resolve(adminUser());
                 }, 1000);
               });
             }
@@ -80,7 +82,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           canSearch={false}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser]))
+            Promise.resolve(pageWithContentAndExactSize([userUser()]))
           }
           addButton={{
             label: 'Create friend',
@@ -90,7 +92,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
               // to create the friend.
               return new Promise(resolve => {
                 setTimeout(() => {
-                  resolve(adminUser);
+                  resolve(adminUser());
                 }, 1000);
               });
             }
@@ -102,7 +104,7 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
     );
   })
   .add('custom isOptionEqual', () => {
-    const [value, setValue] = useState<User[] | undefined>([userUser]);
+    const [value, setValue] = useState<User[] | undefined>([userUser()]);
 
     return (
       <Form>
@@ -112,7 +114,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
@@ -133,8 +137,11 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
+          isOptionEqual={(a, b) => a.id === b.id}
           optionForValue={(user: User) => user.email}
           renderOptions={options => (
             <ListGroup>
@@ -172,7 +179,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -202,7 +211,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -222,7 +233,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -234,7 +247,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -247,7 +262,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -268,7 +285,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           placeholder="Select your best friend"
           canSearch={true}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           optionForValue={(user: User) => user.email}
           value={value}
@@ -306,7 +325,9 @@ storiesOf('Form|ModalPicker/ModalPickerMultiple', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           jarb={{
             validator: 'Hero.name',

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -34,7 +34,8 @@ describe('Component: ModalPickerMultiple', () => {
     hasLabel = true,
     spyOnRenderOptions,
     alignButton,
-    hasDisplayValues = false
+    hasDisplayValues = false,
+    hasIsOptionEqual = false
   }: {
     value?: User[];
     showAddButton: boolean;
@@ -43,6 +44,7 @@ describe('Component: ModalPickerMultiple', () => {
     spyOnRenderOptions?: boolean;
     alignButton?: ButtonAlignment;
     hasDisplayValues?: boolean;
+    hasIsOptionEqual?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -71,6 +73,9 @@ describe('Component: ModalPickerMultiple', () => {
       name: 'bestFriend',
       placeholder: 'Select your best friend',
       canSearch,
+      isOptionEqual: hasIsOptionEqual
+        ? (a: User, b: User) => a.id === b.id
+        : undefined,
       fetchOptions: fetchOptionsSpy,
       optionForValue: (user: User) => user.email,
       renderOptions: renderOptionsSpy,
@@ -122,7 +127,7 @@ describe('Component: ModalPickerMultiple', () => {
   describe('ui', () => {
     it('should render', () => {
       setup({
-        value: [adminUser, userUser],
+        value: [adminUser(), userUser()],
         showAddButton: false
       });
 
@@ -133,7 +138,7 @@ describe('Component: ModalPickerMultiple', () => {
 
     it('should not render search canSearch is false', () => {
       setup({
-        value: [adminUser, userUser],
+        value: [adminUser(), userUser()],
         showAddButton: false,
         canSearch: false
       });
@@ -146,13 +151,13 @@ describe('Component: ModalPickerMultiple', () => {
 
     it('should render multiple labels with the selected values when the value array is not empty', () => {
       setup({
-        value: [adminUser, userUser],
+        value: [adminUser(), userUser()],
         showAddButton: false
       });
 
       expect(
         modalPickerMultiple.find('ModalPickerOpener').props().values
-      ).toEqual([adminUser, userUser]);
+      ).toEqual([adminUser(), userUser()]);
     });
 
     it('should render no labels when the value array is empty', () => {
@@ -166,7 +171,7 @@ describe('Component: ModalPickerMultiple', () => {
     it('should render multiple labels inside the modal with the selected values when the selected property is not empty', () => {
       setup({ value: undefined, showAddButton: false });
       modalPickerMultiple.setState({
-        selected: [adminUser, userUser]
+        selected: [adminUser(), userUser()]
       });
 
       expect(
@@ -205,10 +210,10 @@ describe('Component: ModalPickerMultiple', () => {
     });
 
     it('should render the options with the correct checked state', () => {
-      setup({ value: [adminUser, coordinatorUser], showAddButton: false });
+      setup({ value: [adminUser(), coordinatorUser()], showAddButton: false });
       modalPickerMultiple.setState({
-        page: pageOfUsers,
-        selected: [{ ...adminUser }, { ...coordinatorUser }]
+        page: pageOfUsers(),
+        selected: [adminUser(), coordinatorUser()]
       });
 
       const admin = modalPickerMultiple.find('Input').at(0);
@@ -222,7 +227,7 @@ describe('Component: ModalPickerMultiple', () => {
 
     it('should render properly without label', () => {
       setup({
-        value: [adminUser, userUser],
+        value: [adminUser(), userUser()],
         showAddButton: false,
         hasLabel: false
       });
@@ -233,7 +238,11 @@ describe('Component: ModalPickerMultiple', () => {
     });
 
     it('should render button left', () => {
-      setup({ value: [adminUser], showAddButton: false, alignButton: 'left' });
+      setup({
+        value: [adminUser()],
+        showAddButton: false,
+        alignButton: 'left'
+      });
       expect(toJson(modalPickerMultiple)).toMatchSnapshot(
         'Component: ModalPickerMultiple => ui => should render button left'
       );
@@ -247,7 +256,11 @@ describe('Component: ModalPickerMultiple', () => {
     });
 
     it('should render button right with value', () => {
-      setup({ value: [adminUser], showAddButton: false, alignButton: 'right' });
+      setup({
+        value: [adminUser()],
+        showAddButton: false,
+        alignButton: 'right'
+      });
       expect(toJson(modalPickerMultiple)).toMatchSnapshot(
         'Component: ModalPickerMultiple => ui => should render button right with value'
       );
@@ -255,7 +268,7 @@ describe('Component: ModalPickerMultiple', () => {
 
     it('should use custom display function to render values', () => {
       setup({
-        value: [adminUser],
+        value: [adminUser()],
         showAddButton: false,
         hasDisplayValues: true
       });
@@ -269,11 +282,11 @@ describe('Component: ModalPickerMultiple', () => {
     describe('opening the modal', () => {
       it('should open the modal when the select button is clicked', async done => {
         setup({
-          value: [adminUser, userUser],
+          value: [adminUser(), userUser()],
           showAddButton: false
         });
 
-        const promise = Promise.resolve(pageOfUsers);
+        const promise = Promise.resolve(pageOfUsers());
         fetchOptionsSpy.mockReturnValue(promise);
 
         // @ts-ignore
@@ -290,12 +303,12 @@ describe('Component: ModalPickerMultiple', () => {
 
           const state = modalPickerMultiple.state() as State<User>;
 
-          expect(state.selected).toEqual([adminUser, userUser]);
+          expect(state.selected).toEqual([adminUser(), userUser()]);
           expect(state.isOpen).toBe(true);
           expect(state.query).toBe('');
 
           expect(state.userHasSearched).toBe(false);
-          expect(state.page).toBe(pageOfUsers);
+          expect(state.page).toEqual(pageOfUsers());
 
           // @ts-ignore
           const value = modalPickerMultiple.instance().props.value;
@@ -314,7 +327,7 @@ describe('Component: ModalPickerMultiple', () => {
           showAddButton: false
         });
 
-        const promise = Promise.resolve(pageOfUsers);
+        const promise = Promise.resolve(pageOfUsers());
         fetchOptionsSpy.mockReturnValue(promise);
 
         // @ts-ignore
@@ -348,7 +361,7 @@ describe('Component: ModalPickerMultiple', () => {
         showAddButton: false
       });
 
-      const promise = Promise.resolve(pageOfUsers);
+      const promise = Promise.resolve(pageOfUsers());
       fetchOptionsSpy.mockReturnValue(promise);
 
       const modalPicker = modalPickerMultiple.find('ModalPicker').at(0);
@@ -363,7 +376,7 @@ describe('Component: ModalPickerMultiple', () => {
       setup({ value: undefined, showAddButton: false });
       modalPickerMultiple.setState({ query: 'search' });
 
-      const promise = Promise.resolve(pageOfUsers);
+      const promise = Promise.resolve(pageOfUsers());
       fetchOptionsSpy.mockReturnValue(promise);
 
       const modalPicker = modalPickerMultiple.find('ModalPicker').at(0);
@@ -379,7 +392,7 @@ describe('Component: ModalPickerMultiple', () => {
         const state = modalPickerMultiple.state() as State<User>;
 
         expect(state.userHasSearched).toBe(true);
-        expect(state.page).toBe(pageOfUsers);
+        expect(state.page).toEqual(pageOfUsers());
 
         expect(state.query).toBe('search');
         done();
@@ -405,7 +418,7 @@ describe('Component: ModalPickerMultiple', () => {
     });
 
     it('should when the user clicks save, it should close the modal and select the value', () => {
-      const value = [adminUser, userUser];
+      const value = [adminUser(), userUser()];
       setup({ value, showAddButton: false });
 
       modalPickerMultiple.setState({ isOpen: true });
@@ -422,162 +435,286 @@ describe('Component: ModalPickerMultiple', () => {
       expect(modalPickerMultiple.state().isOpen).toBe(false);
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith([adminUser, userUser]);
+      expect(onChangeSpy).toHaveBeenCalledWith([adminUser(), userUser()]);
     });
 
-    it('should when the user clicks the clear button clear the value', () => {
-      const value = [adminUser, userUser];
-      setup({ value, showAddButton: false });
+    describe('onChange', () => {
+      it('should when the user clicks the clear button clear the value', () => {
+        const value = [adminUser(), userUser()];
+        setup({ value, showAddButton: false });
 
-      modalPickerMultiple.setState({ isOpen: true });
-      modalPickerMultiple.setState({ selected: value });
+        modalPickerMultiple.setState({ isOpen: true });
+        modalPickerMultiple.setState({ selected: value });
 
-      // @ts-ignore
-      modalPickerMultiple
-        .find('ModalPickerOpener')
-        .props()
         // @ts-ignore
-        .onClear();
+        modalPickerMultiple
+          .find('ModalPickerOpener')
+          .props()
+          // @ts-ignore
+          .onClear();
 
-      expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith(undefined);
-    });
-
-    it('should when the user selects an option store the value', () => {
-      setup({ value: [adminUser, coordinatorUser], showAddButton: false });
-      modalPickerMultiple.setState({
-        page: pageOfUsers,
-        selected: [adminUser, coordinatorUser]
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeSpy).toHaveBeenCalledWith(undefined);
       });
 
-      // admin, and coordinator should be selected
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([
-        adminUser,
-        coordinatorUser
-      ]);
+      describe('isOptionEqual', () => {
+        it('should when there is no isOptionEqual fall back to simple equality check', () => {
+          const admin = adminUser();
+          // @ts-ignore
+          admin.x = Math.random();
+          const coordinator = coordinatorUser();
+          const user = userUser();
 
-      // Click on admin, he should be removed
-      // @ts-ignore
-      modalPickerMultiple
-        .find('Input')
-        .at(0)
-        .props()
-        // @ts-ignore
-        .onChange();
-      modalPickerMultiple.update();
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([coordinatorUser]);
+          setup({
+            value: [admin, coordinator],
+            showAddButton: false,
+            hasIsOptionEqual: false
+          });
+          modalPickerMultiple.setState({
+            page: testUtils.pageWithContent([admin, coordinator, user]),
+            selected: [admin, coordinator]
+          });
 
-      // Click on admin again, he should be added
-      // @ts-ignore
-      modalPickerMultiple
-        .find('Input')
-        .at(0)
-        .props()
-        // @ts-ignore
-        .onChange();
-      modalPickerMultiple.update();
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([
-        coordinatorUser,
-        adminUser
-      ]);
+          // admin, and coordinator should be selected
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            admin,
+            coordinator
+          ]);
 
-      // Click on coordinator, he should be removed
-      // @ts-ignore
-      modalPickerMultiple
-        .find('Input')
-        .at(1)
-        .props()
-        // @ts-ignore
-        .onChange();
-      // @ts-ignore
-      modalPickerMultiple.update();
+          // Click on admin, he should be removed
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(0)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([coordinator]);
 
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([adminUser]);
+          // Click on admin again, he should be added
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(0)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            coordinator,
+            admin
+          ]);
 
-      // Click on user again, he should be added
-      // @ts-ignore
-      modalPickerMultiple
-        .find('Input')
-        .at(1)
-        .props()
-        // @ts-ignore
-        .onChange();
-      // @ts-ignore
-      modalPickerMultiple.update();
+          // Click on coordinator, he should be removed
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(1)
+            .props()
+            // @ts-ignore
+            .onChange();
+          // @ts-ignore
+          modalPickerMultiple.update();
 
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([
-        adminUser,
-        coordinatorUser
-      ]);
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([admin]);
 
-      // Click on user, he should be added
-      // @ts-ignore
-      modalPickerMultiple
-        .find('Input')
-        .at(2)
-        .props()
-        // @ts-ignore
-        .onChange();
-      modalPickerMultiple.update();
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([
-        adminUser,
-        coordinatorUser,
-        userUser
-      ]);
+          // Click on user again, he should be added
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(1)
+            .props()
+            // @ts-ignore
+            .onChange();
+          // @ts-ignore
+          modalPickerMultiple.update();
 
-      // Click on user again, he should be removed
-      // @ts-ignore
-      modalPickerMultiple
-        .find('Input')
-        .at(2)
-        .props()
-        // @ts-ignore
-        .onChange();
-      modalPickerMultiple.update();
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([
-        adminUser,
-        coordinatorUser
-      ]);
-    });
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            admin,
+            coordinator
+          ]);
 
-    it('should when the user removes a label inside the modal the label should be removed', () => {
-      setup({ value: [adminUser, userUser], showAddButton: false });
+          // Click on user, he should be added
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(2)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            admin,
+            coordinator,
+            user
+          ]);
 
-      modalPickerMultiple.setState({
-        page: pageOfUsers,
-        selected: [adminUser, userUser]
+          // Click on user again, he should be removed
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(2)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            admin,
+            coordinator
+          ]);
+        });
+
+        it('should when there is a custom isOptionEqual use that for the equality check', () => {
+          setup({
+            value: [adminUser(), coordinatorUser()],
+            showAddButton: false,
+            hasIsOptionEqual: true
+          });
+          modalPickerMultiple.setState({
+            page: pageOfUsers(),
+            selected: [adminUser(), coordinatorUser()]
+          });
+
+          // admin, and coordinator should be selected
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            adminUser(),
+            coordinatorUser()
+          ]);
+
+          // Click on admin, he should be removed
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(0)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            coordinatorUser()
+          ]);
+
+          // Click on admin again, he should be added
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(0)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            coordinatorUser(),
+            adminUser()
+          ]);
+
+          // Click on coordinator, he should be removed
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(1)
+            .props()
+            // @ts-ignore
+            .onChange();
+          // @ts-ignore
+          modalPickerMultiple.update();
+
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([adminUser()]);
+
+          // Click on user again, he should be added
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(1)
+            .props()
+            // @ts-ignore
+            .onChange();
+          // @ts-ignore
+          modalPickerMultiple.update();
+
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            adminUser(),
+            coordinatorUser()
+          ]);
+
+          // Click on user, he should be added
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(2)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            adminUser(),
+            coordinatorUser(),
+            userUser()
+          ]);
+
+          // Click on user again, he should be removed
+          // @ts-ignore
+          modalPickerMultiple
+            .find('Input')
+            .at(2)
+            .props()
+            // @ts-ignore
+            .onChange();
+          modalPickerMultiple.update();
+          // @ts-ignore
+          expect(modalPickerMultiple.state().selected).toEqual([
+            adminUser(),
+            coordinatorUser()
+          ]);
+        });
       });
 
-      const adminTag = modalPickerMultiple.find('Tag').at(0);
-      const userTag = modalPickerMultiple.find('Tag').at(1);
+      it('should when the user removes a label inside the modal the label should be removed', () => {
+        setup({ value: [adminUser(), userUser()], showAddButton: false });
 
-      // @ts-ignore
-      adminTag.props().onRemove(adminUser, true);
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([userUser]);
+        modalPickerMultiple.setState({
+          page: pageOfUsers(),
+          selected: [adminUser(), userUser()]
+        });
 
-      // @ts-ignore
-      userTag.props().onRemove(userUser, true);
-      // @ts-ignore
-      expect(modalPickerMultiple.state().selected).toEqual([]);
+        const adminTag = modalPickerMultiple.find('Tag').at(0);
+        const userTag = modalPickerMultiple.find('Tag').at(1);
+
+        // @ts-ignore
+        adminTag.props().onRemove(adminUser(), true);
+        // @ts-ignore
+        expect(modalPickerMultiple.state().selected).toEqual([userUser()]);
+
+        // @ts-ignore
+        userTag.props().onRemove(userUser(), true);
+        // @ts-ignore
+        expect(modalPickerMultiple.state().selected).toEqual([]);
+      });
     });
 
     describe('addButton', () => {
       it('should add an item on the first position, when the promise resolves', async done => {
         setup({
-          value: [adminUser],
+          value: [adminUser()],
           showAddButton: true
         });
         modalPickerMultiple.setState({
           isOpen: true,
-          page: testUtils.pageWithContent([adminUser])
+          page: testUtils.pageWithContent([adminUser()])
         });
 
         const { promise, resolve } = testUtils.resolvablePromise();
@@ -597,7 +734,7 @@ describe('Component: ModalPickerMultiple', () => {
         expect(modalPickerMultiple.state().isOpen).toBe(false);
         expect(addButtonCallbackSpy).toHaveBeenCalledTimes(1);
 
-        resolve(coordinatorUser);
+        resolve(coordinatorUser());
 
         try {
           await promise;
@@ -612,9 +749,12 @@ describe('Component: ModalPickerMultiple', () => {
             expect(
               // @ts-ignore
               modalPickerMultiple.instance().itemClicked
-            ).toHaveBeenCalledWith(coordinatorUser, true);
+            ).toHaveBeenCalledWith(coordinatorUser(), true);
 
-            expect(state.page.content).toEqual([coordinatorUser, adminUser]);
+            expect(state.page.content).toEqual([
+              coordinatorUser(),
+              adminUser()
+            ]);
 
             expect(state.isOpen).toBe(true);
 
@@ -628,7 +768,7 @@ describe('Component: ModalPickerMultiple', () => {
 
       it('should hide when the promise is rejected', async done => {
         setup({
-          value: [adminUser],
+          value: [adminUser()],
           showAddButton: true
         });
         modalPickerMultiple.setState({ isOpen: true });
@@ -673,12 +813,12 @@ describe('Component: ModalPickerMultiple', () => {
 
         modalPickerMultiple.setState({
           isOpen: true,
-          page: pageOfUsers
+          page: pageOfUsers()
         });
 
         expect(renderOptionsSpy).toHaveBeenCalledTimes(1);
         expect(isOptionSelectedSpy).toHaveBeenCalledTimes(
-          pageOfUsers.content.length
+          pageOfUsers().content.length
         );
       });
 
@@ -687,7 +827,7 @@ describe('Component: ModalPickerMultiple', () => {
 
         modalPickerMultiple.setState({
           isOpen: true,
-          page: pageOfUsers
+          page: pageOfUsers()
         });
 
         // @ts-ignore
@@ -701,7 +841,7 @@ describe('Component: ModalPickerMultiple', () => {
 
         // @ts-ignore
         expect(modalPickerMultiple.state().selected).toEqual([
-          pageOfUsers.content[0]
+          pageOfUsers().content[0]
         ]);
       });
     });
@@ -709,11 +849,13 @@ describe('Component: ModalPickerMultiple', () => {
 
   describe('value changes', () => {
     test('becomes empty', () => {
-      setup({ value: [adminUser], showAddButton: false });
+      const value = [adminUser()];
+
+      setup({ value: value, showAddButton: false });
 
       expect(
         modalPickerMultiple.find('ModalPickerOpener').props().values
-      ).toEqual([adminUser]);
+      ).toEqual(value);
 
       modalPickerMultiple.setProps({ value: undefined });
 
@@ -730,12 +872,12 @@ describe('Component: ModalPickerMultiple', () => {
       ).toBeUndefined();
 
       modalPickerMultiple.setProps({
-        value: [adminUser]
+        value: [adminUser()]
       });
 
       expect(
         modalPickerMultiple.find('ModalPickerOpener').props().values
-      ).toEqual([adminUser]);
+      ).toEqual([adminUser()]);
     });
   });
 });

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -208,7 +208,13 @@ export default class ModalPickerMultiple<T> extends React.Component<
     let selected = this.state.selected as T[];
 
     if (isChecked) {
-      selected = selected.filter(v => v !== item);
+      const { isOptionEqual } = this.props;
+
+      const filterFn = isOptionEqual
+        ? (v: T) => !isOptionEqual(item, v)
+        : (v: T) => v !== item;
+
+      selected = selected.filter(filterFn);
     } else {
       selected.push(item);
     }

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -23,7 +23,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -43,7 +45,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser]))
+            Promise.resolve(pageWithContentAndExactSize([userUser()]))
           }
           addButton={{
             label: 'Create friend',
@@ -53,7 +55,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
               // to create the friend.
               return new Promise(resolve => {
                 setTimeout(() => {
-                  resolve(adminUser);
+                  resolve(adminUser());
                 }, 1000);
               });
             }
@@ -97,7 +99,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           optionForValue={(user: User) => user.email}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -138,7 +142,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           )}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -157,7 +163,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -184,7 +192,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -204,7 +214,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -217,7 +229,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -230,7 +244,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={setValue}
@@ -251,7 +267,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           canSearch={true}
           optionForValue={user => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           value={value}
           onChange={user => setValue(user)}

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -116,7 +116,7 @@ describe('Component: ModalPickerSingle', () => {
 
   describe('ui', () => {
     it('should render', () => {
-      setup({ value: adminUser, showAddButton: false });
+      setup({ value: adminUser(), showAddButton: false });
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should render'
       );
@@ -124,7 +124,7 @@ describe('Component: ModalPickerSingle', () => {
 
     it('should not render search canSearch is false', () => {
       setup({
-        value: adminUser,
+        value: adminUser(),
         showAddButton: false,
         canSearch: false
       });
@@ -136,10 +136,11 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should render a label with the selected value when the value is not empty', () => {
-      setup({ value: adminUser, showAddButton: false });
+      const value = adminUser();
+      setup({ value, showAddButton: false });
       expect(
         modalPickerSingle.find('ModalPickerOpener').props().values
-      ).toEqual(adminUser);
+      ).toEqual(value);
     });
 
     it('should not render a label when the value is empty', () => {
@@ -160,11 +161,11 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should render the options with the correct checked state', () => {
-      setup({ value: adminUser, showAddButton: false });
+      setup({ value: adminUser(), showAddButton: false });
 
       modalPickerSingle.setState({
-        page: pageOfUsers,
-        selected: { ...adminUser }
+        page: pageOfUsers(),
+        selected: { ...adminUser() }
       });
 
       const admin = modalPickerSingle.find('Input').at(0);
@@ -177,14 +178,14 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should render without label', () => {
-      setup({ value: adminUser, showAddButton: false, hasLabel: false });
+      setup({ value: adminUser(), showAddButton: false, hasLabel: false });
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should render without label'
       );
     });
 
     it('should render button left', () => {
-      setup({ value: adminUser, showAddButton: false, alignButton: 'left' });
+      setup({ value: adminUser(), showAddButton: false, alignButton: 'left' });
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should render button left'
       );
@@ -198,14 +199,18 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should render button right with value', () => {
-      setup({ value: adminUser, showAddButton: false, alignButton: 'right' });
+      setup({ value: adminUser(), showAddButton: false, alignButton: 'right' });
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should render button right with value'
       );
     });
 
     it('should use custom display function to render values', () => {
-      setup({ value: adminUser, showAddButton: false, hasDisplayValues: true });
+      setup({
+        value: adminUser(),
+        showAddButton: false,
+        hasDisplayValues: true
+      });
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should use custom display function to render values'
       );
@@ -214,12 +219,14 @@ describe('Component: ModalPickerSingle', () => {
 
   describe('events', () => {
     it('should open the modal when the select button is clicked', async done => {
+      const value = adminUser();
+
       setup({
-        value: adminUser,
+        value,
         showAddButton: false
       });
 
-      const promise = Promise.resolve(pageOfUsers);
+      const promise = Promise.resolve(pageOfUsers());
       fetchOptionsSpy.mockReturnValue(promise);
 
       modalPickerSingle
@@ -236,12 +243,12 @@ describe('Component: ModalPickerSingle', () => {
 
         const state = modalPickerSingle.state() as State<User>;
 
-        expect(state.selected).toEqual(adminUser);
+        expect(state.selected).toEqual(value);
         expect(state.isOpen).toBe(true);
         expect(state.query).toBe('');
 
         expect(state.userHasSearched).toBe(false);
-        expect(state.page).toBe(pageOfUsers);
+        expect(state.page).toEqual(pageOfUsers());
 
         done();
       } catch (error) {
@@ -256,7 +263,7 @@ describe('Component: ModalPickerSingle', () => {
         showAddButton: false
       });
 
-      const promise = Promise.resolve(pageOfUsers);
+      const promise = Promise.resolve(pageOfUsers());
       fetchOptionsSpy.mockReturnValue(promise);
 
       const modalPicker = modalPickerSingle.find('ModalPicker').at(0);
@@ -271,7 +278,7 @@ describe('Component: ModalPickerSingle', () => {
       setup({ value: undefined, showAddButton: false });
       modalPickerSingle.setState({ query: 'search' });
 
-      const promise = Promise.resolve(pageOfUsers);
+      const promise = Promise.resolve(pageOfUsers());
       fetchOptionsSpy.mockReturnValue(promise);
 
       const modalPicker = modalPickerSingle.find('ModalPicker').at(0);
@@ -287,7 +294,7 @@ describe('Component: ModalPickerSingle', () => {
         const state = modalPickerSingle.state() as State<User>;
 
         expect(state.userHasSearched).toBe(true);
-        expect(state.page).toBe(pageOfUsers);
+        expect(state.page).toEqual(pageOfUsers());
 
         expect(state.query).toBe('search');
         done();
@@ -313,7 +320,7 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should when the user clicks save it should close the modal and select the value', () => {
-      setup({ value: adminUser, showAddButton: false });
+      setup({ value: adminUser(), showAddButton: false });
 
       modalPickerSingle.setState({ isOpen: true });
       modalPickerSingle.setState({ selected: adminUser });
@@ -333,10 +340,11 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should when the user clicks the clear button clear the value', () => {
-      setup({ value: adminUser, showAddButton: false });
+      const value = adminUser();
+      setup({ value, showAddButton: false });
 
       modalPickerSingle.setState({ isOpen: true });
-      modalPickerSingle.setState({ selected: adminUser });
+      modalPickerSingle.setState({ selected: value });
 
       // @ts-ignore
       modalPickerSingle
@@ -350,10 +358,10 @@ describe('Component: ModalPickerSingle', () => {
     });
 
     it('should when the user selects an option store the value', () => {
-      setup({ value: adminUser, showAddButton: false });
+      setup({ value: adminUser(), showAddButton: false });
       modalPickerSingle.setState({
-        page: pageOfUsers,
-        selected: adminUser
+        page: pageOfUsers(),
+        selected: adminUser()
       });
 
       // @ts-ignore
@@ -365,7 +373,7 @@ describe('Component: ModalPickerSingle', () => {
         .onChange();
 
       // @ts-ignore
-      expect(modalPickerSingle.state().selected).toEqual(coordinatorUser);
+      expect(modalPickerSingle.state().selected).toEqual(coordinatorUser());
 
       // @ts-ignore
       modalPickerSingle
@@ -376,7 +384,7 @@ describe('Component: ModalPickerSingle', () => {
         .onChange();
 
       // @ts-ignore
-      expect(modalPickerSingle.state().selected).toEqual(userUser);
+      expect(modalPickerSingle.state().selected).toEqual(userUser());
 
       // @ts-ignore
       modalPickerSingle
@@ -387,18 +395,18 @@ describe('Component: ModalPickerSingle', () => {
         .onChange();
 
       // @ts-ignore
-      expect(modalPickerSingle.state().selected).toEqual(adminUser);
+      expect(modalPickerSingle.state().selected).toEqual(adminUser());
     });
 
     describe('addButton', () => {
       it('should add an item on the first position, when the promise resolves', async done => {
         setup({
-          value: adminUser,
+          value: adminUser(),
           showAddButton: true
         });
         modalPickerSingle.setState({
           isOpen: true,
-          page: testUtils.pageWithContent([adminUser])
+          page: testUtils.pageWithContent([adminUser()])
         });
 
         const { promise, resolve } = testUtils.resolvablePromise();
@@ -418,7 +426,7 @@ describe('Component: ModalPickerSingle', () => {
         expect(modalPickerSingle.state().isOpen).toBe(false);
         expect(addButtonCallbackSpy).toHaveBeenCalledTimes(1);
 
-        resolve(userUser);
+        resolve(userUser());
 
         try {
           await promise;
@@ -433,9 +441,9 @@ describe('Component: ModalPickerSingle', () => {
             expect(
               // @ts-ignore
               modalPickerSingle.instance().itemClicked
-            ).toHaveBeenCalledWith(userUser);
+            ).toHaveBeenCalledWith(userUser());
 
-            expect(state.page.content).toEqual([userUser, adminUser]);
+            expect(state.page.content).toEqual([userUser(), adminUser()]);
 
             expect(state.isOpen).toBe(true);
 
@@ -494,12 +502,12 @@ describe('Component: ModalPickerSingle', () => {
 
         modalPickerSingle.setState({
           isOpen: true,
-          page: pageOfUsers
+          page: pageOfUsers()
         });
 
         expect(renderOptionsSpy).toHaveBeenCalledTimes(1);
         expect(isOptionSelectedSpy).toHaveBeenCalledTimes(
-          pageOfUsers.content.length
+          pageOfUsers().content.length
         );
       });
 
@@ -508,7 +516,7 @@ describe('Component: ModalPickerSingle', () => {
 
         modalPickerSingle.setState({
           isOpen: true,
-          page: pageOfUsers
+          page: pageOfUsers()
         });
 
         // @ts-ignore
@@ -522,7 +530,7 @@ describe('Component: ModalPickerSingle', () => {
 
         // @ts-ignore
         expect(modalPickerSingle.state().selected).toEqual(
-          pageOfUsers.content[0]
+          pageOfUsers().content[0]
         );
       });
     });
@@ -530,11 +538,13 @@ describe('Component: ModalPickerSingle', () => {
 
   describe('value changes', () => {
     test('becomes empty', () => {
-      setup({ value: adminUser, showAddButton: false });
+      const value = adminUser();
+
+      setup({ value, showAddButton: false });
 
       expect(
         modalPickerSingle.find('ModalPickerOpener').props().values
-      ).toEqual(adminUser);
+      ).toEqual(value);
 
       modalPickerSingle.setProps({ value: undefined });
 
@@ -550,13 +560,15 @@ describe('Component: ModalPickerSingle', () => {
         modalPickerSingle.find('ModalPickerOpener').props().values
       ).toBeUndefined();
 
+      const value = adminUser();
+
       modalPickerSingle.setProps({
-        value: adminUser
+        value
       });
 
       expect(
         modalPickerSingle.find('ModalPickerOpener').props().values
-      ).toEqual(adminUser);
+      ).toEqual(value);
     });
   });
 });

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -146,7 +146,7 @@ storiesOf('Form|RadioGroup', module)
           label="Subject"
           placeholder="Please enter your subject"
           optionForValue={(user: User) => user.email}
-          options={() => resolveAfter(pageOfUsers)}
+          options={() => resolveAfter(pageOfUsers())}
           value={subject}
           onChange={setSubject}
         />
@@ -165,7 +165,7 @@ storiesOf('Form|RadioGroup', module)
           label="Subject"
           placeholder="Please enter your subject"
           optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers)}
+          options={() => Promise.resolve(pageOfUsers())}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={subject}
           onChange={setSubject}

--- a/src/form/RadioGroup/RadioGroup.test.tsx
+++ b/src/form/RadioGroup/RadioGroup.test.tsx
@@ -33,7 +33,7 @@ describe('Component: RadioGroup', () => {
       text,
       isOptionEnabled,
       optionForValue: (user: User) => user?.email,
-      options: [adminUser, coordinatorUser, userUser],
+      options: [adminUser(), coordinatorUser(), userUser()],
       value,
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
@@ -56,7 +56,7 @@ describe('Component: RadioGroup', () => {
   describe('ui', () => {
     test('with value', () => {
       const { radioGroup } = setup({
-        value: adminUser,
+        value: adminUser(),
         isOptionEnabled: undefined
       });
 
@@ -89,7 +89,7 @@ describe('Component: RadioGroup', () => {
 
     test('without placeholder', () => {
       const { radioGroup } = setup({
-        value: adminUser,
+        value: adminUser(),
         isOptionEnabled: undefined,
         hasPlaceholder: false
       });
@@ -101,7 +101,7 @@ describe('Component: RadioGroup', () => {
 
     test('without label', () => {
       const { radioGroup } = setup({
-        value: adminUser,
+        value: adminUser(),
         isOptionEnabled: undefined,
         hasLabel: false
       });
@@ -113,7 +113,7 @@ describe('Component: RadioGroup', () => {
 
     test('horizontal', () => {
       const { radioGroup } = setup({
-        value: adminUser,
+        value: adminUser(),
         isOptionEnabled: undefined,
         horizontal: true
       });
@@ -137,12 +137,12 @@ describe('Component: RadioGroup', () => {
       radio.props().onChange({ target: { value: 0 } });
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith(adminUser);
+      expect(onChangeSpy).toHaveBeenCalledWith(adminUser());
     });
 
     it('should clear the value when the cancel button is clicked', () => {
       const { radioGroup, onChangeSpy } = setup({
-        value: adminUser,
+        value: adminUser(),
         canClear: true
       });
 
@@ -160,7 +160,7 @@ describe('Component: RadioGroup', () => {
     describe('isOptionEnabled', () => {
       it('should when "isOptionEnabled" is not defined always be true', () => {
         const { radioGroup } = setup({
-          value: adminUser,
+          value: adminUser(),
           isOptionEnabled: undefined
         });
 
@@ -194,9 +194,9 @@ describe('Component: RadioGroup', () => {
 
         expect(isOptionEnabledSpy).toHaveBeenCalledTimes(3);
         expect(isOptionEnabledSpy.mock.calls).toEqual([
-          [adminUser],
-          [coordinatorUser],
-          [userUser]
+          [adminUser()],
+          [coordinatorUser()],
+          [userUser()]
         ]);
       });
     });
@@ -205,7 +205,7 @@ describe('Component: RadioGroup', () => {
   describe('value changes', () => {
     test('becomes empty', () => {
       const { radioGroup } = setup({
-        value: userUser,
+        value: userUser(),
         isOptionEnabled: undefined
       });
 
@@ -236,7 +236,7 @@ describe('Component: RadioGroup', () => {
       expect(radios.at(1).props().checked).toBe(false);
       expect(radios.at(2).props().checked).toBe(false);
 
-      radioGroup.setProps({ value: coordinatorUser });
+      radioGroup.setProps({ value: coordinatorUser() });
 
       radios = radioGroup.find('Input');
 

--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -44,7 +44,7 @@ storiesOf('Form|Select', module)
           label="Subject"
           placeholder="Please enter your subject"
           optionForValue={(user: User) => user.email}
-          options={() => resolveAfter(pageOfUsers)}
+          options={() => resolveAfter(pageOfUsers())}
           value={subject}
           onChange={setSubject}
         />
@@ -58,9 +58,9 @@ storiesOf('Form|Select', module)
           id="subject"
           label="Subject"
           placeholder="Please enter your subject"
-          value={userUser}
+          value={userUser()}
           optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers)}
+          options={() => Promise.resolve(pageOfUsers())}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           onChange={value => action(`You entered ${value}`)}
         />

--- a/src/form/Select/Select.test.tsx
+++ b/src/form/Select/Select.test.tsx
@@ -34,7 +34,7 @@ describe('Component: Select', () => {
       text,
       isOptionEnabled,
       optionForValue: (user: User) => user?.email,
-      options: [adminUser, coordinatorUser, userUser],
+      options: [adminUser(), coordinatorUser(), userUser()],
       value,
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
@@ -51,7 +51,7 @@ describe('Component: Select', () => {
 
   describe('ui', () => {
     test('with value', () => {
-      setup({ value: adminUser, isOptionEnabled: undefined });
+      setup({ value: adminUser(), isOptionEnabled: undefined });
 
       expect(toJson(select)).toMatchSnapshot(
         'Component: Select => ui => with value'
@@ -86,7 +86,7 @@ describe('Component: Select', () => {
 
     test('without placeholder', () => {
       setup({
-        value: adminUser,
+        value: adminUser(),
         isOptionEnabled: undefined,
         hasPlaceholder: false
       });
@@ -98,7 +98,7 @@ describe('Component: Select', () => {
 
     test('without label', () => {
       setup({
-        value: adminUser,
+        value: adminUser(),
         isOptionEnabled: undefined,
         hasLabel: false
       });
@@ -127,7 +127,7 @@ describe('Component: Select', () => {
     });
 
     it('should not select the placeholder as the default value when value is not an empty string', () => {
-      setup({ value: adminUser, isOptionEnabled: undefined });
+      setup({ value: adminUser(), isOptionEnabled: undefined });
 
       const defaultOption = select.find('option').first();
       expect(defaultOption.text()).toBe('Please enter your subject');
@@ -161,7 +161,7 @@ describe('Component: Select', () => {
       rsInput.props().onChange({ target: { value: 0 } });
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
-      expect(onChangeSpy).toHaveBeenCalledWith(adminUser);
+      expect(onChangeSpy).toHaveBeenCalledWith(adminUser());
     });
 
     test('onBlur', () => {
@@ -176,7 +176,7 @@ describe('Component: Select', () => {
 
     describe('isOptionEnabled', () => {
       it('should when "isOptionEnabled" is not defined always be true', () => {
-        setup({ value: adminUser, isOptionEnabled: undefined });
+        setup({ value: adminUser(), isOptionEnabled: undefined });
 
         const options = select.find('option');
         expect(options.length).toBe(4);
@@ -205,9 +205,9 @@ describe('Component: Select', () => {
 
         expect(isOptionEnabledSpy).toHaveBeenCalledTimes(3);
         expect(isOptionEnabledSpy.mock.calls).toEqual([
-          [adminUser],
-          [coordinatorUser],
-          [userUser]
+          [adminUser()],
+          [coordinatorUser()],
+          [userUser()]
         ]);
       });
     });
@@ -215,7 +215,7 @@ describe('Component: Select', () => {
 
   describe('value changes', () => {
     test('becomes empty', () => {
-      setup({ value: userUser, isOptionEnabled: undefined });
+      setup({ value: userUser(), isOptionEnabled: undefined });
 
       let rsInput = select.find('Input');
       expect(rsInput.props().value).toBe(2);
@@ -232,7 +232,7 @@ describe('Component: Select', () => {
       let rsInput = select.find('Input');
       expect(rsInput.props().value).toBe(undefined);
 
-      select.setProps({ value: coordinatorUser });
+      select.setProps({ value: coordinatorUser() });
 
       rsInput = select.find('Input');
       expect(rsInput.props().value).toBe(1);

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
@@ -20,7 +20,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadMultiple', module)
           placeholder="Please provide all your friends"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -35,7 +37,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadMultiple', module)
           label="Friends"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -50,7 +54,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadMultiple', module)
           placeholder="Please provide all your friends"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -76,7 +82,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadMultiple', module)
           placeholder="Please provide all your friends"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -93,7 +101,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadMultiple', module)
           placeholder="Please provide all your friends"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           jarb={{
             validator: 'User.friends',

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
@@ -55,7 +55,7 @@ describe('Component: TypeaheadMultiple', () => {
 
   describe('ui', () => {
     test('with value', () => {
-      setup({ value: [adminUser] });
+      setup({ value: [adminUser()] });
 
       expect(toJson(typeaheadMultiple)).toMatchSnapshot(
         'Component: TypeaheadMultiple => ui => with value'
@@ -63,7 +63,7 @@ describe('Component: TypeaheadMultiple', () => {
     });
 
     test('without placeholder', () => {
-      setup({ value: [adminUser], hasPlaceholder: false });
+      setup({ value: [adminUser()], hasPlaceholder: false });
 
       expect(toJson(typeaheadMultiple)).toMatchSnapshot(
         'Component: TypeaheadMultiple => ui => without placeholder'
@@ -71,7 +71,7 @@ describe('Component: TypeaheadMultiple', () => {
     });
 
     test('without label', () => {
-      setup({ value: [adminUser], hasLabel: false });
+      setup({ value: [adminUser()], hasLabel: false });
 
       expect(toJson(typeaheadMultiple)).toMatchSnapshot(
         'Component: TypeaheadMultiple => ui => without label'
@@ -124,7 +124,7 @@ describe('Component: TypeaheadMultiple', () => {
     test('fetchOptions', async done => {
       setup({ value: undefined });
 
-      const promise = Promise.resolve(pageOfUsers);
+      const promise = Promise.resolve(pageOfUsers());
 
       fetchOptionsSpy.mockReturnValue(promise);
 
@@ -142,15 +142,15 @@ describe('Component: TypeaheadMultiple', () => {
           options: [
             {
               label: 'admin@42.nl',
-              value: adminUser
+              value: adminUser()
             },
             {
               label: 'coordinator@42.nl',
-              value: coordinatorUser
+              value: coordinatorUser()
             },
             {
               label: 'user@42.nl',
-              value: userUser
+              value: userUser()
             }
           ]
         });
@@ -164,7 +164,7 @@ describe('Component: TypeaheadMultiple', () => {
 
     describe('value changes', () => {
       test('becomes empty', () => {
-        setup({ value: [adminUser] });
+        setup({ value: [adminUser()] });
 
         let asyncTypeahead = typeaheadMultiple
           .find('div')
@@ -173,7 +173,7 @@ describe('Component: TypeaheadMultiple', () => {
         expect(asyncTypeahead.props().selected).toEqual([
           {
             label: 'admin@42.nl',
-            value: adminUser
+            value: adminUser()
           }
         ]);
 
@@ -197,8 +197,10 @@ describe('Component: TypeaheadMultiple', () => {
           .first();
         expect(asyncTypeahead.props().selected).toEqual([]);
 
+        const value = adminUser();
+
         typeaheadMultiple.setProps({
-          value: [adminUser]
+          value: [value]
         });
 
         asyncTypeahead = typeaheadMultiple
@@ -208,7 +210,7 @@ describe('Component: TypeaheadMultiple', () => {
         expect(asyncTypeahead.props().selected).toEqual([
           {
             label: 'admin@42.nl',
-            value: adminUser
+            value
           }
         ]);
 

--- a/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
@@ -19,7 +19,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadSingle', module)
           placeholder="Please provide your best friend"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -34,7 +36,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadSingle', module)
           label="Best friend"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -49,7 +53,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadSingle', module)
           placeholder="Please provide your best friend"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -75,7 +81,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadSingle', module)
           placeholder="Please provide your best friend"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           onChange={value => action(`onChange: ${value}`)}
         />
@@ -92,7 +100,9 @@ storiesOf('Form|Typeahead/JarbTypeaheadSingle', module)
           placeholder="Please provide your best friend"
           optionForValue={(user: User) => user.email}
           fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser, adminUser]))
+            Promise.resolve(
+              pageWithContentAndExactSize([userUser(), adminUser()])
+            )
           }
           jarb={{
             validator: 'User.bestFriend',

--- a/src/form/Typeahead/single/TypeaheadSingle.test.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.test.tsx
@@ -55,7 +55,7 @@ describe('Component: TypeaheadSingle', () => {
 
   describe('ui', () => {
     test('with value', () => {
-      setup({ value: adminUser });
+      setup({ value: adminUser() });
 
       expect(toJson(typeaheadSingle)).toMatchSnapshot(
         'Component: TypeaheadSingle => ui => with value'
@@ -63,7 +63,7 @@ describe('Component: TypeaheadSingle', () => {
     });
 
     test('without placeholder', () => {
-      setup({ value: adminUser, hasPlaceholder: false });
+      setup({ value: adminUser(), hasPlaceholder: false });
 
       expect(toJson(typeaheadSingle)).toMatchSnapshot(
         'Component: TypeaheadSingle => ui => without placeholder'
@@ -71,7 +71,7 @@ describe('Component: TypeaheadSingle', () => {
     });
 
     test('without label', () => {
-      setup({ value: adminUser, hasLabel: false });
+      setup({ value: adminUser(), hasLabel: false });
 
       expect(toJson(typeaheadSingle)).toMatchSnapshot(
         'Component: TypeaheadSingle => ui => without label'
@@ -103,15 +103,17 @@ describe('Component: TypeaheadSingle', () => {
           .children()
           .first();
 
+        const value = adminUser();
+
         asyncTypeahead.props().onChange([
           {
             label: 'Maarten',
-            value: adminUser
+            value
           }
         ]);
 
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
-        expect(onChangeSpy).toHaveBeenCalledWith(adminUser);
+        expect(onChangeSpy).toHaveBeenCalledWith(value);
 
         expect(onBlurSpy).toHaveBeenCalledTimes(1);
       });
@@ -121,7 +123,7 @@ describe('Component: TypeaheadSingle', () => {
       test('value does not match query', async done => {
         setup({ value: undefined });
 
-        const promise = Promise.resolve(pageOfUsers);
+        const promise = Promise.resolve(pageOfUsers());
 
         fetchOptionsSpy.mockReturnValue(promise);
 
@@ -140,15 +142,15 @@ describe('Component: TypeaheadSingle', () => {
             options: [
               {
                 label: 'admin@42.nl',
-                value: adminUser
+                value: adminUser()
               },
               {
                 label: 'coordinator@42.nl',
-                value: coordinatorUser
+                value: coordinatorUser()
               },
               {
                 label: 'user@42.nl',
-                value: userUser
+                value: userUser()
               }
             ]
           });
@@ -165,7 +167,7 @@ describe('Component: TypeaheadSingle', () => {
       test('value matches query', async done => {
         setup({ value: undefined });
 
-        const promise = Promise.resolve(pageOfUsers);
+        const promise = Promise.resolve(pageOfUsers());
 
         fetchOptionsSpy.mockReturnValue(promise);
 
@@ -184,21 +186,21 @@ describe('Component: TypeaheadSingle', () => {
             options: [
               {
                 label: 'admin@42.nl',
-                value: adminUser
+                value: adminUser()
               },
               {
                 label: 'coordinator@42.nl',
-                value: coordinatorUser
+                value: coordinatorUser()
               },
               {
                 label: 'user@42.nl',
-                value: userUser
+                value: userUser()
               }
             ]
           });
 
           expect(onChangeSpy).toHaveBeenCalledTimes(1);
-          expect(onChangeSpy).toHaveBeenCalledWith(adminUser);
+          expect(onChangeSpy).toHaveBeenCalledWith(adminUser());
 
           done();
         } catch (error) {
@@ -210,7 +212,9 @@ describe('Component: TypeaheadSingle', () => {
 
     describe('value changes', () => {
       test('becomes empty', () => {
-        setup({ value: adminUser });
+        const value = adminUser();
+
+        setup({ value: adminUser() });
 
         let asyncTypeahead = typeaheadSingle
           .find('div')
@@ -220,7 +224,7 @@ describe('Component: TypeaheadSingle', () => {
         expect(asyncTypeahead.props().selected).toEqual([
           {
             label: 'admin@42.nl',
-            value: adminUser
+            value
           }
         ]);
 
@@ -244,8 +248,10 @@ describe('Component: TypeaheadSingle', () => {
           .first();
         expect(asyncTypeahead.props().selected).toEqual([]);
 
+        const value = adminUser();
+
         typeaheadSingle.setProps({
-          value: adminUser
+          value
         });
 
         asyncTypeahead = typeaheadSingle
@@ -255,7 +261,7 @@ describe('Component: TypeaheadSingle', () => {
         expect(asyncTypeahead.props().selected).toEqual([
           {
             label: 'admin@42.nl',
-            value: adminUser
+            value
           }
         ]);
 

--- a/src/form/ValuePicker/ValuePicker.stories.tsx
+++ b/src/form/ValuePicker/ValuePicker.stories.tsx
@@ -11,36 +11,53 @@ import { FinalForm, Form } from '../story-utils';
 import Button from '../../core/Button/Button';
 import { Tooltip, Icon } from '../..';
 
-const small = Promise.resolve(
-  pageWithContentAndExactSize([userUser, adminUser])
-);
+/*
+  Storing users here instead of calling the fixtures again so
+  options remain selected.
+*/
+const user = userUser();
+const admin = adminUser();
+
+const randomUser1 = randomUser();
+const randomUser2 = randomUser();
+const randomUser3 = randomUser();
+const randomUser4 = randomUser();
+const randomUser5 = randomUser();
+const randomUser6 = randomUser();
+const randomUser7 = randomUser();
+const randomUser8 = randomUser();
+const randomUser9 = randomUser();
+const randomUser10 = randomUser();
+const randomUser11 = randomUser();
+
+const small = Promise.resolve(pageWithContentAndExactSize([user, admin]));
 
 const medium = Promise.resolve(
   pageWithContentAndExactSize([
-    userUser,
-    adminUser,
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser()
+    user,
+    admin,
+    randomUser1,
+    randomUser2,
+    randomUser3,
+    randomUser4
   ])
 );
 
 const large = Promise.resolve(
   pageWithContent([
-    userUser,
-    adminUser,
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser(),
-    randomUser()
+    user,
+    admin,
+    randomUser1,
+    randomUser2,
+    randomUser3,
+    randomUser4,
+    randomUser5,
+    randomUser6,
+    randomUser7,
+    randomUser8,
+    randomUser9,
+    randomUser10,
+    randomUser11
   ])
 );
 
@@ -78,7 +95,7 @@ storiesOf('Form|ValuePicker/multiple', module)
     );
   })
   .add('custom isOptionEqual', () => {
-    const [value, setValue] = useState<User[] | undefined>([userUser]);
+    const [value, setValue] = useState<User[] | undefined>([user]);
 
     const [size, setSize] = useState('small');
 

--- a/src/form/ValuePicker/ValuePicker.test.tsx
+++ b/src/form/ValuePicker/ValuePicker.test.tsx
@@ -68,9 +68,9 @@ describe('Component: ValuePicker', () => {
     it('should render a `RadioGroup` component when `totalElements` is less than 4', async done => {
       const promise = Promise.resolve(
         testUtils.pageWithContentAndExactSize([
-          adminUser,
-          coordinatorUser,
-          userUser
+          adminUser(),
+          coordinatorUser(),
+          userUser()
         ])
       );
 
@@ -105,10 +105,10 @@ describe('Component: ValuePicker', () => {
     it('should render a `Select` component when `totalElements` is less than 11 but more than 3', async done => {
       const promise = Promise.resolve(
         testUtils.pageWithContentAndExactSize([
-          adminUser,
-          coordinatorUser,
-          userUser,
-          nobodyUser
+          adminUser(),
+          coordinatorUser(),
+          userUser(),
+          nobodyUser()
         ])
       );
 
@@ -142,7 +142,7 @@ describe('Component: ValuePicker', () => {
 
     it('should render a `ModalPickerSingle` when `totalElements` is more than than 10', async done => {
       const promise = Promise.resolve(
-        testUtils.pageWithContent([adminUser, coordinatorUser, userUser])
+        testUtils.pageWithContent([adminUser(), coordinatorUser(), userUser()])
       );
 
       const fetchOptionsSpy = jest.fn(() => promise);
@@ -178,9 +178,9 @@ describe('Component: ValuePicker', () => {
     it('should render a `CheckboxMultipleSelect` component when `totalElements` is less than 11', async done => {
       const promise = Promise.resolve(
         testUtils.pageWithContentAndExactSize([
-          adminUser,
-          coordinatorUser,
-          userUser
+          adminUser(),
+          coordinatorUser(),
+          userUser()
         ])
       );
 
@@ -214,7 +214,7 @@ describe('Component: ValuePicker', () => {
 
     it('should render a `ModalPickerMultiple` when `totalElements` is more than 10', async done => {
       const promise = Promise.resolve(
-        testUtils.pageWithContent([adminUser, coordinatorUser, userUser])
+        testUtils.pageWithContent([adminUser(), coordinatorUser(), userUser()])
       );
 
       const fetchOptionsSpy = jest.fn(() => promise);

--- a/src/form/useOptions.test.ts
+++ b/src/form/useOptions.test.ts
@@ -14,8 +14,8 @@ describe('useOptions', () => {
   describe('when optionsOrFetcher is an array', () => {
     test('that the options are used as is and loading is false', () => {
       const config = {
-        optionsOrFetcher: [userUser, coordinatorUser, adminUser],
-        value: userUser,
+        optionsOrFetcher: [userUser(), coordinatorUser(), adminUser()],
+        value: userUser(),
         optionForValue: user => user.email,
         isOptionEqual: (a, b) => a.id === b.id
       };
@@ -23,15 +23,15 @@ describe('useOptions', () => {
       const { result } = renderHook(() => useOptions(config));
 
       expect(result.current).toEqual({
-        options: [userUser, coordinatorUser, adminUser],
+        options: [userUser(), coordinatorUser(), adminUser()],
         loading: false
       });
     });
 
     test('that when the value is set but not in options that it is added to the options on the first place', () => {
       const config = {
-        optionsOrFetcher: [userUser, coordinatorUser, adminUser],
-        value: nobodyUser,
+        optionsOrFetcher: [userUser(), coordinatorUser(), adminUser()],
+        value: nobodyUser(),
         optionForValue: user => user.email,
         isOptionEqual: (a, b) => a.id === b.id
       };
@@ -39,7 +39,7 @@ describe('useOptions', () => {
       const { result } = renderHook(() => useOptions(config));
 
       expect(result.current).toEqual({
-        options: [nobodyUser, userUser, coordinatorUser, adminUser],
+        options: [nobodyUser(), userUser(), coordinatorUser(), adminUser()],
         loading: false
       });
     });
@@ -49,7 +49,7 @@ describe('useOptions', () => {
     test('that the options are fetched', async () => {
       const config = {
         optionsOrFetcher: () =>
-          Promise.resolve(pageOf([adminUser, userUser], 1)),
+          Promise.resolve(pageOf([adminUser(), userUser()], 1)),
         value: undefined,
         optionForValue: user => user.email,
         isOptionEqual: (a, b) => a.id === b.id
@@ -67,7 +67,7 @@ describe('useOptions', () => {
       await waitForNextUpdate();
 
       expect(result.current).toEqual({
-        options: [adminUser, userUser],
+        options: [adminUser(), userUser()],
         loading: false
       });
     });
@@ -80,7 +80,9 @@ describe('useOptions', () => {
             optionsOrFetcher: () =>
               Promise.resolve(
                 pageOf(
-                  watch === 'filter' ? [adminUser] : [adminUser, userUser],
+                  watch === 'filter'
+                    ? [adminUser()]
+                    : [adminUser(), userUser()],
                   1
                 )
               ),
@@ -100,7 +102,7 @@ describe('useOptions', () => {
       await waitForNextUpdate();
 
       expect(result.current).toEqual({
-        options: [adminUser, userUser],
+        options: [adminUser(), userUser()],
         loading: false
       });
 
@@ -109,7 +111,7 @@ describe('useOptions', () => {
       await waitForNextUpdate();
 
       expect(result.current).toEqual({
-        options: [adminUser],
+        options: [adminUser()],
         loading: false
       });
     });
@@ -117,8 +119,8 @@ describe('useOptions', () => {
     test('that when the value is set but not in options that it is added to the options on the first place', async () => {
       const config = {
         optionsOrFetcher: () =>
-          Promise.resolve(pageOf([adminUser, userUser], 1)),
-        value: nobodyUser,
+          Promise.resolve(pageOf([adminUser(), userUser()], 1)),
+        value: nobodyUser(),
         optionForValue: user => user.email,
         isOptionEqual: (a, b) => a.id === b.id
       };
@@ -128,14 +130,14 @@ describe('useOptions', () => {
       );
 
       expect(result.current).toEqual({
-        options: [nobodyUser],
+        options: [nobodyUser()],
         loading: true
       });
 
       await waitForNextUpdate();
 
       expect(result.current).toEqual({
-        options: [nobodyUser, adminUser, userUser],
+        options: [nobodyUser(), adminUser(), userUser()],
         loading: false
       });
     });

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -26,57 +26,59 @@ export function randomUser(): User {
   };
 }
 
-const admin = {
-  id: 42,
-  email: 'admin@42.nl',
-  firstName: 'admin',
-  lastName: 'user',
-  active: true,
-  roles: [UserRole.ADMIN]
-};
+export function adminUser() {
+  return {
+    id: 42,
+    email: 'admin@42.nl',
+    firstName: 'admin',
+    lastName: 'user',
+    active: true,
+    roles: [UserRole.ADMIN]
+  };
+}
 
-export const adminUser = Object.freeze(admin);
+export function userUser() {
+  return {
+    id: 1337,
+    email: 'user@42.nl',
+    firstName: 'test',
+    lastName: 'user',
+    active: false,
+    roles: [UserRole.USER]
+  };
+}
 
-const user = {
-  id: 1337,
-  email: 'user@42.nl',
-  firstName: 'test',
-  lastName: 'user',
-  active: false,
-  roles: [UserRole.USER]
-};
+export function coordinatorUser() {
+  return {
+    id: 777,
+    email: 'coordinator@42.nl',
+    firstName: 'coordinator',
+    lastName: 'user',
+    active: false,
+    roles: [UserRole.ADMIN, UserRole.USER]
+  };
+}
 
-export const userUser = Object.freeze(user);
+export function nobodyUser() {
+  return {
+    id: 999,
+    email: 'nobody@42.nl',
+    firstName: 'no',
+    lastName: 'body',
+    active: false,
+    roles: []
+  };
+}
 
-const coordinator = {
-  id: 777,
-  email: 'coordinator@42.nl',
-  firstName: 'coordinator',
-  lastName: 'user',
-  active: false,
-  roles: [UserRole.ADMIN, UserRole.USER]
-};
-
-export const coordinatorUser = Object.freeze(coordinator);
-
-const nobody = {
-  id: 999,
-  email: 'nobody@42.nl',
-  firstName: 'no',
-  lastName: 'body',
-  active: false,
-  roles: []
-};
-
-export const nobodyUser = Object.freeze(nobody);
-
-export const pageOfUsers: Page<User> = Object.freeze({
-  content: [adminUser, coordinatorUser, userUser],
-  last: false,
-  totalElements: 9,
-  totalPages: 3,
-  size: 3,
-  number: 2,
-  first: false,
-  numberOfElements: 3
-});
+export function pageOfUsers(): Page<User> {
+  return {
+    content: [adminUser(), coordinatorUser(), userUser()],
+    last: false,
+    totalElements: 9,
+    totalPages: 3,
+    size: 3,
+    number: 2,
+    first: false,
+    numberOfElements: 3
+  };
+}


### PR DESCRIPTION
The deselect broke when using a custom `isOptionEqual` callback. The
idea of the `isOptionEqual` is that you can say that two objects are
equal based on something other than the default reference equality.
The canonical usecase being checking two `id`'s.

In both the `CheckboxMultipleSelect`, and `ModalPickerMultiple` when
clicking an option a routine is executed when an option is selected,
which should remove it when it is already selected.

In both cases de deselection uses a filter:

```ts
   selected = selected.filter(v: T) => v !== item);
```

Of course this filter uses simple reference equality. Which in cases
when using `isOptionEqual` breaks, because the user will provide us with
different `objects` each time, which of course breaks selection.

The fix is using the `isOptionEqual` instead, simple enough.

However how did this bug exist in the first place. We use objects
everywere in our test and stories? The answer is that the fixtures
are frozen objects. This makes reference equality work... by accident.

Changed all fixtures to be functions instead, this way we always create
new instances, and then these bugs are caught more easily. Of course
this meant changing the code which use the fixtures.

Closes: #447