### PR TITLE
feat: Input can be made disabled and read-only

### DIFF
--- a/src/form/Input/Input.stories.tsx
+++ b/src/form/Input/Input.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import Input, { JarbInput } from './Input';
 import { Form, FinalForm } from '../story-utils';
-import { Tooltip, Icon } from '../..';
+import { Tooltip, Icon, Button } from '../..';
 
 function isSuperman(value: string) {
   return value === 'superman' ? undefined : 'Not "superman"';
@@ -99,6 +99,64 @@ storiesOf('Form|Input', module)
           placeholder="Please enter your first name"
           onChange={value => action(`You entered ${value}`)}
         />
+      </Form>
+    );
+  })
+  .add('disabled', () => {
+    const [isDisabled, setDisabled] = useState<boolean>(true);
+
+    return (
+      <Form>
+        <Input
+          id="firstName"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>First name</span>
+              <Tooltip
+                className="ml-1"
+                content="Your first name is on your birth certificate"
+              >
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please enter your first name"
+          disabled={isDisabled}
+          onChange={value => action(`You entered ${value}`)}
+        />
+
+        <Button onClick={() => setDisabled(!isDisabled)}>
+          Toggle disabled state
+        </Button>
+      </Form>
+    );
+  })
+  .add('readOnly', () => {
+    const [isReadOnly, setReadOnly] = useState<boolean>(true);
+
+    return (
+      <Form>
+        <Input
+          id="firstName"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>First name</span>
+              <Tooltip
+                className="ml-1"
+                content="Your first name is on your birth certificate"
+              >
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please enter your first name"
+          readOnly={isReadOnly}
+          onChange={value => action(`You entered ${value}`)}
+        />
+
+        <Button onClick={() => setReadOnly(!isReadOnly)}>
+          Toggle readOnly state
+        </Button>
       </Form>
     );
   })

