### PR TITLE
fix: ImageUpload replace file extension to match output

### DIFF
--- a/src/form/ImageUpload/ImageUpload.tsx
+++ b/src/form/ImageUpload/ImageUpload.tsx
@@ -14,7 +14,8 @@ import {
   calculateScale,
   cropToAvatarEditorConfig,
   dataUrlToFile,
-  getPicaInstance
+  getPicaInstance,
+  replaceFileExtension
 } from './utils';
 
 export interface Text {
@@ -102,6 +103,13 @@ interface BaseProps {
    * Optionally customized text you want to use in this component.
    */
   text?: Text;
+
+  /**
+   * Optionally whether to keep the original file extension or to
+   * replace it with .png (because the output is always a PNG file).
+   * Defaults to false.
+   */
+  keepOriginalFileExtension?: boolean;
 }
 
 interface WithoutLabel extends BaseProps {
@@ -219,7 +227,7 @@ export default class ImageUpload extends Component<Props, State> {
   async onCrop() {
     /* istanbul ignore else */
     if (this.editorRef.current) {
-      const { crop } = this.props;
+      const { crop, keepOriginalFileExtension = false } = this.props;
 
       const canvas = this.editorRef.current.getImage();
       const config = cropToAvatarEditorConfig(crop);
@@ -239,12 +247,15 @@ export default class ImageUpload extends Component<Props, State> {
       );
 
       const dataUrl = picaCanvas.toDataURL('image/png', 1.0);
-      const file = dataUrlToFile(dataUrl, this.state.fileName);
+      const fileName = keepOriginalFileExtension
+        ? this.state.fileName
+        : replaceFileExtension(this.state.fileName);
+      const file = dataUrlToFile(dataUrl, fileName);
 
       this.props.onChange(file);
       doBlur(this.props.onBlur);
 
-      this.setState({ mode: Mode.FILE_SELECTED, imageSrc: dataUrl });
+      this.setState({ mode: Mode.FILE_SELECTED, imageSrc: dataUrl, fileName });
     }
   }
 

--- a/src/form/ImageUpload/utils.test.ts
+++ b/src/form/ImageUpload/utils.test.ts
@@ -2,7 +2,8 @@ import {
   getPicaInstance,
   dataUrlToFile,
   cropToAvatarEditorConfig,
-  calculateScale
+  calculateScale,
+  replaceFileExtension
 } from './utils';
 
 test('getPicaInstance', () => {
@@ -56,4 +57,23 @@ test('calculateScale', () => {
   // clamp
   expect(calculateScale(1, 800)).toBe(1);
   expect(calculateScale(10, -800)).toBe(10);
+});
+
+test('replaceFileExtension', () => {
+  expect(replaceFileExtension('')).toBe('');
+  expect(replaceFileExtension('test')).toBe('test');
+  expect(replaceFileExtension('test.png')).toBe('test.png');
+  expect(replaceFileExtension('test.jpg')).toBe('test.png');
+  expect(replaceFileExtension('test.jpeg')).toBe('test.png');
+  expect(replaceFileExtension('test.svg')).toBe('test.png');
+  expect(replaceFileExtension('test.gif')).toBe('test.png');
+  expect(replaceFileExtension('test.bmp')).toBe('test.png');
+  expect(replaceFileExtension('test.tif')).toBe('test.png');
+  expect(replaceFileExtension('test.tiff')).toBe('test.png');
+  expect(replaceFileExtension('test.webp')).toBe('test.png');
+  expect(replaceFileExtension('test.bladiebla')).toBe('test.png');
+  expect(replaceFileExtension('test.bladiebla.jpg')).toBe('test.bladiebla.png');
+  expect(replaceFileExtension('test.jpg2')).toBe('test.png');
+  expect(replaceFileExtension('test.jpg_2')).toBe('test.png');
+  expect(replaceFileExtension('test...jpg')).toBe('test...png');
 });

--- a/src/form/ImageUpload/utils.ts
+++ b/src/form/ImageUpload/utils.ts
@@ -64,3 +64,8 @@ export function calculateScale(scale: number, delta: number): number {
 
   return clamped;
 }
+
+// Replace any part after the last dot in the filename with .png
+export function replaceFileExtension(fileName: string) {
+  return fileName.replace(/\.[\w]+$/, '.png');
+}


### PR DESCRIPTION
ImageUpload accepts any image, but the output is always a PNG file. The
output file doesn't have the .png extension though. This is not a
problem for browsers, as they don't use the extension, but the
extension should match the contents.

Added a function that replaces the file extension with .png.
Added an optional property to keep the original file name.

Closes #480