### PR TITLE
fix: options mapping

### DIFF
--- a/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
+++ b/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
   <FormGroup
     check={true}
     inline={true}
-    key="admin@42.nl"
+    key="42"
     tag="div"
   >
     <Label
@@ -60,7 +60,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
   <FormGroup
     check={true}
     inline={true}
-    key="coordinator@42.nl"
+    key="777"
     tag="div"
   >
     <Label
@@ -90,7 +90,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
   <FormGroup
     check={true}
     inline={true}
-    key="user@42.nl"
+    key="1337"
     tag="div"
   >
     <Label
@@ -182,7 +182,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
       <FormGroup
         check={true}
         inline={false}
-        key="admin@42.nl"
+        key="42"
         tag="div"
       >
         <Label
@@ -212,7 +212,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
       <FormGroup
         check={true}
         inline={false}
-        key="coordinator@42.nl"
+        key="777"
         tag="div"
       >
         <Label
@@ -242,7 +242,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
       <FormGroup
         check={true}
         inline={false}
-        key="user@42.nl"
+        key="1337"
         tag="div"
       >
         <Label
@@ -321,7 +321,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
       <FormGroup
         check={true}
         inline={false}
-        key="admin@42.nl"
+        key="42"
         tag="div"
       >
         <Label
@@ -351,7 +351,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
       <FormGroup
         check={true}
         inline={false}
-        key="coordinator@42.nl"
+        key="777"
         tag="div"
       >
         <Label
@@ -381,7 +381,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
       <FormGroup
         check={true}
         inline={false}
-        key="user@42.nl"
+        key="1337"
         tag="div"
       >
         <Label
@@ -468,7 +468,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
       <FormGroup
         check={true}
         inline={false}
-        key="admin@42.nl"
+        key="42"
         tag="div"
       >
         <Label
@@ -498,7 +498,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
       <FormGroup
         check={true}
         inline={false}
-        key="coordinator@42.nl"
+        key="777"
         tag="div"
       >
         <Label
@@ -528,7 +528,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
       <FormGroup
         check={true}
         inline={false}
-        key="user@42.nl"
+        key="1337"
         tag="div"
       >
         <Label

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -12,10 +12,12 @@ import { AddButtonCallback, AddButtonOptions, ButtonAlignment } from '../types';
 import {
   FetchOptionsCallback,
   isOptionSelected,
+  keyForOption,
   OptionEqual,
   OptionForValue,
   RenderOptions,
-  RenderOptionsOption
+  RenderOptionsOption,
+  UniqueKeyForValue
 } from '../../option';
 import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
 import { ModalPickerValueTruncator } from '../ModalPickerValueTruncator/ModalPickerValueTruncator';
@@ -102,6 +104,13 @@ interface BaseProps<T> {
    * Optionally callback to display the selected items.
    */
   displayValues?: DisplayValues<T>;
+
+  /**
+   * Optional callback to get a unique key for an item.
+   * This is used to provide each option in the form element a unique key.
+   * Defaults to the 'id' property if it exists, otherwise uses optionForValue.
+   */
+  uniqueKeyForValue?: UniqueKeyForValue<T>;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -339,7 +348,13 @@ export default class ModalPickerMultiple<T> extends React.Component<
       return <EmptyModal userHasSearched={this.state.userHasSearched} />;
     }
 
