### PR TITLE
improvement: added vertical mode to DateRangePicker.

### DIFF
--- a/src/form/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/form/DateRangePicker/DateRangePicker.stories.tsx
@@ -31,6 +31,32 @@ storiesOf('Form|DateTime/DateRangePicker', module)
       </Form>
     );
   })
+  .add('vertical', () => {
+    return (
+      <Form>
+        <DateRangePicker
+          horizontal={false}
+          onChange={() => action('value changed')}
+          from={{
+            id: 'fromId',
+            label: 'From Date',
+            placeholder: 'Please enter a From date',
+            dateFormat: 'YYYY-MM-DD',
+            timeFormat: 'HH:mm:ss',
+            isDateAllowed: current => current.day() !== 0 && current.day() !== 6
+          }}
+          to={{
+            id: 'toId',
+            label: 'To Date',
+            placeholder: 'Please enter a To date',
+            dateFormat: 'YYYY-MM-DD',
+            timeFormat: 'HH:mm:ss',
+            isDateAllowed: current => current.day() !== 0 && current.day() !== 6
+          }}
+        />
+      </Form>
+    );
+  })
   .add('open in modal', () => {
     return (
       <Form>

--- a/src/form/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/form/DateRangePicker/DateRangePicker.test.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import DateRangePicker, { Value } from './DateRangePicker';
+import { Mode } from '../DateTimeInput/DateTimeInput';
 
 describe('Component: DateRangePicker', () => {
   let dateRangePicker: ShallowWrapper;
@@ -13,11 +14,13 @@ describe('Component: DateRangePicker', () => {
   function setup({
     value,
     onFocus,
-    mode
+    mode,
+    horizontal
   }: {
     value: Value;
     onFocus: boolean;
-    mode?: 'modal' | 'default';
+    mode?: Mode;
+    horizontal?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onFocusSpy = jest.fn();
@@ -25,6 +28,7 @@ describe('Component: DateRangePicker', () => {
     dateRangePicker = shallow(
       <DateRangePicker
         value={value}
+        horizontal={horizontal}
         onChange={onChangeSpy}
         onFocus={onFocus ? onFocusSpy : undefined}
         from={{
@@ -90,6 +94,20 @@ describe('Component: DateRangePicker', () => {
       });
       expect(toJson(dateRangePicker)).toMatchSnapshot(
         'Component: DateRangePicker => ui => open in modal'
+      );
+    });
+
+    test('vertical', () => {
+      setup({
+        value: {
+          from: new Date(2200, 0, 1, 12, 30, 40),
+          to: new Date(2010, 0, 1, 12, 30, 40)
+        },
+        onFocus: false,
+        horizontal: false
+      });
+      expect(toJson(dateRangePicker)).toMatchSnapshot(
+        'Component: DateRangePicker => ui => horizontal'
       );
     });
   });

--- a/src/form/DateRangePicker/DateRangePicker.tsx
+++ b/src/form/DateRangePicker/DateRangePicker.tsx
@@ -4,7 +4,8 @@ import { get } from 'lodash';
 import { Color, DistributiveOmit } from '../types';
 
 import DateTimeInput, {
-  Props as DateTimeInputProps
+  Props as DateTimeInputProps,
+  Mode
 } from '../DateTimeInput/DateTimeInput';
 
 import withJarb from '../withJarb/withJarb';
@@ -93,7 +94,14 @@ interface Props {
    * Whether or not the date picker should be displayed in a modal.
    * Defaults to opening in a tooltip-like layout.
    */
-  mode?: 'modal' | 'default';
+  mode?: Mode;
+
+  /**
+   * Whether or not the date picker should be shown horizontally.
+   *
+   * Defaults to `true`.
+   */
+  horizontal?: boolean;
 }
 
 interface State {
@@ -154,11 +162,17 @@ export default class DateRangePicker extends Component<Props, State> {
   }
 
   render() {
-    const { className = '', valid, color, mode } = this.props;
+    const {
+      className = '',
+      valid,
+      color,
+      mode,
+      horizontal = true
+    } = this.props;
 
     return (
       <Row className={`date-range-picker ${className}`}>
-        <Col sm="12" md="6">
+        <Col sm="12" md={horizontal ? '6' : '12'}>
           <DateTimeInput
             {...this.props.from}
             value={this.state.fromDate}
@@ -169,7 +183,11 @@ export default class DateRangePicker extends Component<Props, State> {
             mode={mode}
           />
         </Col>
-        <Col sm="12" md="6">
+        <Col
+          sm="12"
+          md={horizontal ? '6' : '12'}
+          className={!horizontal ? 'mt-2' : undefined}
+        >
           <DateTimeInput
             {...this.props.to}
             value={this.state.toDate}

--- a/src/form/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/src/form/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -182,6 +182,100 @@ exports[`Component: DateRangePicker ui open in modal: Component: DateRangePicker
 </Row>
 `;
 
+exports[`Component: DateRangePicker ui vertical: Component: DateRangePicker => ui => horizontal 1`] = `
+<Row
+  className="date-range-picker "
+  tag="div"
+  widths={
+    Array [
+      "xs",
+      "sm",
+      "md",
+      "lg",
+      "xl",
+    ]
+  }
+>
+  <Col
+    md="12"
+    sm="12"
+    tag="div"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    <DateTimeInput
+      color="danger"
+      dateFormat="YYYY-MM-DD"
+      id="fromId"
+      isDateAllowed={[Function]}
+      label="From Date"
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="Please enter a From date"
+      timeFormat="HH:mm:ss"
+      valid={false}
+      value={2200-01-01T11:30:40.000Z}
+    />
+  </Col>
+  <Col
+    className="mt-2"
+    md="12"
+    sm="12"
+    tag="div"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    <DateTimeInput
+      color="danger"
+      dateFormat="YYYY-MM-DD"
+      id="toId"
+      isDateAllowed={[Function]}
+      label="To Date"
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="Please enter a To date"
+      timeFormat="HH:mm:ss"
+      valid={false}
+      value={2010-01-01T11:30:40.000Z}
+    />
+  </Col>
+  <Col
+    className="mb-2"
+    tag="div"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+    xs="12"
+  >
+    <FormFeedback
+      tag="div"
+    >
+      The "From Date" must be before the "To Date"
+    </FormFeedback>
+  </Col>
+</Row>
+`;
+
 exports[`Component: DateRangePicker ui with errors: Component: DateRangePicker => ui => with errors 1`] = `
 <Row
   className="date-range-picker "

--- a/src/form/DateTimeInput/DateTimeInput.test.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.test.tsx
@@ -5,7 +5,7 @@ import toJson from 'enzyme-to-json';
 import moment from 'moment';
 import Datetime from 'react-datetime';
 
-import DateTimeInput, { IsDateAllowed } from './DateTimeInput';
+import DateTimeInput, { IsDateAllowed, Mode } from './DateTimeInput';
 import * as FormatError from './useHasFormatError/useHasFormatError';
 import * as IsModalOpen from './useIsModalOpen/useIsModalOpen';
 
@@ -25,7 +25,7 @@ describe('Component: DateTimeInput', () => {
     value?: Date;
     isDateAllowed?: IsDateAllowed;
     hasLabel?: boolean;
-    mode?: 'modal' | 'default';
+    mode?: Mode;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();

--- a/src/form/DateTimeInput/DateTimeInput.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.tsx
@@ -23,6 +23,8 @@ import Addon from '../Input/Addon/Addon';
  */
 export type IsDateAllowed = (date: Moment, selectedDate?: Moment) => boolean;
 
+export type Mode = 'modal' | 'default';
+
 export interface Props {
   /**
    * The id of the form element.
@@ -116,7 +118,7 @@ export interface Props {
    * Whether or not the date picker should be displayed in a modal.
    * Defaults to opening in a tooltip-like layout.
    */
-  mode?: 'modal' | 'default';
+  mode?: Mode;
 
   /**
    * Optionally customized text within the DateTimeModal component.

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
@@ -110,6 +110,7 @@ export function DateTimeModal(props: Props) {
       text={text}
       size="sm"
       className="date-time-modal"
+      stickyFooter={false}
     >
       <Datetime
         input={false}

--- a/src/form/DateTimeInput/DateTimeModal/__snapshots__/DateTimeModal.test.tsx.snap
+++ b/src/form/DateTimeInput/DateTimeModal/__snapshots__/DateTimeModal.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Component: DateTimeModal ui with value: Component: DateTimeModal => ui 
   onClose={[MockFunction]}
   onSave={[Function]}
   size="sm"
+  stickyFooter={false}
   text={
     Object {
       "save": "Select",
@@ -45,6 +46,7 @@ exports[`Component: DateTimeModal ui without value: Component: DateTimeModal => 
   onClose={[MockFunction]}
   onSave={[Function]}
   size="sm"
+  stickyFooter={false}
   text={
     Object {
       "save": "Select",


### PR DESCRIPTION
When `horizontal` is `false` it will render vertically. By default it
will render horizontally.

Also gave the `mode` a shared type definition.

Closes: #444