--- a/src/form/Input/Input.test.tsx
+++ b/src/form/Input/Input.test.tsx
@@ -39,7 +39,9 @@ describe('Component: Input', () => {
     position,
     valid,
     hasPlaceholder = true,
-    hasLabel = true
+    hasLabel = true,
+    disabled = false,
+    readOnly = false
   }: {
     value?: string;
     type?: InputType;
@@ -48,6 +50,8 @@ describe('Component: Input', () => {
     valid?: boolean;
     hasPlaceholder?: boolean;
     hasLabel?: boolean;
+    disabled?: boolean;
+    readOnly?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -66,7 +70,9 @@ describe('Component: Input', () => {
       error: 'Some error',
       valid,
       mask,
-      addon
+      addon,
+      disabled,
+      readOnly
     };
 
     if (hasLabel) {
@@ -181,6 +187,58 @@ describe('Component: Input', () => {
       rsInput.props().onFocus();
 
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('disabled', () => {
+    test('input is disabled when the prop is set to true', () => {
+      setup({ value: 'Maarten', type: 'text', disabled: true });
+
+      let rsInput = input.find('Input');
+      expect(rsInput.props().disabled).toBeTruthy();
+
+      input.setProps({ disabled: false });
+
+      rsInput = input.find('Input');
+      expect(rsInput.props().disabled).toBeFalsy();
+    });
+
+    test('input is not disabled when the prop is set to false', () => {
+      setup({ value: 'Maarten', type: 'text', disabled: false });
+
+      let rsInput = input.find('Input');
+      expect(rsInput.props().disabled).toBeFalsy();
+
+      input.setProps({ disabled: true });
+
+      rsInput = input.find('Input');
+      expect(rsInput.props().disabled).toBeTruthy();
+    });
+  });
+
+  describe('readOnly', () => {
+    test('input is read-only when the prop is set to true', () => {
+      setup({ value: 'Maarten', type: 'text', readOnly: true });
+
+      let rsInput = input.find('Input');
+      expect(rsInput.props().readOnly).toBeTruthy();
+
+      input.setProps({ readOnly: false });
+
+      rsInput = input.find('Input');
+      expect(rsInput.props().readOnly).toBeFalsy();
+    });
+
+    test('is not read-only when the prop is set to false', () => {
+      setup({ value: 'Maarten', type: 'text', readOnly: false });
+
+      let rsInput = input.find('Input');
+      expect(rsInput.props().readOnly).toBeFalsy();
+
+      input.setProps({ readOnly: true });
+
+      rsInput = input.find('Input');
+      expect(rsInput.props().readOnly).toBeTruthy();
     });
   });
 

--- a/src/form/Input/Input.tsx
+++ b/src/form/Input/Input.tsx
@@ -78,6 +78,22 @@ interface BaseProps {
    * Useful for styling the component.
    */
   className?: string;
+
+  /**
+   * Optionally whether or not the form element is disabled.
+   * A disabled form element is a form element that can't be edited. Also, it won't be included when submitting the form.
+   *
+   * Defaults to `false`
+   */
+  disabled?: boolean;
+
+  /**
+   * Optionally whether or not the form element is read-only.
+   * A read-only form element is a form element that can't be edited, but will be included when submitting the form.
+   *
+   * Defaults to `false`
+   */
+  readOnly?: boolean;
 }
 
 interface WithoutLabel extends BaseProps {
@@ -118,7 +134,9 @@ export default function Input(props: Props) {
     valid,
     mask,
     addon,
-    className = ''
+    className = '',
+    disabled,
+    readOnly
   } = props;
 
   const inputProps = {
@@ -132,7 +150,9 @@ export default function Input(props: Props) {
     onFocus,
     onChange: (event: ChangeEvent<HTMLInputElement>) =>
       onChange(event.target.value),
-    onBlur
+    onBlur,
+    disabled,
+    readOnly
   };
 
   // Cannot pass a reference when the input requires a mask

--- a/src/form/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/form/Input/__snapshots__/Input.test.tsx.snap
@@ -22,12 +22,14 @@ exports[`Component: Input ui defaults to text: Component: Input => ui => default
     First name
   </Label>
   <Input
+    disabled={false}
     id="firstName"
     key="input"
     onBlur={[MockFunction]}
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder="Please enter your first name"
+    readOnly={false}
     type="text"
     value="Maarten"
   />
@@ -57,6 +59,7 @@ exports[`Component: Input ui is invalid: Component: Input => is invalid 1`] = `
     First name
   </Label>
   <Input
+    disabled={false}
     id="firstName"
     invalid={true}
     key="input"
@@ -64,6 +67,7 @@ exports[`Component: Input ui is invalid: Component: Input => is invalid 1`] = `
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder="Please enter your first name"
+    readOnly={false}
     type="text"
     valid={false}
   />
@@ -93,12 +97,14 @@ exports[`Component: Input ui is valid: Component: Input => is valid 1`] = `
     First name
   </Label>
   <Input
+    disabled={false}
     id="firstName"
     key="input"
     onBlur={[MockFunction]}
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder="Please enter your first name"
+    readOnly={false}
     type="text"
     valid={true}
   />
@@ -137,12 +143,14 @@ exports[`Component: Input ui position left: Component: Input => position left 1`
       position="left"
     />
     <Input
+      disabled={false}
       id="firstName"
       key="input"
       onBlur={[MockFunction]}
       onChange={[Function]}
       onFocus={[MockFunction]}
       placeholder="Please enter your first name"
+      readOnly={false}
       type="text"
     />
   </InputGroup>
@@ -175,12 +183,14 @@ exports[`Component: Input ui position right: Component: Input => position right 
     tag="div"
   >
     <Input
+      disabled={false}
       id="firstName"
       key="input"
       onBlur={[MockFunction]}
       onChange={[Function]}
       onFocus={[MockFunction]}
       placeholder="Please enter your first name"
+      readOnly={false}
       type="text"
     />
     <Addon
@@ -216,12 +226,14 @@ exports[`Component: Input ui type email: Component: Input => ui => type email 1`
     First name
   </Label>
   <Input
+    disabled={false}
     id="firstName"
     key="input"
     onBlur={[MockFunction]}
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder="Please enter your first name"
+    readOnly={false}
     type="email"
     value="Maarten"
   />
@@ -251,6 +263,7 @@ exports[`Component: Input ui with mask: Component: Input => ui => with mask 1`] 
     First name
   </Label>
   <t
+    disabled={false}
     id="firstName"
     key="mask"
     mask={
@@ -275,6 +288,7 @@ exports[`Component: Input ui with mask: Component: Input => ui => with mask 1`] 
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder="Please enter your first name"
+    readOnly={false}
     render={[Function]}
     type="text"
     value="Maarten"
@@ -290,11 +304,13 @@ exports[`Component: Input ui without label: Component: Input => ui => without la
   tag="div"
 >
   <Input
+    disabled={false}
     key="input"
     onBlur={[MockFunction]}
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder="Please enter your first name"
+    readOnly={false}
     type="text"
     value="Maarten"
   />
@@ -324,12 +340,14 @@ exports[`Component: Input ui without placeholder: Component: Input => ui => with
     First name
   </Label>
   <Input
+    disabled={false}
     id="firstName"
     key="input"
     onBlur={[MockFunction]}
     onChange={[Function]}
     onFocus={[MockFunction]}
     placeholder=""
+    readOnly={false}
     type="text"
     value="Maarten"
   />


### PR DESCRIPTION
Added the ability to make form inputs `disabled` or `readOnly`. These
behave exactly as in traditional forms: Disabled inputs are not editable
and not included on submission. Read-only inputs are not editable but
are included on submission