### PR TITLE
bugfix: DateTimeInput no longer uses browsers timezone.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24638,9 +24638,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moo": {
       "version": "0.5.1",
@@ -27719,21 +27719,11 @@
       }
     },
     "react-datetime": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.16.3.tgz",
-      "integrity": "sha512-amWfb5iGEiyqjLmqCLlPpu2oN415jK8wX1qoTq7qn6EYiU7qQgbNHglww014PT4O/3G5eo/3kbJu/M/IxxTyGw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-3.0.4.tgz",
+      "integrity": "sha512-v6MVwCve+DRaLN2f22LTO5TlrPpkUXumPkp1zfrbhaFtSYGl2grZ2JtwJfLxRj/T4ACyePAV4srCR6cMSiQ/Iw==",
       "requires": {
-        "create-react-class": "^15.5.2",
-        "object-assign": "^3.0.0",
-        "prop-types": "^15.5.7",
-        "react-onclickoutside": "^6.5.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
+        "prop-types": "^15.5.7"
       }
     },
     "react-dev-utils": {
@@ -28122,11 +28112,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-onclickoutside": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz",
-      "integrity": "sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A=="
     },
     "react-overlays": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "bootstrap": "4.4.1",
     "material-design-icons": "3.0.1",
-    "moment": "2.24.0",
+    "moment": "2.29.1",
     "overlayscrollbars": "1.10.3",
     "overlayscrollbars-react": "0.2.1",
     "pica": "5.1.0",
@@ -44,7 +44,7 @@
     "react-avatar-editor": "11.0.7",
     "react-bootstrap-typeahead": "4.0.0-alpha.6",
     "react-color": "2.18.0",
-    "react-datetime": "2.16.3",
+    "react-datetime": "3.0.4",
     "react-display-name": "0.2.5",
     "react-final-form": "6.3.5",
     "react-is": "16.12.0",

--- a/scripts/dev-publish.sh
+++ b/scripts/dev-publish.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 read -p "Have you updated the package version (y/n)? " answer
 case ${answer:0:1} in
 y | Y) ;;
@@ -46,7 +47,23 @@ EOD
 
 printf -- '\033[32m SUCCESS: verdaccio user created \033[0m\n'
 
+
+# Build version
+printf -- '\033[37m Attempting to build \033[0m\n'
+npm run build
+printf -- '\033[32m SUCCESS: Succesfully build \033[0m\n'
+
+# Cleanup
+printf -- '\033[37m Cleaning up build artifacts... \033[0m\n'
+git checkout stats.html
+git checkout .size-snapshot.json
+printf -- '\033[32m SUCCESS: Succesfully cleaned up build artifacts \033[0m\n'
+
 # Publish packages
 printf -- '\033[37m Attempting to publish to verdaccio... \033[0m\n'
 npm publish --registry http://localhost:4873
 printf -- '\033[32m SUCCESS: Succesfully published packages \033[0m\n'
+
+# Provide instructions
+version=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
+printf -- '\033[32m Now go to your test project set the version of "@42.nl/ui" to "%s" then run "npm install --registry http://localhost:4873" \033[0m\n' $version

--- a/src/form/DateTimeInput/DateTimeInput.stories.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.stories.tsx
@@ -115,7 +115,7 @@ storiesOf('Form|DateTime/DateTimeInput', module)
           name="dateOfBirth"
           label="Date of birth"
           placeholder="Please enter your date of birth"
