### PR TITLE
feat: Added ConfirmModal to trigger user confirmation without button

### DIFF
--- a/src/core/ConfirmButton/ConfirmButton.test.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.test.tsx
@@ -154,7 +154,7 @@ describe('Component: ConfirmButton', () => {
         .onClick(event);
 
       // @ts-ignore
-      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(true);
+      expect(confirmButton.find('ConfirmModal').props().isOpen).toBe(true);
     }
 
     it('should open the Modal when the ConfirmButton button is clicked', () => {
@@ -174,7 +174,7 @@ describe('Component: ConfirmButton', () => {
         .onClick(event);
 
       // @ts-ignore
-      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(true);
+      expect(confirmButton.find('ConfirmModal').props().isOpen).toBe(true);
 
       expect(event.stopPropagation).toHaveBeenCalledTimes(1);
     });
@@ -188,10 +188,10 @@ describe('Component: ConfirmButton', () => {
       openModal();
 
       // @ts-ignore
-      confirmButton.find('OpenCloseModal').prop('onClose')();
+      confirmButton.find('ConfirmModal').prop('onClose')();
 
       // @ts-ignore
-      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(false);
+      expect(confirmButton.find('ConfirmModal').props().isOpen).toBe(false);
     });
 
     it('should close and save the Modal when the Accept button is clicked', () => {
@@ -204,14 +204,14 @@ describe('Component: ConfirmButton', () => {
 
       // @ts-ignore
       confirmButton
-        .find('OpenCloseModal')
+        .find('ConfirmModal')
         // @ts-ignore
         .prop('onSave')();
 
       expect(onConfirmSpy).toHaveBeenCalledTimes(1);
 
       // @ts-ignore
-      expect(confirmButton.find('OpenCloseModal').props().isOpen).toBe(false);
+      expect(confirmButton.find('ConfirmModal').props().isOpen).toBe(false);
     });
   });
 });

--- a/src/core/ConfirmButton/ConfirmButton.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.tsx
@@ -10,8 +10,7 @@ import Button, {
 } from '../Button/Button';
 import { Color } from '../types';
 import IconType from '../Icon/types';
-import { t } from '../../utilities/translation/translation';
-import { OpenCloseModal } from '../../core/OpenCloseModal/OpenCloseModal';
+import ConfirmModal from '../ConfirmModal/ConfirmModal';
 
 interface Text {
   /**
@@ -215,30 +214,15 @@ export default function ConfirmButton({
     >
       <Button {...getProps()} />
 
-      <OpenCloseModal
+      <ConfirmModal
         isOpen={isOpen}
         onClose={() => setOpen(false)}
         onSave={() => saveModal()}
-        label={t({
-          overrideText: modalHeader,
-          key: 'ConfirmButton.MODAL_HEADER',
-          fallback: 'Confirmation'
-        })}
-        text={{
-          cancel: t({
-            overrideText: cancel,
-            key: 'ConfirmButton.CANCEL',
-            fallback: 'Cancel'
-          }),
-          save: t({
-            overrideText: confirm,
-            key: 'ConfirmButton.CONFIRM',
-            fallback: 'Confirm'
-          })
-        }}
-      >
-        {dialogText}
-      </OpenCloseModal>
+        label={modalHeader}
+        modalText={dialogText}
+        cancelText={cancel}
+        confirmText={confirm}
+      />
     </div>
   );
 }

--- a/src/core/ConfirmButton/__snapshots__/ConfirmButton.test.tsx.snap
+++ b/src/core/ConfirmButton/__snapshots__/ConfirmButton.test.tsx.snap
@@ -16,26 +16,20 @@ exports[`Component: ConfirmButton ui button and icon: Component: ConfirmButton =
   >
     Delete user
   </Button>
-  <OpenCloseModal
+  <ConfirmModal
     isOpen={false}
-    label="Confirmation"
+    modalText={
+      <p>
+        Are you sure you want to 
+        <strong>
+          delete
+        </strong>
+         the user?
+      </p>
+    }
     onClose={[Function]}
     onSave={[Function]}
-    text={
-      Object {
-        "cancel": "Cancel",
-        "save": "Confirm",
-      }
-    }
-  >
-    <p>
-      Are you sure you want to 
-      <strong>
-        delete
-      </strong>
-       the user?
-    </p>
-  </OpenCloseModal>
+  />
 </div>
 `;
 
@@ -56,26 +50,23 @@ exports[`Component: ConfirmButton ui custom class, color and texts: Component: C
   >
     Delete user
   </Button>
-  <OpenCloseModal
+  <ConfirmModal
+    cancelText="NO"
+    confirmText="YES"
     isOpen={false}
     label="PLEASE SAY YES"
+    modalText={
+      <p>
+        Are you sure you want to 
+        <strong>
+          delete
+        </strong>
+         the user?
+      </p>
+    }
     onClose={[Function]}
     onSave={[Function]}
-    text={
-      Object {
-        "cancel": "NO",
-        "save": "YES",
-      }
-    }
-  >
-    <p>
-      Are you sure you want to 
-      <strong>
-        delete
-      </strong>
-       the user?
-    </p>
-  </OpenCloseModal>
+  />
 </div>
 `;
 
@@ -94,26 +85,20 @@ exports[`Component: ConfirmButton ui only button: Component: ConfirmButton => ui
   >
     Delete user
   </Button>
-  <OpenCloseModal
+  <ConfirmModal
     isOpen={false}
-    label="Confirmation"
+    modalText={
+      <p>
+        Are you sure you want to 
+        <strong>
+          delete
+        </strong>
+         the user?
+      </p>
+    }
     onClose={[Function]}
     onSave={[Function]}
-    text={
-      Object {
-        "cancel": "Cancel",
-        "save": "Confirm",
-      }
-    }
-  >
-    <p>
-      Are you sure you want to 
-      <strong>
-        delete
-      </strong>
-       the user?
-    </p>
-  </OpenCloseModal>
+  />
 </div>
 `;
 
@@ -131,26 +116,20 @@ exports[`Component: ConfirmButton ui only icon in progress: Component: ConfirmBu
     inProgress={true}
     onClick={[Function]}
   />
-  <OpenCloseModal
+  <ConfirmModal
     isOpen={false}
-    label="Confirmation"
+    modalText={
+      <p>
+        Are you sure you want to 
+        <strong>
+          delete
+        </strong>
+         the user?
+      </p>
+    }
     onClose={[Function]}
     onSave={[Function]}
-    text={
-      Object {
-        "cancel": "Cancel",
-        "save": "Confirm",
-      }
-    }
-  >
-    <p>
-      Are you sure you want to 
-      <strong>
-        delete
-      </strong>
-       the user?
-    </p>
-  </OpenCloseModal>
+  />
 </div>
 `;
 
@@ -168,25 +147,19 @@ exports[`Component: ConfirmButton ui only icon: Component: ConfirmButton => ui =
     inProgress={false}
     onClick={[Function]}
   />
-  <OpenCloseModal
+  <ConfirmModal
     isOpen={false}
-    label="Confirmation"
+    modalText={
+      <p>
+        Are you sure you want to 
+        <strong>
+          delete
+        </strong>
+         the user?
+      </p>
+    }
     onClose={[Function]}
     onSave={[Function]}
-    text={
-      Object {
-        "cancel": "Cancel",
-        "save": "Confirm",
-      }
-    }
-  >
-    <p>
-      Are you sure you want to 
-      <strong>
-        delete
-      </strong>
-       the user?
-    </p>
-  </OpenCloseModal>
+  />
 </div>
 `;

--- a/src/core/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/core/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,96 @@
+import { storiesOf } from '@storybook/react';
+import ConfirmModal from './ConfirmModal';
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import {
+  ButtonDropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle
+} from 'reactstrap';
+
+const disclaimer = (
+  <>
+    <p className="mt-3">
+      <strong>Note:</strong> In most cases, you&apos;ll want to use the{' '}
+      <code>ConfirmButton</code> component instead. ConfirmButton offers an
+      easy-to-use button that triggers this dialog.
+    </p>
+    <p>
+      When it is not possible to trigger the action through a button, such as
+      when using a ButtonDropdown, you can use this component directly instead.
+    </p>
+  </>
+);
+
+storiesOf('core|ConfirmModal', module)
+  .addParameters({ component: ConfirmModal })
+  .add('in dropdown', () => {
+    const [isDropdownMenuOpen, setDropdownMenuOpen] = useState(false);
+    const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
+
+    return (
+      <div className="text-center mt-3">
+        <ConfirmModal
+          isOpen={isConfirmModalOpen}
+          onClose={() => setConfirmModalOpen(false)}
+          onSave={() => {
+            setConfirmModalOpen(false);
+            action('confirm clicked')();
+          }}
+          modalText="Are you sure to delete this user? This operation cannot be undone!"
+        />
+        <ButtonDropdown
+          isOpen={isDropdownMenuOpen}
+          toggle={() => setDropdownMenuOpen(!isDropdownMenuOpen)}
+        >
+          <DropdownToggle caret>Actions</DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem onClick={() => setConfirmModalOpen(true)}>
+              Delete user
+            </DropdownItem>
+          </DropdownMenu>
+        </ButtonDropdown>
+
+        {disclaimer}
+      </div>
+    );
+  })
+  .add('with custom text', () => {
+    const [isDropdownMenuOpen, setDropdownMenuOpen] = useState(false);
+    const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
+
+    return (
+      <div className="text-center mt-3">
+        <ConfirmModal
+          isOpen={isConfirmModalOpen}
+          onClose={() => setConfirmModalOpen(false)}
+          onSave={() => {
+            setConfirmModalOpen(false);
+            action('Confirm clicked')();
+          }}
+          label="PLEASE SAY YES"
+          modalText={
+            <p>
+              Are you sure you want to <strong>delete</strong> all users?
+            </p>
+          }
+          confirmText="YES"
+          cancelText="NO"
+        />
+        <ButtonDropdown
+          isOpen={isDropdownMenuOpen}
+          toggle={() => setDropdownMenuOpen(!isDropdownMenuOpen)}
+        >
+          <DropdownToggle caret>Actions - custom text</DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem onClick={() => setConfirmModalOpen(true)}>
+              Delete all users
+            </DropdownItem>
+          </DropdownMenu>
+        </ButtonDropdown>
+
+        {disclaimer}
+      </div>
+    );
+  });

--- a/src/core/ConfirmModal/ConfirmModal.test.tsx
+++ b/src/core/ConfirmModal/ConfirmModal.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import ConfirmModal from './ConfirmModal';
+
+describe('Component: ConfirmModal', () => {
+  describe('ui', () => {
+    test('default texts', () => {
+      const confirmAction = shallow(
+        <ConfirmModal
+          isOpen={true}
+          onClose={() => undefined}
+          onSave={() => undefined}
+          modalText={
+            <p>
+              Are you sure you want to <strong>delete</strong> the user?
+            </p>
+          }
+        />
+      );
+
+      expect(toJson(confirmAction)).toMatchSnapshot(
+        'Component: ConfirmModal => ui => default texts'
+      );
+    });
+
+    test('custom texts', () => {
+      const confirmAction = shallow(
+        <ConfirmModal
+          isOpen={true}
+          onClose={() => undefined}
+          onSave={() => undefined}
+          modalText={
+            <p>
+              Are you sure you want to <strong>delete</strong> all users in the
+              database?
+            </p>
+          }
+          cancelText="NO"
+          confirmText="YES"
+          label="Perform dangerous action"
+        />
+      );
+
+      expect(toJson(confirmAction)).toMatchSnapshot(
+        'Component: ConfirmModal => ui => custom texts'
+      );
+    });
+  });
+
+  describe('events - onClose and onSave', () => {
+    let confirmModal: ShallowWrapper;
+    let onCloseSpy: jest.Mock;
+    let onSaveSpy: jest.Mock;
+
+    type Props = { text: string };
+
+    function setup({ text }: Props) {
+      onCloseSpy = jest.fn();
+      onSaveSpy = jest.fn();
+
+      const props = {
+        isOpen: false,
+        onClose: onCloseSpy,
+        onSave: onSaveSpy,
+        label: 'Are you sure you want a ConfirmAction?',
+        modalText: text
+      };
+
+      confirmModal = shallow(<ConfirmModal {...props} />);
+    }
+
+    function openModal() {
+      confirmModal = confirmModal.setProps({ isOpen: true });
+
+      // @ts-ignore
+      expect(confirmModal.find('OpenCloseModal').props().isOpen).toBe(true);
+    }
+
+    it('should open the OpenCloseModal when the ConfirmModal is opened', () => {
+      setup({
+        text: 'Delete all data in the database?'
+      });
+
+      confirmModal = confirmModal.setProps({ isOpen: true });
+
+      // @ts-ignore
+      expect(confirmModal.find('OpenCloseModal').props().isOpen).toBe(true);
+    });
+
+    it('should call onClose when the Modal is closed', () => {
+      setup({
+        text: 'Delete this user and all his data?'
+      });
+
+      openModal();
+
+      // @ts-ignore
+      confirmModal.find('OpenCloseModal').prop('onClose')();
+
+      expect(onCloseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onSave when the Modal is confirmed', () => {
+      setup({
+        text: 'Delete this note?'
+      });
+
+      openModal();
+
+      // @ts-ignore
+      confirmModal
+        .find('OpenCloseModal')
+        // @ts-ignore
+        .prop('onSave')();
+
+      expect(onSaveSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/core/ConfirmModal/ConfirmModal.tsx
+++ b/src/core/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { OpenCloseModal, t } from '../..';
+
+type Props = {
+  /**
+   * The text to show in the heading of the modal. Defaults to "Confirmation"
+   *
+   * @default Confirmation
+   */
+  label?: string;
+
+  /**
+   * The text to show as the cancel button's text, defaults to "Cancel"
+   *
+   * @default Cancel
+   */
+  cancelText?: string;
+
+  /**
+   * The text to show as the ok button's text, defaults to "OK"
+   *
+   * @default OK
+   */
+  confirmText?: string;
+
+  /**
+   * Whether or not the modal must be shown
+   */
+  isOpen: boolean;
+
+  /**
+   * Function that gets called when the modal is dismissed or closed via the close button
+   *
+   */
+  onClose: () => void;
+
+  /**
+   * Function that gets called when the user clicks the save button
+   */
+  onSave: () => void;
+
+  /**
+   * Text which is rendered inside the modal
+   */
+  modalText: React.ReactNode;
+};
+
+/**
+ * ConfirmModal offers the user a confirmation dialog before performing an operation.
+ * The main use case is a delete action, which we want the user to confirm before proceeding.
+ *
+ * Note: In most cases, you'll want to use {@link ConfirmButton} instead. That component offers an easy-to-use button that triggers this dialog.
+ * However, if it is not possible to trigger the action through a button, such as when using a ButtonDropdown, you can use this component directly instead.
+ */
+export default function ConfirmModal({
+  isOpen,
+  onClose,
+  onSave,
+  label,
+  cancelText,
+  confirmText,
+  modalText
+}: Props) {
+  return (
+    <OpenCloseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={onSave}
+      label={t({
+        overrideText: label,
+        key: 'ConfirmButton.MODAL_HEADER',
+        fallback: 'Confirmation'
+      })}
+      text={{
+        cancel: t({
+          overrideText: cancelText,
+          key: 'ConfirmButton.CANCEL',
+          fallback: 'Cancel'
+        }),
+        save: t({
+          overrideText: confirmText,
+          key: 'ConfirmButton.CONFIRM',
+          fallback: 'Confirm'
+        })
+      }}
+    >
+      {modalText}
+    </OpenCloseModal>
+  );
+}

--- a/src/core/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/core/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: ConfirmModal ui custom texts: Component: ConfirmModal => ui => custom texts 1`] = `
+<OpenCloseModal
+  isOpen={true}
+  label="Perform dangerous action"
+  onClose={[Function]}
+  onSave={[Function]}
+  text={
+    Object {
+      "cancel": "NO",
+      "save": "YES",
+    }
+  }
+>
+  <p>
+    Are you sure you want to 
+    <strong>
+      delete
+    </strong>
+     all users in the database?
+  </p>
+</OpenCloseModal>
+`;
+
+exports[`Component: ConfirmModal ui default texts: Component: ConfirmModal => ui => default texts 1`] = `
+<OpenCloseModal
+  isOpen={true}
+  label="Confirmation"
+  onClose={[Function]}
+  onSave={[Function]}
+  text={
+    Object {
+      "cancel": "Cancel",
+      "save": "Confirm",
+    }
+  }
+>
+  <p>
+    Are you sure you want to 
+    <strong>
+      delete
+    </strong>
+     the user?
+  </p>
+</OpenCloseModal>
+`;


### PR DESCRIPTION
Added `ConfirmModal`, which is based on `OpenCloseModal` and offers
the user a confirmation before performing an action.

A confirmation dialog was previously only accessible through
`ConfirmButton`. While `ConfirmButton` remains the primary choice to
perform operations that need confirmation from the user, in some cases
it could be needed to offer a confirmation modal through other means.

An example is a `ButtonDropdown` which contains a remove action that
needs confirmation. In such case, we want to use the generic confirm
modal but don't want to render a button.