### PR TITLE
bugfix: TextEditor now longer allows all formatting such as images

### DIFF
--- a/src/core/AsyncContent/AsyncContent.test.tsx
+++ b/src/core/AsyncContent/AsyncContent.test.tsx
@@ -109,7 +109,7 @@ describe('Component: AsyncContent', () => {
     test('with retry button', () => {
       const reloadSpy = jest.fn();
 
-      jest.spyOn(console, 'error');
+      jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const state = {
         isLoading: false,
         isFulfilled: false,
@@ -129,7 +129,7 @@ describe('Component: AsyncContent', () => {
     });
 
     test('without retry button', () => {
-      jest.spyOn(console, 'error');
+      jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const state = {
         isLoading: false,
         isFulfilled: false,
@@ -147,7 +147,7 @@ describe('Component: AsyncContent', () => {
     test('should not render when showRetryButton is undefined', () => {
       const reloadSpy = jest.fn();
 
-      jest.spyOn(console, 'error');
+      jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const state = {
         isLoading: false,
         isFulfilled: false,

--- a/src/form/TextEditor/TextEditor.stories.tsx
+++ b/src/form/TextEditor/TextEditor.stories.tsx
@@ -89,6 +89,43 @@ storiesOf('Form|TextEditor', module)
     );
   })
   .add('custom toolbar', () => {
+    return (
+      <Form>
+        <TextEditor
+          id="description"
+          label="Description"
+          placeholder="Please add a description"
+          onChange={value => action(`onChange: ${value}`)}
+          modules={{
+            toolbar: [
+              ['bold', 'italic', 'underline', 'strike'], // toggled buttons
+              ['blockquote', 'code-block'],
+
+              [{ header: 1 }, { header: 2 }], // custom button values
+              [{ list: 'ordered' }, { list: 'bullet' }],
+              [{ script: 'sub' }, { script: 'super' }], // superscript/subscript
+              [{ indent: '-1' }, { indent: '+1' }], // outdent/indent
+              [{ direction: 'rtl' }], // text direction
+
+              [{ size: ['small', false, 'large', 'huge'] }], // custom dropdown
+              [{ header: [1, 2, 3, 4, 5, 6, false] }],
+
+              [{ color: [] }, { background: [] }], // dropdown with defaults from theme
+              [{ font: [] }],
+              [{ align: [] }],
+
+              ['link', 'image', 'video'],
+
+              ['clean']
+            ]
+          }}
+        />
+
+        {disclaimer}
+      </Form>
+    );
+  })
+  .add('custom toolbar option', () => {
     const placeholders = [{ label: 'First name', value: 'firstName' }];
 
     useEffect(() => {
@@ -168,6 +205,45 @@ storiesOf('Form|TextEditor', module)
             }
           }}
         />
+        {disclaimer}
+      </Form>
+    );
+  })
+  .add('manual formats', () => {
+    return (
+      <Form>
+        <TextEditor
+          id="description"
+          label="Description"
+          placeholder="Please add a description"
+          onChange={value => action(`onChange: ${value}`)}
+          modules={{
+            // This determines what is in the toolbar. But not
+            // which formats are supported. Quill does this to
+            // allow bold text to be pasted or entered with a
+            // shortcut, but not show a toolbar button.
+            toolbar: ['italic', 'underline', 'strike']
+          }}
+          // These are the formats which are allowed to be used.
+          // When you include a format here you can paste or use
+          // the shortcut to use the format. In this case we allow
+          // text to be bold, but we do not include it in the toolbar.
+          // This means that using the ctrl-b shortcut, or pasting bold
+          // text, will result in bold text.
+          formats={['bold', 'italic', 'underline', 'strike']}
+        />
+
+        <p>
+          This example shows how to use the <strong>formats</strong> props. Even
+          though there is no bold button in the toolbar you can still paste bold
+          text or use the ctrl-b shortcut.
+        </p>
+
+        <p>
+          This is achieved by not including <strong>bold</strong> in the toolbar
+          but only including it in the <strong>formats</strong> prop.
+        </p>
+
         {disclaimer}
       </Form>
     );

--- a/src/form/TextEditor/TextEditor.test.tsx
+++ b/src/form/TextEditor/TextEditor.test.tsx
@@ -15,12 +15,14 @@ describe('Component: TextEditor', () => {
     value,
     hasPlaceholder = true,
     hasLabel = true,
-    hasToolbarOptions = false
+    hasModules = false,
+    formats = undefined
   }: {
     value?: string;
     hasPlaceholder?: boolean;
     hasLabel?: boolean;
-    hasToolbarOptions?: boolean;
+    hasModules?: boolean;
+    formats?: string[];
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -34,13 +36,12 @@ describe('Component: TextEditor', () => {
       onFocus: onFocusSpy,
       error: 'Some error',
       valid: true,
-      modules: hasToolbarOptions
+      modules: hasModules
         ? {
-            toolbar: {
-              container: []
-            }
+            toolbar: ['bold']
           }
-        : undefined
+        : undefined,
+      formats
     };
 
     if (hasLabel) {
@@ -82,11 +83,19 @@ describe('Component: TextEditor', () => {
       );
     });
 
-    test('with custom toolbar', () => {
-      setup({ value: 'Maarten', hasLabel: false, hasToolbarOptions: true });
+    test('with modules', () => {
+      setup({ value: 'Maarten', hasLabel: false, hasModules: true });
 
       expect(toJson(textEditor)).toMatchSnapshot(
-        'Component: textEditor => ui => with custom toolbar'
+        'Component: textEditor => ui => with modules'
+      );
+    });
+
+    test('with formats', () => {
+      setup({ value: 'Maarten', hasLabel: false, formats: ['italic'] });
+
+      expect(toJson(textEditor)).toMatchSnapshot(
+        'Component: textEditor => ui => with formats'
       );
     });
   });

--- a/src/form/TextEditor/TextEditor.tsx
+++ b/src/form/TextEditor/TextEditor.tsx
@@ -7,6 +7,7 @@ import { StringMap } from 'quill';
 import withJarb from '../withJarb/withJarb';
 import { doBlur } from '../utils';
 import { Color } from '../types';
+import { formatsFromToolbarModule } from './utils';
 
 interface BaseProps {
   /**
@@ -57,8 +58,30 @@ interface BaseProps {
 
   /**
    * Optional configuration option to i.e. customize the toolbar.
+   *
+   * @see https://quilljs.com/docs/modules/
    */
   modules?: StringMap;
+
+  /**
+   * Optional configuration to determine which `Quill` formats are
+   * allowed. A format in `Quill` is: bold text, headers, links,
+   * colors, etc etc. If something is not in the `formats` it is not
+   * allowed in the `TextEditor`.
+   *
+   * In Quill it is possible to not show an item in the toolbar but
+   * allow it in the `formats`. For example you can remove the "bold"
+   * item from the toolbar but allow it in the `formats`. This way the
+   * user can still copy paste bold text into the `TextEditor`, or use
+   * the ctrl-b keyboard shortcut to make bold text.
+   *
+   * By default the `formats` will be the same as the allowed `toolbar`
+   * items in the `modules` prop. This way you do not need to keep
+   * `formats` and `modules.toolbar` in sync.
+   *
+   * @see https://quilljs.com/docs/formats/
+   */
+  formats?: string[];
 }
 
 interface WithoutLabel extends BaseProps {
@@ -106,7 +129,8 @@ export default function TextEditor(props: Props) {
     color,
     value,
     className = '',
-    modules
+    modules,
+    formats
   } = props;
 
   const inputProps = {
@@ -116,7 +140,8 @@ export default function TextEditor(props: Props) {
     onBlur: () => doBlur(onBlur),
     onFocus,
     value,
-    modules
+    modules,
+    formats: formats ? formats : formatsFromToolbarModule(modules)
   };
 
   const classes = classNames({ 'is-invalid': valid === false });

--- a/src/form/TextEditor/__snapshots__/TextEditor.test.tsx.snap
+++ b/src/form/TextEditor/__snapshots__/TextEditor.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: TextEditor ui with custom toolbar: Component: textEditor => ui => with custom toolbar 1`] = `
+exports[`Component: TextEditor ui with formats: Component: textEditor => ui => with formats 1`] = `
 <FormGroup
   className=""
   color="success"
@@ -8,11 +8,41 @@ exports[`Component: TextEditor ui with custom toolbar: Component: textEditor => 
 >
   <Quill
     className=""
+    formats={
+      Array [
+        "italic",
+      ]
+    }
+    modules={Object {}}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[MockFunction]}
+    placeholder="Please enter your first name"
+    theme="snow"
+    value="Maarten"
+  />
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TextEditor ui with modules: Component: textEditor => ui => with modules 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Quill
+    className=""
+    formats={
+      Array [
+        "bold",
+      ]
+    }
     modules={
       Object {
-        "toolbar": Object {
-          "container": Array [],
-        },
+        "toolbar": Array [
+          "bold",
+        ],
       }
     }
     onBlur={[Function]}
@@ -49,6 +79,16 @@ exports[`Component: TextEditor ui with value: Component: textEditor => ui => wit
   </Label>
   <Quill
     className=""
+    formats={
+      Array [
+        "header",
+        "list",
+        "bold",
+        "italic",
+        "underline",
+        "link",
+      ]
+    }
     id="firstName"
     modules={Object {}}
     onBlur={[Function]}
@@ -70,6 +110,16 @@ exports[`Component: TextEditor ui without label: Component: textEditor => ui => 
 >
   <Quill
     className=""
+    formats={
+      Array [
+        "header",
+        "list",
+        "bold",
+        "italic",
+        "underline",
+        "link",
+      ]
+    }
     modules={Object {}}
     onBlur={[Function]}
     onChange={[Function]}
@@ -105,6 +155,16 @@ exports[`Component: TextEditor ui without placeholder: Component: textEditor => 
   </Label>
   <Quill
     className=""
+    formats={
+      Array [
+        "header",
+        "list",
+        "bold",
+        "italic",
+        "underline",
+        "link",
+      ]
+    }
     id="firstName"
     modules={Object {}}
     onBlur={[Function]}

--- a/src/form/TextEditor/utils.test.ts
+++ b/src/form/TextEditor/utils.test.ts
@@ -1,0 +1,108 @@
+import { formatsFromToolbarModule } from './utils';
+
+describe('formatsFromToolbarModule', () => {
+  it('should when the "modules" are undefined return the default formats', () => {
+    expect(formatsFromToolbarModule(undefined)).toEqual([
+      'header',
+      'list',
+      'bold',
+      'italic',
+      'underline',
+      'link'
+    ]);
+  });
+
+  it('should when the "toolbar" is undefined return the default formats', () => {
+    expect(formatsFromToolbarModule({ haha: 42 })).toEqual([
+      'header',
+      'list',
+      'bold',
+      'italic',
+      'underline',
+      'link'
+    ]);
+  });
+
+  it('should when the "toolbar" has a "container" property use that instead of the "toolbar" prop', () => {
+    const placeholders = [{ label: 'First name', value: 'firstName' }];
+
+    const modules = {
+      toolbar: {
+        container: [
+          [
+            {
+              placeholder: placeholders.map(ph => ph.value)
+            }
+          ],
+          ['bold', 'italic', 'underline', 'link']
+        ],
+        handlers: {
+          placeholder: () => undefined
+        }
+      }
+    };
+
+    expect(formatsFromToolbarModule(modules)).toEqual([
+      'placeholder',
+      'bold',
+      'italic',
+      'underline',
+      'link'
+    ]);
+  });
+
+  it('should throw an error when "toolbar" is not an array', () => {
+    expect(() => {
+      formatsFromToolbarModule({ toolbar: 42 });
+    }).toThrowError('TextEditor: expecting modules.toolbar to be an array');
+  });
+
+  it('should know how to extract formats from a complex toolbar definition ', () => {
+    const modules = {
+      toolbar: [
+        ['bold', 'italic', 'underline', 'strike'], // toggled buttons
+        ['blockquote', 'code-block'],
+
+        [{ header: 1 }, { header: 2 }], // custom button values
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        [{ script: 'sub' }, { script: 'super' }], // superscript/subscript
+        [{ indent: '-1' }, { indent: '+1' }], // outdent/indent
+        [{ direction: 'rtl' }], // text direction
+
+        [{ size: ['small', false, 'large', 'huge'] }], // custom dropdown
+        [{ header: [1, 2, 3, 4, 5, 6, false] }],
+
+        [{ color: [] }, { background: [] }], // dropdown with defaults from theme
+        [{ font: [] }],
+        [{ align: [] }],
+
+        ['link', 'image', 'video'],
+
+        ['clean']
+      ]
+    };
+
+    expect(formatsFromToolbarModule(modules)).toEqual([
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'blockquote',
+      'code-block',
+      'header',
+      'list',
+      'script',
+      'indent',
+      'direction',
+      'size',
+      'color',
+      'background',
+      'font',
+      'align',
+      'link',
+      'image',
+      'video',
+      'clean'
+    ]);
+  });
+});

--- a/src/form/TextEditor/utils.ts
+++ b/src/form/TextEditor/utils.ts
@@ -1,0 +1,64 @@
+import { StringMap } from 'quill';
+import { isArray, flatMap, uniq } from 'lodash';
+
+/* 
+  When module.toolbar exists it will generate the formats for Quill
+  based on the items in the toolbar.
+
+  When module or toolbar is empty the default formats are returned.
+*/
+export function formatsFromToolbarModule(
+  modules: StringMap | undefined
+): string[] {
+  // If there are no modules use the default formats
+  if (!modules) {
+    return defaultFormats();
+  }
+
+  let { toolbar } = modules;
+
+  // If there is no toolbar defined use the default formats
+  if (!toolbar) {
+    return defaultFormats();
+  }
+
+  // When advanced toolbars are used we want to take the container.
+  if (toolbar.container) {
+    toolbar = toolbar.container;
+  }
+
+  if (!isArray(toolbar)) {
+    throw new Error('TextEditor: expecting modules.toolbar to be an array');
+  }
+
+  return uniq(formatsForToolbar(toolbar));
+}
+
+/* 
+  Recursive function which can generate the formats based 
+  on the toolbar
+*/
+function formatsForToolbar(toolbarItem: any): string | string[] {
+  if (typeof toolbarItem === 'string') {
+    // toolbar strings are also the formats, so we can just return
+    // them as is.
+    return toolbarItem;
+  } else if (isArray(toolbarItem)) {
+    // Further reduce the array of formats, it could be an array of
+    // strings or objects or mixed at this point.
+    return flatMap(toolbarItem, formatsForToolbar);
+  } else {
+    // When an object the keys of the objects are the formats
+    return formatsForToolbar(Object.keys(toolbarItem));
+  }
+}
+
+/* 
+  Helper to create the default formats. These are the formats of
+  the default toolbar of the TextEditor component.
+  
+  Is a function to prevent accidental mutations.
+*/
+function defaultFormats() {
+  return ['header', 'list', 'bold', 'italic', 'underline', 'link'];
+}


### PR DESCRIPTION
Quill separates the toolbar from the allowed formats. For example it is
possible to not show the "bold" toolbar item, but to allow the ctrl-b
shortcut and pasting bold text. The `format` property defines which
formatting is actually allowed.

We did not set the `formats` for the `TextEditor` which then defaults
to allow all formats. This is unexpected, developers do not expect that
for the default toolbar we provide, that the user can for example can
paste images.

The solution is adding a `formats` property to the `TextEditor` which
by default is set to all items in the default toolbar.

This way when customising the toolbar the developer can also set the
`formats` allowing only what the end user expects.

Closes #490