-    const { optionForValue, isOptionEqual, ...props } = this.props;
+    const {
+      optionForValue,
+      isOptionEqual,
+      // @ts-ignore
+      uniqueKeyForValue,
+      ...props
+    } = this.props;
 
     if ('renderOptions' in props && props.renderOptions) {
       return props.renderOptions(
@@ -349,6 +364,7 @@ export default class ModalPickerMultiple<T> extends React.Component<
 
     return page.content.map(option => {
       const label = optionForValue(option);
+      const key = keyForOption({ option, uniqueKeyForValue, optionForValue });
 
       const isChecked = isOptionSelected({
         option,
@@ -358,11 +374,10 @@ export default class ModalPickerMultiple<T> extends React.Component<
       });
 
       return (
-        <FormGroup key={label} check>
+        <FormGroup key={key} check>
           <Label check>
             <Input
               type="checkbox"
-              name={label}
               checked={isChecked}
               onChange={() => this.itemClicked(option, isChecked)}
             />

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -11,10 +11,12 @@ import { Color } from '../../types';
 import {
   FetchOptionsCallback,
   isOptionSelected,
+  keyForOption,
   OptionEqual,
   OptionForValue,
   RenderOptions,
-  RenderOptionsOption
+  RenderOptionsOption,
+  UniqueKeyForValue
 } from '../../option';
 import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
 import { ModalPickerValueTruncator } from '../ModalPickerValueTruncator/ModalPickerValueTruncator';
@@ -101,6 +103,13 @@ interface BaseProps<T> {
    * Optionally callback to display the selected item.
    */
   displayValues?: DisplayValue<T>;
+
+  /**
+   * Optional callback to get a unique key for an item.
+   * This is used to provide each option in the form element a unique key.
+   * Defaults to the 'id' property if it exists, otherwise uses optionForValue.
+   */
+  uniqueKeyForValue?: UniqueKeyForValue<T>;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -323,7 +332,12 @@ export default class ModalPickerSingle<T> extends React.Component<
       return <EmptyModal userHasSearched={this.state.userHasSearched} />;
     }
 
-    const { optionForValue, isOptionEqual, ...props } = this.props;
+    const {
+      optionForValue,
+      isOptionEqual,
+      uniqueKeyForValue,
+      ...props
+    } = this.props;
 
     if ('renderOptions' in props && props.renderOptions) {
       return props.renderOptions(
@@ -333,20 +347,21 @@ export default class ModalPickerSingle<T> extends React.Component<
 
     return page.content.map((option: T) => {
       const label = optionForValue(option);
+      const key = keyForOption({ option, uniqueKeyForValue, optionForValue });
 
       const isChecked = isOptionSelected({
         option,
+        uniqueKeyForValue,
         optionForValue,
         isOptionEqual,
         value: selected
       });
 
       return (
-        <FormGroup key={label} check>
+        <FormGroup key={key} check>
           <Label check>
             <Input
               type="radio"
-              name={label}
               checked={isChecked}
               onChange={() => this.itemClicked(option)}
             />

--- a/src/form/RadioGroup/RadioGroup.tsx
+++ b/src/form/RadioGroup/RadioGroup.tsx
@@ -7,10 +7,12 @@ import { Color } from '../types';
 import { t } from '../../utilities/translation/translation';
 import {
   isOptionSelected,
+  keyForOption,
   OptionEnabledCallback,
   OptionEqual,
   OptionForValue,
-  OptionsFetcher
+  OptionsFetcher,
+  UniqueKeyForValue
 } from '../option';
 import { doBlur } from '../utils';
 import Loading from '../../core/Loading/Loading';
@@ -130,6 +132,13 @@ interface BaseProps<T> {
    * the optionsFetcher to reload the options.
    */
   watch?: any;
+
+  /**
+   * Optional callback to get a unique key for an item.
+   * This is used to provide each option in the form element a unique key.
+   * Defaults to the 'id' property if it exists, otherwise uses optionForValue.
+   */
+  uniqueKeyForValue?: UniqueKeyForValue<T>;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -159,6 +168,7 @@ export default function RadioGroup<T>(props: Props<T>) {
     placeholder,
     onChange,
     onBlur,
+    uniqueKeyForValue,
     optionForValue,
     isOptionEqual,
     horizontal = false,
@@ -218,15 +228,21 @@ export default function RadioGroup<T>(props: Props<T>) {
 
           {options.map(option => {
             const label = optionForValue(option);
+            const key = keyForOption({
+              option,
+              uniqueKeyForValue,
+              optionForValue
+            });
 
             return (
-              <FormGroup key={label} check inline={horizontal}>
+              <FormGroup key={key} check inline={horizontal}>
                 <Label check>
                   <Input
                     type="radio"
                     value={label}
                     checked={isOptionSelected({
                       option,
+                      uniqueKeyForValue,
                       optionForValue,
                       isOptionEqual,
                       value

--- a/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
   <FormGroup
     check={true}
     inline={true}
-    key="admin@42.nl"
+    key="42"
     tag="div"
   >
     <Label
@@ -48,7 +48,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
   <FormGroup
     check={true}
     inline={true}
-    key="coordinator@42.nl"
+    key="777"
     tag="div"
   >
     <Label
@@ -78,7 +78,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
   <FormGroup
     check={true}
     inline={true}
-    key="user@42.nl"
+    key="1337"
     tag="div"
   >
     <Label
@@ -127,7 +127,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
   <FormGroup
     check={true}
     inline={false}
-    key="admin@42.nl"
+    key="42"
     tag="div"
   >
     <Label
@@ -157,7 +157,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
   <FormGroup
     check={true}
     inline={false}
-    key="coordinator@42.nl"
+    key="777"
     tag="div"
   >
     <Label
@@ -187,7 +187,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
   <FormGroup
     check={true}
     inline={false}
-    key="user@42.nl"
+    key="1337"
     tag="div"
   >
     <Label
@@ -233,7 +233,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
   <FormGroup
     check={true}
     inline={false}
-    key="admin@42.nl"
+    key="42"
     tag="div"
   >
     <Label
@@ -263,7 +263,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
   <FormGroup
     check={true}
     inline={false}
-    key="coordinator@42.nl"
+    key="777"
     tag="div"
   >
     <Label
@@ -293,7 +293,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
   <FormGroup
     check={true}
     inline={false}
-    key="user@42.nl"
+    key="1337"
     tag="div"
   >
     <Label
@@ -335,7 +335,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
   <FormGroup
     check={true}
     inline={false}
-    key="admin@42.nl"
+    key="42"
     tag="div"
   >
     <Label
@@ -365,7 +365,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
   <FormGroup
     check={true}
     inline={false}
-    key="coordinator@42.nl"
+    key="777"
     tag="div"
   >
     <Label
@@ -395,7 +395,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
   <FormGroup
     check={true}
     inline={false}
-    key="user@42.nl"
+    key="1337"
     tag="div"
   >
     <Label

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -8,10 +8,12 @@ import { Color } from '../types';
 import { t } from '../../utilities/translation/translation';
 import {
   isOptionSelected,
+  keyForOption,
   OptionEnabledCallback,
   OptionEqual,
   OptionForValue,
-  OptionsFetcher
+  OptionsFetcher,
+  UniqueKeyForValue
 } from '../option';
 import { useOptions } from '../useOptions';
 import Loading from '../../core/Loading/Loading';
@@ -105,6 +107,13 @@ interface BaseProps<T> {
    * the optionsFetcher to reload the options.
    */
   watch?: any;
+
+  /**
+   * Optional callback to get a unique key for an item.
+   * This is used to provide each option in the form element a unique key.
+   * Defaults to the 'id' property if it exists, otherwise uses optionForValue.
+   */
+  uniqueKeyForValue?: UniqueKeyForValue<T>;
 }
 
 interface WithoutLabel<T> extends BaseProps<T> {
@@ -141,6 +150,7 @@ export default function Select<T>(props: Props<T>) {
     placeholder,
     onChange,
     onBlur,
+    uniqueKeyForValue,
     optionForValue,
     isOptionEqual,
     watch
@@ -149,6 +159,7 @@ export default function Select<T>(props: Props<T>) {
   const { options, loading } = useOptions({
     optionsOrFetcher: props.options,
     value,
+    uniqueKeyForValue,
     isOptionEqual,
     optionForValue,
     watch
@@ -179,7 +190,13 @@ export default function Select<T>(props: Props<T>) {
   const indexOfValue =
     value !== undefined
       ? options.findIndex(option =>
-          isOptionSelected({ option, optionForValue, isOptionEqual, value })
+          isOptionSelected({
+            option,
+            uniqueKeyForValue,
+            optionForValue,
+            isOptionEqual,
+            value
+          })
         )
       : undefined;
 
@@ -207,10 +224,15 @@ export default function Select<T>(props: Props<T>) {
 
           {options.map((option, index) => {
             const label = optionForValue(option);
+            const key = keyForOption({
+              option,
+              uniqueKeyForValue,
+              optionForValue
+            });
 
             return (
               <option
-                key={label}
+                key={key}
                 // @ts-ignore
                 value={index}
                 disabled={!isOptionEnabled(option)}

--- a/src/form/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/form/Select/__snapshots__/Select.test.tsx.snap
@@ -36,21 +36,21 @@ exports[`Component: Select ui with value: Component: Select => ui => with value 
     </option>
     <option
       disabled={false}
-      key="admin@42.nl"
+      key="42"
       value={0}
     >
       admin@42.nl
     </option>
     <option
       disabled={false}
-      key="coordinator@42.nl"
+      key="777"
       value={1}
     >
       coordinator@42.nl
     </option>
     <option
       disabled={false}
-      key="user@42.nl"
+      key="1337"
       value={2}
     >
       user@42.nl
@@ -80,21 +80,21 @@ exports[`Component: Select ui without label: Component: Select => ui => without 
     </option>
     <option
       disabled={false}
-      key="admin@42.nl"
+      key="42"
       value={0}
     >
       admin@42.nl
     </option>
     <option
       disabled={false}
-      key="coordinator@42.nl"
+      key="777"
       value={1}
     >
       coordinator@42.nl
     </option>
     <option
       disabled={false}
-      key="user@42.nl"
+      key="1337"
       value={2}
     >
       user@42.nl
@@ -137,21 +137,21 @@ exports[`Component: Select ui without placeholder: Component: Select => ui => wi
     <option />
     <option
       disabled={false}
-      key="admin@42.nl"
+      key="42"
       value={0}
     >
       admin@42.nl
     </option>
     <option
       disabled={false}
-      key="coordinator@42.nl"
+      key="777"
       value={1}
     >
       coordinator@42.nl
     </option>
     <option
       disabled={false}
-      key="user@42.nl"
+      key="1337"
       value={2}
     >
       user@42.nl

--- a/src/form/ValuePicker/ValuePicker.tsx
+++ b/src/form/ValuePicker/ValuePicker.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Color } from '../types';
-import { FetchOptionsCallback, OptionEqual, OptionForValue } from '../option';
+import {
+  FetchOptionsCallback,
+  OptionEqual,
+  OptionForValue,
+  UniqueKeyForValue
+} from '../option';
 import withJarb from '../withJarb/withJarb';
 
 import ModalPickerMultiple from '../ModalPicker/multiple/ModalPickerMultiple';
@@ -79,6 +84,13 @@ interface BaseValuePickerProps<T> {
    * This text should already be translated.
    */
   text?: Text;
+
+  /**
+   * Optional callback to get a unique key for an item.
+   * This is used to provide each option in the form element a unique key.
+   * Defaults to the 'id' property if it exists, otherwise uses optionForValue.
+   */
+  uniqueKeyForValue?: UniqueKeyForValue<T>;
 }
 
 interface SingleValuePicker<T> extends BaseValuePickerProps<T> {

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
                 <FormGroup
                   check={true}
                   inline={false}
-                  key="admin@42.nl"
+                  key="42"
                   tag="div"
                 >
                   <div
@@ -173,7 +173,7 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
                 <FormGroup
                   check={true}
                   inline={false}
-                  key="coordinator@42.nl"
+                  key="777"
                   tag="div"
                 >
                   <div
@@ -220,7 +220,7 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
                 <FormGroup
                   check={true}
                   inline={false}
-                  key="user@42.nl"
+                  key="1337"
                   tag="div"
                 >
                   <div
@@ -835,7 +835,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
         <FormGroup
           check={true}
           inline={false}
-          key="admin@42.nl"
+          key="42"
           tag="div"
         >
           <div
@@ -882,7 +882,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
         <FormGroup
           check={true}
           inline={false}
-          key="coordinator@42.nl"
+          key="777"
           tag="div"
         >
           <div
@@ -929,7 +929,7 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
         <FormGroup
           check={true}
           inline={false}
-          key="user@42.nl"
+          key="1337"
           tag="div"
         >
           <div
@@ -1073,28 +1073,28 @@ exports[`Component: ValuePicker single should render a \`Select\` component when
             </option>
             <option
               disabled={false}
-              key="admin@42.nl"
+              key="42"
               value={0}
             >
               admin@42.nl
             </option>
             <option
               disabled={false}
-              key="coordinator@42.nl"
+              key="777"
               value={1}
             >
               coordinator@42.nl
             </option>
             <option
               disabled={false}
-              key="user@42.nl"
+              key="1337"
               value={2}
             >
               user@42.nl
             </option>
             <option
               disabled={false}
-              key="nobody@42.nl"
+              key="999"
               value={3}
             >
               nobody@42.nl

--- a/src/form/option.test.tsx
+++ b/src/form/option.test.tsx
@@ -1,53 +1,65 @@
-import { isOptionSelected } from './option';
+import { isOptionSelected, keyForOption } from './option';
 
 type Boat = {
-  id: number;
+  id?: number;
+  uniqueKey: string;
   name: string;
 };
 
+function setup() {
+  const speedBoat: Boat = {
+    id: 1,
+    uniqueKey: 's',
+    name: 'Speedy'
+  };
+
+  const tugBoat: Boat = {
+    id: 2,
+    uniqueKey: 't',
+    name: 'Tugger'
+  };
+
+  // anotherTugBoat is also named tugger just like tugBoat but
+  // has a different id
+  const anotherTugBoat: Boat = {
+    id: 3,
+    uniqueKey: 'a',
+    name: 'Tugger'
+  };
+
+  // Is the same as speedBoat but another instance with a different name
+  const speedBoatCopy: Boat = {
+    id: 1,
+    uniqueKey: 'c',
+    name: 'Speedie'
+  };
+
+  const uniqueKeyForValue = (boat: Boat) => `${boat.uniqueKey}`;
+  const optionForValue = (boat: Boat) => boat.name;
+  const isOptionEqual = (a: Boat, b: Boat) => a.id === b.id;
+
+  return {
+    uniqueKeyForValue,
+    optionForValue,
+    isOptionEqual,
+    speedBoat,
+    tugBoat,
+    anotherTugBoat,
+    speedBoatCopy
+  };
+}
+
 describe('Util: isOptionSelected', () => {
-  function setup() {
-    const speedBoat: Boat = {
-      id: 1,
-      name: 'Speedy'
-    };
-
-    const tugBoat: Boat = {
-      id: 2,
-      name: 'Tugger'
-    };
-
-    // anotherTugBoat is also named tugger just like tugBoat but
-    // has a different id
-    const anotherTugBoat: Boat = {
-      id: 3,
-      name: 'Tugger'
-    };
-
-    // Is the same as speedBoat but another instance with a different name
-    const speedBoatCopy: Boat = {
-      id: 1,
-      name: 'Speedie'
-    };
-
-    const optionForValue = (boat: Boat) => boat.name;
-    const isOptionEqual = (a: Boat, b: Boat) => a.id === b.id;
-
-    return {
-      optionForValue,
-      isOptionEqual,
-      speedBoat,
-      tugBoat,
-      anotherTugBoat,
-      speedBoatCopy
-    };
-  }
-
   it('should when the value is undefined return false', () => {
-    const { optionForValue, speedBoat } = setup();
+    const { uniqueKeyForValue, optionForValue, speedBoat } = setup();
 
     expect(
-      isOptionSelected({ value: undefined, option: speedBoat, optionForValue })
+      isOptionSelected({
+        value: undefined,
+        option: speedBoat,
+        uniqueKeyForValue,
+        optionForValue
+      })
     ).toBe(false);
   });
 
@@ -55,6 +67,7 @@ describe('Util: isOptionSelected', () => {
     describe('when "isOptionEqual" is defined', () => {
       it('should consider a value selected when the "isOptionEqual" returns true for one item in the array', () => {
         const {
+          uniqueKeyForValue,
           optionForValue,
           isOptionEqual,
           speedBoat,
@@ -65,6 +78,7 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: [speedBoatCopy],
             option: speedBoat,
+            uniqueKeyForValue,
             optionForValue,
             isOptionEqual
           })
@@ -73,6 +87,7 @@ describe('Util: isOptionSelected', () => {
 
       it('should not consider a value selected when "isOptionEqual" returns false for every item in the array', () => {
         const {
+          uniqueKeyForValue,
           optionForValue,
           isOptionEqual,
           tugBoat,
@@ -83,6 +98,7 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: [tugBoat],
             option: anotherTugBoat,
+            uniqueKeyForValue,
             optionForValue,
             isOptionEqual
           })
@@ -91,25 +107,69 @@ describe('Util: isOptionSelected', () => {
     });
 
     describe('when "isOptionEqual" is not defined', () => {
-      it('should consider a value selected when "optionForValue" returns the same string for one item in the array', () => {
-        const { optionForValue, tugBoat, anotherTugBoat } = setup();
+      it('should consider a value selected when "keyForOption" returns the same string for one item in the array', () => {
+        const {
+          uniqueKeyForValue,
+          optionForValue,
+          speedBoat,
+          speedBoatCopy,
+          tugBoat,
+          anotherTugBoat
+        } = setup();
 
+        expect(
+          isOptionSelected({
+            value: [tugBoat],
+            option: { ...anotherTugBoat, uniqueKey: tugBoat.uniqueKey },
+            optionForValue,
+            uniqueKeyForValue
+          })
+        ).toBe(true);
+        expect(
+          isOptionSelected({
+            value: [speedBoat],
+            option: speedBoatCopy,
+            optionForValue
+          })
+        ).toBe(true);
+        expect(
+          isOptionSelected({
+            value: [{ ...tugBoat, id: undefined }],
+            option: { ...anotherTugBoat, id: undefined },
+            optionForValue
+          })
+        ).toBe(true);
+      });
+
+      it('should not consider a value selected when "keyForOption" does not return the same string for any item in the array', () => {
+        const {
+          uniqueKeyForValue,
+          optionForValue,
+          speedBoat,
+          speedBoatCopy,
+          tugBoat,
+          anotherTugBoat
+        } = setup();
+
+        expect(
+          isOptionSelected({
+            value: [speedBoatCopy],
+            option: speedBoat,
+            optionForValue,
+            uniqueKeyForValue
+          })
+        ).toBe(false);
         expect(
           isOptionSelected({
             value: [tugBoat],
             option: anotherTugBoat,
             optionForValue
           })
-        ).toBe(true);
-      });
-
-      it('should not consider a value selected when "optionForValue" does not return the same string for at least one item in the array', () => {
-        const { optionForValue, speedBoat, speedBoatCopy } = setup();
-
+        ).toBe(false);
         expect(
           isOptionSelected({
-            value: [speedBoatCopy],
-            option: speedBoat,
+            value: [{ ...speedBoatCopy, id: undefined }],
+            option: { ...speedBoat, id: undefined },
             optionForValue
           })
         ).toBe(false);
@@ -157,29 +217,98 @@ describe('Util: isOptionSelected', () => {
     });
 
     describe('when "isOptionEqual" is not defined', () => {
-      it('should consider a value selected when "optionForValue" returns the same string', () => {
-        const { optionForValue, tugBoat, anotherTugBoat } = setup();
+      it('should consider a value selected when "keyForOption" returns the same string', () => {
+        const {
+          uniqueKeyForValue,
+          optionForValue,
+          tugBoat,
+          anotherTugBoat
+        } = setup();
 
         expect(
           isOptionSelected({
             value: tugBoat,
-            option: anotherTugBoat,
+            option: { ...anotherTugBoat, uniqueKey: tugBoat.uniqueKey },
+            optionForValue,
+            uniqueKeyForValue
+          })
+        ).toBe(true);
+        expect(
+          isOptionSelected({
+            value: tugBoat,
+            option: { ...anotherTugBoat, id: tugBoat.id },
+            optionForValue
+          })
+        ).toBe(true);
+        expect(
+          isOptionSelected({
+            value: { ...tugBoat, id: undefined },
+            option: { ...anotherTugBoat, id: undefined },
             optionForValue
           })
         ).toBe(true);
       });
 
-      it('should not consider a value selected when "optionForValue" does not return the same string', () => {
-        const { optionForValue, speedBoat, speedBoatCopy } = setup();
+      it('should not consider a value selected when "keyForOption" does not return the same string', () => {
+        const {
+          uniqueKeyForValue,
+          optionForValue,
+          speedBoat,
+          speedBoatCopy,
+          tugBoat
+        } = setup();
 
         expect(
           isOptionSelected({
             value: speedBoatCopy,
             option: speedBoat,
+            optionForValue,
+            uniqueKeyForValue
+          })
+        ).toBe(false);
+        expect(
+          isOptionSelected({
+            value: tugBoat,
+            option: speedBoat,
+            optionForValue
+          })
+        ).toBe(false);
+        expect(
+          isOptionSelected({
+            value: speedBoatCopy,
+            option: { ...speedBoat, id: undefined },
             optionForValue
           })
         ).toBe(false);
       });
     });
+  });
+});
+
+describe('util: keyForOption', () => {
+  it('should return uniqueKey property when uniqueKeyForValue is defined', () => {
+    const { optionForValue, uniqueKeyForValue, speedBoat, tugBoat } = setup();
+    expect(
+      keyForOption({ option: speedBoat, optionForValue, uniqueKeyForValue })
+    ).toBe('s');
+    expect(
+      keyForOption({ option: tugBoat, optionForValue, uniqueKeyForValue })
+    ).toBe('t');
+  });
+
+  it('should return id property when option is an object with an id', () => {
+    const { optionForValue, speedBoat, tugBoat } = setup();
+    expect(keyForOption({ option: speedBoat, optionForValue })).toBe('1');
+    expect(keyForOption({ option: tugBoat, optionForValue })).toBe('2');
+  });
+
+  it('should return name property when optionForValue is defined', () => {
+    const { optionForValue, speedBoat, tugBoat } = setup();
+    expect(
+      keyForOption({ option: { ...speedBoat, id: undefined }, optionForValue })
+    ).toBe('Speedy');
+    expect(
+      keyForOption({ option: { ...tugBoat, id: undefined }, optionForValue })
+    ).toBe('Tugger');
   });
 });

--- a/src/form/useOptions.ts
+++ b/src/form/useOptions.ts
@@ -5,13 +5,15 @@ import {
   isOptionSelected,
   OptionEqual,
   OptionForValue,
-  OptionsFetcher
+  OptionsFetcher,
+  UniqueKeyForValue
 } from './option';
 import { isEqual } from 'lodash';
 
 interface UseOptionConfig<T> {
   optionsOrFetcher: OptionsFetcher<T> | T[];
   value?: T;
+  uniqueKeyForValue?: UniqueKeyForValue<T>;
   optionForValue: OptionForValue<T>;
   isOptionEqual?: OptionEqual<T>;
   watch?: any;
@@ -26,6 +28,7 @@ export function useOptions<T>(config: UseOptionConfig<T>): UseOptionResult<T> {
   const {
     optionsOrFetcher,
     value,
+    uniqueKeyForValue,
     optionForValue,
     isOptionEqual,
     watch
@@ -96,13 +99,26 @@ export function useOptions<T>(config: UseOptionConfig<T>): UseOptionResult<T> {
     if (value) {
       if (
         !options.some(option =>
-          isOptionSelected({ option, optionForValue, isOptionEqual, value })
+          isOptionSelected({
+            option,
+            uniqueKeyForValue,
+            optionForValue,
+            isOptionEqual,
+            value
+          })
         )
       ) {
         setOptions([value, ...options]);
       }
     }
-  }, [value, options, isOptionEqual, optionForValue, setOptions]);
+  }, [
+    value,
+    options,
+    isOptionEqual,
+    uniqueKeyForValue,
+    optionForValue,
+    setOptions
+  ]);
 
   return { loading, options };
 }


### PR DESCRIPTION
Every form element with multiple options use the label as key for
mapping, but the label is not always unique. This sometimes causes more
options to be displayed than actually should be displayed.

Added optional uniqueKeyForValue property to get unique property for an
item.