### PR TITLE
fix: ImageUpload exceeds container size in edit mode

### DIFF
--- a/src/form/ImageUpload/ImageUpload.scss
+++ b/src/form/ImageUpload/ImageUpload.scss
@@ -20,6 +20,10 @@
       cursor: pointer;
     }
   }
+  canvas {
+    max-width: 100%;
+    height: auto !important;
+  }
   .img-upload-wrapper {
     @extend .text-center;
     padding-top: 3rem;


### PR DESCRIPTION
When an image is selected in the ImageUpload component, the editor
exceeds the container borders and therefor sometimes even the window
borders.

Added CSS rules to maximize the canvas size without messing up the
image ratio.

Closes #467