-          dateFormat="YYYY-MM-DD"
+          dateFormat="DD-MM-YYYY"
           timeFormat={false}
           isDateAllowed={date => {
             return date.isBefore(new Date());
@@ -131,7 +131,7 @@ storiesOf('Form|DateTime/DateTimeInput', module)
           name="weddingDay"
           label="Wedding day"
           placeholder="Please enter your wedding day"
-          dateFormat="YYYY-MM-DD"
+          dateFormat="DD-MM-YYYY"
           timeFormat={false}
           isDateAllowed={date => {
             return date.isAfter(new Date());
@@ -164,7 +164,7 @@ storiesOf('Form|DateTime/DateTimeInput', module)
           name="dueDate"
           label="Due date"
           placeholder="Please enter the due date for when the ticket needs to be resolved"
-          dateFormat="YYYY-MM-DD"
+          dateFormat="DD-MM-YYYY"
           timeFormat="HH:mm:ss"
           jarb={{
             validator: 'Issue.dueDate',

--- a/src/form/DateTimeInput/DateTimeInput.test.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.test.tsx
@@ -106,8 +106,9 @@ describe('Component: DateTimeInput', () => {
       setup({});
 
       const input = shallow(
+        // @ts-ignore
         dateTimeInput
-          .find('DateTime')
+          .find(Datetime)
           .props()
           // @ts-ignore
           .renderInput({ id: 10 })
@@ -122,8 +123,9 @@ describe('Component: DateTimeInput', () => {
       setup({ mode: 'modal' });
 
       const inputGroup = shallow(
+        // @ts-ignore
         dateTimeInput
-          .find('DateTime')
+          .find(Datetime)
           .props()
           // @ts-ignore
           .renderInput({ id: 10 })
@@ -276,7 +278,7 @@ describe('Component: DateTimeInput', () => {
 
       const dateTime = dateTimeInput.find(Datetime);
       // @ts-ignore
-      dateTime.props().onFocus();
+      dateTime.props().onOpen();
 
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
@@ -317,8 +319,9 @@ describe('Component: DateTimeInput', () => {
         setup({ mode: 'modal' });
 
         const inputGroup = shallow(
+          // @ts-ignore
           dateTimeInput
-            .find('DateTime')
+            .find(Datetime)
             .props()
             // @ts-ignore
             .renderInput({ id: 10 })

--- a/src/form/DateTimeInput/DateTimeInput.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.tsx
@@ -110,6 +110,15 @@ export interface Props {
   locale?: string;
 
   /**
+   * When true, input time values will be interpreted as UTC (Zulu time)
+   * by Moment.js. Otherwise they will default to the user's local
+   * timezone.
+   *
+   * Defaults to true.
+   */
+  utc?: boolean;
+
+  /**
    * Optional extra CSS class you want to add to the component.
    * Useful for styling the component.
    */
@@ -161,6 +170,7 @@ export default function DateTimeInput(props: Props) {
     value,
     error,
     locale,
+    utc = true,
     mode = 'default',
     text,
     className = ''
@@ -187,7 +197,6 @@ export default function DateTimeInput(props: Props) {
           value.trim(), // value includes an empty char at the back for some reason.
           combineFormat(dateFormat, timeFormat)
         );
-
         onChange(date.toDate());
         setHasFormatError(false);
       } else {
@@ -246,12 +255,13 @@ export default function DateTimeInput(props: Props) {
             : maskedInput(props)
         }
         onChange={onChange}
-        onFocus={onFocus}
+        onOpen={onFocus}
         value={value ? value : lastStringValue}
         dateFormat={dateFormat}
         timeFormat={timeFormat}
         closeOnSelect={true}
         locale={locale}
+        utc={utc}
         isValidDate={(date: Moment, current?: Moment) =>
           isDateAllowed(date, current)
         }
@@ -268,6 +278,7 @@ export default function DateTimeInput(props: Props) {
           isDateAllowed={isDateAllowed}
           label={placeholder}
           locale={locale}
+          utc={utc}
           text={text}
         />
       ) : null}

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.test.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import Datetime from 'react-datetime';
 
 import { DateTimeModal } from './DateTimeModal';
 
@@ -54,7 +55,7 @@ describe('Component: DateTimeModal', () => {
 
       // @ts-ignore
       dateTimeModal
-        .find('DateTime')
+        .find(Datetime)
         .props()
         // @ts-ignore
         .onChange(value);
@@ -70,7 +71,7 @@ describe('Component: DateTimeModal', () => {
 
       // @ts-ignore
       dateTimeModal
-        .find('DateTime')
+        .find(Datetime)
         .props()
         // @ts-ignore
         .onChange(value);
@@ -86,7 +87,7 @@ describe('Component: DateTimeModal', () => {
 
       // @ts-ignore
       dateTimeModal
-        .find('DateTime')
+        .find(Datetime)
         .props()
         // @ts-ignore
         .onChange(value);
@@ -109,7 +110,7 @@ describe('Component: DateTimeModal', () => {
 
       // @ts-ignore
       dateTimeModal
-        .find('DateTime')
+        .find(Datetime)
         .props()
         // @ts-ignore
         .onChange(value);
@@ -135,7 +136,7 @@ describe('Component: DateTimeModal', () => {
 
       // @ts-ignore
       dateTimeModal
-        .find('DateTime')
+        .find(Datetime)
         .props()
         // @ts-ignore
         .isValidDate(value, current);

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
@@ -73,6 +73,15 @@ type Props = {
   isDateAllowed?: IsDateAllowed;
 
   /**
+   * When true, input time values will be interpreted as UTC (Zulu time)
+   * by Moment.js. Otherwise they will default to the user's local
+   * timezone.
+   *
+   * Defaults to true.
+   */
+  utc?: boolean;
+
+  /**
    * Optionally customized text within the component.
    * This text should already be translated.
    */
@@ -88,6 +97,7 @@ export function DateTimeModal(props: Props) {
     dateFormat,
     timeFormat,
     locale,
+    utc = true,
     text = {
       save: t({
         key: 'DateTimeModal.SELECT',
@@ -121,6 +131,7 @@ export function DateTimeModal(props: Props) {
         dateFormat={dateFormat}
         timeFormat={timeFormat}
         locale={locale}
+        utc={utc}
         isValidDate={(date: Moment, current?: Moment) =>
           isDateAllowed(date, current)
         }

--- a/src/form/DateTimeInput/DateTimeModal/__snapshots__/DateTimeModal.test.tsx.snap
+++ b/src/form/DateTimeInput/DateTimeModal/__snapshots__/DateTimeModal.test.tsx.snap
@@ -14,26 +14,29 @@ exports[`Component: DateTimeModal ui with value: Component: DateTimeModal => ui 
     }
   }
 >
-  <DateTime
+  <n
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={false}
     closeOnTab={true}
     dateFormat="YYYY-MM-DD"
-    defaultValue=""
     input={false}
     inputProps={Object {}}
     isValidDate={[Function]}
-    onBlur={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[Function]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[Function]}
     open={true}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat="HH:II:SS"
-    utc={false}
+    utc={true}
     value={"2020-01-31T23:00:00.000Z"}
   />
 </OpenCloseModal>
@@ -53,26 +56,29 @@ exports[`Component: DateTimeModal ui without value: Component: DateTimeModal => 
     }
   }
 >
-  <DateTime
+  <n
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={false}
     closeOnTab={true}
     dateFormat="YYYY-MM-DD"
-    defaultValue=""
     input={false}
     inputProps={Object {}}
     isValidDate={[Function]}
-    onBlur={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[Function]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[Function]}
     open={true}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat="HH:II:SS"
-    utc={false}
+    utc={true}
     value=""
   />
 </OpenCloseModal>

--- a/src/form/DateTimeInput/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/src/form/DateTimeInput/__snapshots__/DateTimeInput.test.tsx.snap
@@ -55,12 +55,12 @@ exports[`Component: DateTimeInput ui with date picker in modal: Component: DateT
       )
     </span>
   </Label>
-  <DateTime
+  <n
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={true}
     closeOnTab={true}
     dateFormat="YYYY-MM-DD"
-    defaultValue=""
     input={true}
     inputProps={
       Object {
@@ -91,18 +91,21 @@ exports[`Component: DateTimeInput ui with date picker in modal: Component: DateT
       }
     }
     isValidDate={[Function]}
-    onBlur={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[MockFunction]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[MockFunction]}
     open={false}
     renderInput={[Function]}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat="HH:mm:ss"
-    utc={false}
+    utc={true}
     value=""
   />
   Some error
@@ -114,6 +117,7 @@ exports[`Component: DateTimeInput ui with date picker in modal: Component: DateT
     onClose={[Function]}
     onSave={[Function]}
     timeFormat="HH:mm:ss"
+    utc={true}
   />
 </FormGroup>
 `;
@@ -147,12 +151,12 @@ exports[`Component: DateTimeInput ui with format error: Component: DateTimeInput
       )
     </span>
   </Label>
-  <DateTime
+  <n
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={true}
     closeOnTab={true}
     dateFormat="YYYY-MM-DD"
-    defaultValue=""
     input={true}
     inputProps={
       Object {
@@ -183,17 +187,20 @@ exports[`Component: DateTimeInput ui with format error: Component: DateTimeInput
       }
     }
     isValidDate={[Function]}
-    onBlur={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[MockFunction]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[MockFunction]}
     renderInput={[Function]}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat="HH:mm:ss"
-    utc={false}
+    utc={true}
     value={2000-01-01T11:30:40.000Z}
   />
   Some error
@@ -229,12 +236,12 @@ exports[`Component: DateTimeInput ui with label: Component: DateTimeInput => ui 
       )
     </span>
   </Label>
-  <DateTime
+  <n
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={true}
     closeOnTab={true}
     dateFormat="YYYY-MM-DD"
-    defaultValue=""
     input={true}
     inputProps={
       Object {
@@ -265,17 +272,20 @@ exports[`Component: DateTimeInput ui with label: Component: DateTimeInput => ui 
       }
     }
     isValidDate={[Function]}
-    onBlur={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[MockFunction]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[MockFunction]}
     renderInput={[Function]}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat="HH:mm:ss"
-    utc={false}
+    utc={true}
     value={2000-01-01T11:30:40.000Z}
   />
   Some error
@@ -288,12 +298,12 @@ exports[`Component: DateTimeInput ui without label: Component: DateTimeInput => 
   color="success"
   tag="div"
 >
-  <DateTime
+  <n
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={true}
     closeOnTab={true}
     dateFormat="YYYY-MM-DD"
-    defaultValue=""
     input={true}
     inputProps={
       Object {
@@ -324,17 +334,20 @@ exports[`Component: DateTimeInput ui without label: Component: DateTimeInput => 
       }
     }
     isValidDate={[Function]}
-    onBlur={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[MockFunction]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[MockFunction]}
     renderInput={[Function]}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat="HH:mm:ss"
-    utc={false}
+    utc={true}
     value={2000-01-01T11:30:40.000Z}
   />
   Some error

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export { default as TextButton } from './core/TextButton/TextButton';
 export { useShowAfter } from './core/useShowAfter/useShowAfter';
 
 // Form
+export { AutoSave } from './form/AutoSave/AutoSave';
 export { default as withJarb } from './form/withJarb/withJarb';
 export { default as Input, JarbInput } from './form/Input/Input';
 export { default as Textarea, JarbTextarea } from './form/Textarea/Textarea';


### PR DESCRIPTION
When the user picked a date the timezone would be in the timezone that
the browser is currently in. When the user selected `28-10-2019` from
the `DateTimeInput` using the picker the value of the date would become
`2019-10-27T23:00:00.000Z`.

The `2019-10-27T23:00:00.000Z` is parsed by Spring for a `LocalDate`
as `2019-10-27`.

By using setting `react-datetime`'s `utc` property to `true` by default
the date would become: `2019-10-28T00:00:00.000Z` which is correctly
parsed.

By default the `utc` property in the `DateTimeInput` will be `true`
and this is passed to `DateTimeModal` as well.

Updated:

1. `moment` from `2.24.0` to `2.29.1`.

2. `react-datetime` from `2.16.3` to `3.04`. This changes `onFocus` to
   `onOpen` as a breaking change for us. Also the name of the default
    export changed to a strange string, so now in the tests we find
    `Datetime` directly instead of the string variant.

Also exposing the `AutoSave` component in the index export.

Fixes #492