### PR TITLE
improvement: required mark in label

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -181,6 +181,9 @@ Here is a JSON notation containing all keys and default translations:
     "SPECIAL_CHARACTER": "Must contain at least one special character ({{specialChars}})",
     "MINIMUM_LENGTH": "Must contain at least {{minimumLength}} characters",
     "NO_SPACE": "Must not contain any space"
+  },
+  "withJarb": {
+    "REQUIRED_MARK": " *"
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@42.nl/jarb-final-form": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@42.nl/jarb-final-form/-/jarb-final-form-1.2.0.tgz",
-      "integrity": "sha512-C79IBaUjjN7HL2FLd5g/eGp3gpDhv0LKlQL0lsGiUCv+rQpHAkpqH37gGObOLQXcLFtq9swUbPh7V5qJ/T/pZg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@42.nl/jarb-final-form/-/jarb-final-form-1.3.0.tgz",
+      "integrity": "sha512-2WGYf4ezNsm+FuaBuskeb8nnlanGEF1lGdHRPVajOv/c6h098Lmj+FTOoRsn5vCR7+5jMyzArZszzHbvESXHVA==",
       "dev": true
     },
     "@42.nl/react-error-store": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-textarea-autosize": "7.1.2"
   },
   "peerDependencies": {
-    "@42.nl/jarb-final-form": "^1.2.0",
+    "@42.nl/jarb-final-form": "^1.3.0",
     "@42.nl/react-error-store": "^1.0.1",
     "@42.nl/spring-connect": "^4.1.0",
     "classnames": "^2.2.6",
@@ -65,7 +65,7 @@
     "reactstrap": "^8.3.2"
   },
   "devDependencies": {
-    "@42.nl/jarb-final-form": "1.2.0",
+    "@42.nl/jarb-final-form": "1.3.0",
     "@42.nl/react-error-store": "1.0.1",
     "@42.nl/spring-connect": "4.1.0",
     "@babel/plugin-transform-modules-commonjs": "7.8.3",

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,0 +1,9 @@
+import { getConfig, configure } from './config';
+
+test('config', () => {
+  expect(getConfig()).toEqual({ showRequiredMarkInLabel: true });
+  configure({ showRequiredMarkInLabel: false });
+  expect(getConfig()).toEqual({ showRequiredMarkInLabel: false });
+  configure({ showRequiredMarkInLabel: true });
+  expect(getConfig()).toEqual({ showRequiredMarkInLabel: true });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,15 @@
+type Config = {
+  showRequiredMarkInLabel: boolean;
+};
+
+let config: Config = {
+  showRequiredMarkInLabel: true
+};
+
+export function getConfig() {
+  return config;
+}
+
+export function configure(_config: Config) {
+  config = _config;
+}

--- a/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
+++ b/src/form/withJarb/__snapshots__/withJarb.test.tsx.snap
@@ -53,6 +53,11 @@ exports[`HoC: withJarb errorMode: tooltip: withJarb => errorMode: tooltip => jar
   >
     <Input
       color=""
+      label={
+        <MarkedAsRequiredLabel
+          validator="User.email"
+        />
+      }
       onBlur={[MockFunction]}
       onChange={[Function]}
       value="value"
@@ -105,7 +110,12 @@ exports[`HoC: withJarb ui: withJarb => ui => jarbField 1`] = `
     />
   }
   id="firstName"
-  label="First name"
+  label={
+    <MarkedAsRequiredLabel
+      label="First name"
+      validator="User.email"
+    />
+  }
   onBlur={[MockFunction]}
   onChange={[Function]}
   placeholder="Please enter your first name"

--- a/src/form/withJarb/components/MarkedAsRequiredLabel/MarkedAsRequiredLabel.test.tsx
+++ b/src/form/withJarb/components/MarkedAsRequiredLabel/MarkedAsRequiredLabel.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import * as jarbFinalForm from '@42.nl/jarb-final-form';
+import { MarkedAsRequiredLabel } from './MarkedAsRequiredLabel';
+import { configure } from '../../../..';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import Tooltip from '../../../../core/Tooltip/Tooltip';
+import { setConstraints } from '@42.nl/jarb-final-form';
+
+describe('Component: MarkedAsRequiredLabel', () => {
+  function setup({
+    hasLabel = true,
+    customLabel = false
+  }: {
+    hasLabel?: boolean;
+    customLabel?: boolean;
+  }) {
+    const markedAsRequiredLabel = shallow(
+      <MarkedAsRequiredLabel
+        validator="Person.firstName"
+        label={
+          hasLabel ? (
+            customLabel ? (
+              <Tooltip content="This field is required">First Name</Tooltip>
+            ) : (
+              'First Name'
+            )
+          ) : (
+            undefined
+          )
+        }
+      />
+    );
+    return { markedAsRequiredLabel };
+  }
+
+  it('should not render anything when label is undefined', () => {
+    const { markedAsRequiredLabel } = setup({ hasLabel: false });
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should return undefined when label is undefined'
+    );
+  });
+
+  it('should render label without required mark when showRequiredMarkInLabel is disabled in config', () => {
+    configure({ showRequiredMarkInLabel: false });
+    const { markedAsRequiredLabel } = setup({});
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should render label without required mark when showRequiredMarkInLabel is disabled in config'
+    );
+    configure({ showRequiredMarkInLabel: true });
+  });
+
+  it('should render label without required mark when constraints are not defined', () => {
+    jest.spyOn(jarbFinalForm, 'getConstraints').mockReturnValue(undefined);
+    const { markedAsRequiredLabel } = setup({});
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should render label without required mark when constraints are not defined'
+    );
+  });
+
+  it('should render label without required mark when constraints does not include field validator', () => {
+    jest.spyOn(jarbFinalForm, 'getConstraints').mockReturnValue({ User: {} });
+    const { markedAsRequiredLabel } = setup({});
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should render label without required mark when constraints does not include field validator'
+    );
+  });
+
+  it('should render label without required mark when constraints include field validator but field is not required', () => {
+    jest.spyOn(jarbFinalForm, 'getConstraints').mockReturnValue({
+      Person: {
+        firstName: {
+          javaType: 'java.lang.String',
+          types: ['text'],
+          required: false,
+          minimumLength: null,
+          maximumLength: 50,
+          fractionLength: null,
+          radix: null,
+          pattern: null,
+          min: null,
+          max: null,
+          name: 'name'
+        }
+      }
+    });
+    const { markedAsRequiredLabel } = setup({});
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should render label without required mark when constraints include field validator but field is not required'
+    );
+  });
+
+  it('should render label without required mark when label is a custom component', () => {
+    jest.spyOn(jarbFinalForm, 'getConstraints').mockReturnValue({
+      Person: {
+        firstName: {
+          javaType: 'java.lang.String',
+          types: ['text'],
+          required: false,
+          minimumLength: null,
+          maximumLength: 50,
+          fractionLength: null,
+          radix: null,
+          pattern: null,
+          min: null,
+          max: null,
+          name: 'name'
+        }
+      }
+    });
+    const { markedAsRequiredLabel } = setup({ customLabel: true });
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should render label without required mark when label is a custom component'
+    );
+  });
+
+  it('should render label with required mark when constraints include field validator', () => {
+    setConstraints({
+      Person: {
+        firstName: {
+          javaType: 'java.lang.String',
+          types: ['text'],
+          required: true,
+          minimumLength: null,
+          maximumLength: 50,
+          fractionLength: null,
+          radix: null,
+          pattern: null,
+          min: null,
+          max: null,
+          name: 'name'
+        }
+      }
+    });
+    const { markedAsRequiredLabel } = setup({});
+    expect(toJson(markedAsRequiredLabel)).toMatchSnapshot(
+      'Component: MarkedAsRequiredLabel => should render label with required mark when constraints include field validator'
+    );
+  });
+});

