### PR TITLE
fix: storybook "show code" was broken.

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -1,6 +1,8 @@
 import '../src/main.scss';
 import {setConstraints} from "@42.nl/jarb-final-form/lib";
 
+import "./show-code-fix.scss";
+
 setConstraints({
   Person: {
     firstName: {

--- a/storybook/show-code-fix.scss
+++ b/storybook/show-code-fix.scss
@@ -1,0 +1,24 @@
+/* 
+  Hack to fix "show code" buttons see: 
+  
+  https://github.com/42BV/ui/issues/94 
+*/
+
+pre.hljs {
+  color: inherit;
+
+  code {
+    .tag,
+    .token {
+      display: inline;
+      margin-right: 0px;
+      cursor: auto;
+      color: inherit;
+      background-color: rgba(0, 0, 0, 0);
+      padding-left: 0;
+      padding-right: 0;
+      font-size: 1em;
+      font-weight: normal;
+    }
+  }
+}


### PR DESCRIPTION
The "show code" would add CSS on the `.tag` and `.token` which clashed
with the CSS from our own `Tag` component. Fixed by resetting the style
for `.token` and `.tag` under `pre.hljs > code` elements.

Thanks @arjanvlek.

Closes: #94