--- a/src/form/withJarb/components/MarkedAsRequiredLabel/MarkedAsRequiredLabel.tsx
+++ b/src/form/withJarb/components/MarkedAsRequiredLabel/MarkedAsRequiredLabel.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { isRequired } from '@42.nl/jarb-final-form';
+import { getConfig } from '../../../../config/config';
+import { t } from '../../../../utilities/translation/translation';
+
+type Props = {
+  label?: React.ReactNode;
+  validator: string;
+};
+
+export function MarkedAsRequiredLabel({ label, validator }: Props) {
+  if (!label) {
+    return null;
+  }
+
+  const { showRequiredMarkInLabel } = getConfig();
+
+  if (
+    typeof label === 'string' &&
+    showRequiredMarkInLabel &&
+    isRequired(validator)
+  ) {
+    return (
+      <>
+        {label}
+        {t({
+          key: 'withJarb.REQUIRED_MARK',
+          fallback: ' *'
+        })}
+      </>
+    );
+  }
+
+  return <>{label}</>;
+}

--- a/src/form/withJarb/components/MarkedAsRequiredLabel/__snapshots__/MarkedAsRequiredLabel.test.tsx.snap
+++ b/src/form/withJarb/components/MarkedAsRequiredLabel/__snapshots__/MarkedAsRequiredLabel.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: MarkedAsRequiredLabel should not render anything when label is undefined: Component: MarkedAsRequiredLabel => should return undefined when label is undefined 1`] = `""`;
+
+exports[`Component: MarkedAsRequiredLabel should render label with required mark when constraints include field validator: Component: MarkedAsRequiredLabel => should render label with required mark when constraints include field validator 1`] = `
+<Fragment>
+  First Name
+   *
+</Fragment>
+`;
+
+exports[`Component: MarkedAsRequiredLabel should render label without required mark when constraints are not defined: Component: MarkedAsRequiredLabel => should render label without required mark when constraints are not defined 1`] = `
+<Fragment>
+  First Name
+</Fragment>
+`;
+
+exports[`Component: MarkedAsRequiredLabel should render label without required mark when constraints does not include field validator: Component: MarkedAsRequiredLabel => should render label without required mark when constraints does not include field validator 1`] = `
+<Fragment>
+  First Name
+</Fragment>
+`;
+
+exports[`Component: MarkedAsRequiredLabel should render label without required mark when constraints include field validator but field is not required: Component: MarkedAsRequiredLabel => should render label without required mark when constraints include field validator but field is not required 1`] = `
+<Fragment>
+  First Name
+</Fragment>
+`;
+
+exports[`Component: MarkedAsRequiredLabel should render label without required mark when label is a custom component: Component: MarkedAsRequiredLabel => should render label without required mark when label is a custom component 1`] = `
+<Fragment>
+  <Tooltip
+    content="This field is required"
+  >
+    First Name
+  </Tooltip>
+</Fragment>
+`;
+
+exports[`Component: MarkedAsRequiredLabel should render label without required mark when showRequiredMarkInLabel is disabled in config: Component: MarkedAsRequiredLabel => should render label without required mark when showRequiredMarkInLabel is disabled in config 1`] = `
+<Fragment>
+  First Name
+</Fragment>
+`;

--- a/src/form/withJarb/withJarb.tsx
+++ b/src/form/withJarb/withJarb.tsx
@@ -9,6 +9,7 @@ import FormError from '../FormError/FormError';
 import { getState } from '../utils';
 import Tooltip from '../../core/Tooltip/Tooltip';
 import { useHasErrors } from './useHasErrors/useHasErrors';
+import { MarkedAsRequiredLabel } from './components/MarkedAsRequiredLabel/MarkedAsRequiredLabel';
 
 // This is a list of props that `withJarb` will pass to the `final-form`
 // Field, but not the wrapper.
@@ -35,6 +36,7 @@ interface FieldCompatible<Value, ChangeValue> {
   valid?: boolean;
   error?: React.ReactNode;
   errorMode?: 'tooltip' | 'below';
+  label?: React.ReactNode;
 }
 
 /**
@@ -112,6 +114,13 @@ export default function withJarb<
     // Bit magical this one but this makes TypeScript accept all other
     // props as the Props to the wrapped component.
     const wrapperProps = (omit(rest, passedFieldProps) as unknown) as P;
+
+    wrapperProps.label = (
+      <MarkedAsRequiredLabel
+        validator={jarb.validator}
+        label={wrapperProps.label}
+      />
+    );
 
     const fieldProps = pick(rest, [
       'initialValue',

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ export { t } from './utilities/translation/translation';
 export { setTranslator } from './utilities/translation/translator';
 export { pageOf } from './utilities/page/page';
 export { useBodyFixOnModalClose } from './core/useBodyFixOnModalClose/useBodyFixOnModalClose';
+export { configure } from './config/config';
 
 // Types
 export { Color } from './core/types';


### PR DESCRIPTION
When using a Jarb field, the field should know if it's required, so it
should be possible to add a required mark to the label when the field is
required.

Added check that adds required mark to label in Jarb fields when the
field is required.
Added configure function to optionally disable required mark entirely.

Closes #465