### PR TITLE
form: unified props for form components with predetermined options

### DIFF
--- a/src/core/AsyncList/__snapshots__/AsyncList.test.tsx.snap
+++ b/src/core/AsyncList/__snapshots__/AsyncList.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`Component: Async|AsyncList ui 1`] = `
         Object {
           "active": true,
           "email": "admin@42.nl",
-          "firstName": "admin",
+          "firstName": "Addie",
           "id": 42,
-          "lastName": "user",
+          "lastName": "Admin",
           "roles": Array [
             "ADMIN",
           ],
@@ -20,9 +20,9 @@ exports[`Component: Async|AsyncList ui 1`] = `
         Object {
           "active": false,
           "email": "coordinator@42.nl",
-          "firstName": "coordinator",
+          "firstName": "Cordelia",
           "id": 777,
-          "lastName": "user",
+          "lastName": "Coordinator",
           "roles": Array [
             "ADMIN",
             "USER",
@@ -31,9 +31,9 @@ exports[`Component: Async|AsyncList ui 1`] = `
         Object {
           "active": false,
           "email": "user@42.nl",
-          "firstName": "test",
+          "firstName": "Ulysses",
           "id": 1337,
-          "lastName": "user",
+          "lastName": "User",
           "roles": Array [
             "USER",
           ],

--- a/src/core/AsyncPage/__snapshots__/AsyncPage.test.tsx.snap
+++ b/src/core/AsyncPage/__snapshots__/AsyncPage.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`Component: AsyncPage ui 1`] = `
           Object {
             "active": true,
             "email": "admin@42.nl",
-            "firstName": "admin",
+            "firstName": "Addie",
             "id": 42,
-            "lastName": "user",
+            "lastName": "Admin",
             "roles": Array [
               "ADMIN",
             ],
@@ -21,9 +21,9 @@ exports[`Component: AsyncPage ui 1`] = `
           Object {
             "active": false,
             "email": "coordinator@42.nl",
-            "firstName": "coordinator",
+            "firstName": "Cordelia",
             "id": 777,
-            "lastName": "user",
+            "lastName": "Coordinator",
             "roles": Array [
               "ADMIN",
               "USER",
@@ -32,9 +32,9 @@ exports[`Component: AsyncPage ui 1`] = `
           Object {
             "active": false,
             "email": "user@42.nl",
-            "firstName": "test",
+            "firstName": "Ulysses",
             "id": 1337,
-            "lastName": "user",
+            "lastName": "User",
             "roles": Array [
               "USER",
             ],

--- a/src/core/OpenCloseModal/OpenCloseModal.stories.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.stories.tsx
@@ -49,7 +49,7 @@ storiesOf('core/OpenCloseModal', module)
               'I work at 42, the most awesome company in the world!',
               'Nothing'
             ]}
-            optionForValue={(option) => option}
+            labelForOption={(option) => option}
           />
         </OpenCloseModal>
       </Card>
@@ -196,7 +196,7 @@ storiesOf('core/OpenCloseModal', module)
               { label: 'Sell it!', value: 'sell' },
               { label: 'Put it in my pocket', value: 'store' }
             ]}
-            optionForValue={(option) => option.label}
+            labelForOption={(option) => option.label}
           />
         </OpenCloseModal>
       </Card>

--- a/src/core/OpenCloseModal/OpenCloseModal.test.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.test.tsx
@@ -45,10 +45,10 @@ describe('Component: OpenCloseModal', () => {
     }
 
     const children = (
-      <RadioGroup
+      <RadioGroup<string>
         onChange={jest.fn()}
         options={['local', 'development', 'test', 'acceptation', 'production']}
-        optionForValue={(v) => v}
+        labelForOption={(v) => v}
       />
     );
 

--- a/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
+++ b/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
@@ -43,8 +43,8 @@ exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseM
     tag="div"
   >
     <RadioGroup
+      labelForOption={[Function]}
       onChange={[MockFunction]}
-      optionForValue={[Function]}
       options={
         Array [
           "local",
@@ -122,8 +122,8 @@ exports[`Component: OpenCloseModal ui in progress: Component: OpenCloseModal => 
     tag="div"
   >
     <RadioGroup
+      labelForOption={[Function]}
       onChange={[MockFunction]}
-      optionForValue={[Function]}
       options={
         Array [
           "local",
@@ -202,8 +202,8 @@ exports[`Component: OpenCloseModal ui sans sticky footer: Component: OpenCloseMo
     tag="div"
   >
     <RadioGroup
+      labelForOption={[Function]}
       onChange={[MockFunction]}
-      optionForValue={[Function]}
       options={
         Array [
           "local",
@@ -281,8 +281,8 @@ exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => u
     tag="div"
   >
     <RadioGroup
+      labelForOption={[Function]}
       onChange={[MockFunction]}
-      optionForValue={[Function]}
       options={
         Array [
           "local",
@@ -360,8 +360,8 @@ exports[`Component: OpenCloseModal ui without buttons: Component: OpenCloseModal
     tag="div"
   >
     <RadioGroup
+      labelForOption={[Function]}
       onChange={[MockFunction]}
-      optionForValue={[Function]}
       options={
         Array [
           "local",
@@ -410,8 +410,8 @@ exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal =
     tag="div"
   >
     <RadioGroup
+      labelForOption={[Function]}
       onChange={[MockFunction]}
-      optionForValue={[Function]}
       options={
         Array [
           "local",

--- a/src/core/SearchInput/SearchInput.stories.tsx
+++ b/src/core/SearchInput/SearchInput.stories.tsx
@@ -130,8 +130,8 @@ storiesOf('core/SearchInput', module)
                 label="Predefined queries"
                 value={query}
                 placeholder="Please select a predefined query"
-                optionForValue={(option) => option}
                 options={['Maarten', 'Jeffrey']}
+                labelForOption={(option) => option}
                 onChange={(value) => {
                   if (value) {
                     setValue(value);

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -1,63 +1,289 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { range } from 'lodash';
 
 import CheckboxMultipleSelect, {
   JarbCheckboxMultipleSelect
 } from './CheckboxMultipleSelect';
-import { FinalForm, Form } from '../story-utils';
-import { pageOfUsers, userUser } from '../../test/fixtures';
-import { User } from '../../test/types';
-import { Icon, Tooltip } from '../..';
-
-type SubjectOption = {
-  value: string;
-  label: string;
-};
-
-const options: SubjectOption[] = range(0, 100).map((i) => ({
-  value: `${i}`,
-  label: `Selection #${i}`
-}));
+import {
+  FinalForm,
+  Form,
+  IsOptionEqualInfo,
+  KeyForOptionInfo,
+  nonExistingProvince,
+  Province,
+  provinceFetcher,
+  provinces,
+  ReloadOptionsInfo
+} from '../story-utils';
+import { Icon, Toggle, Tooltip } from '../..';
 
 storiesOf('Form/CheckboxMultipleSelect', module)
-  .add('defined options', () => {
-    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
 
     return (
-      <div>
-        <Form>
-          <CheckboxMultipleSelect
-            id="subject"
-            label="Subject"
-            placeholder="Please select your subjects"
-            optionForValue={(option: SubjectOption) => option.label}
-            isOptionEnabled={(option) => option.value !== 'awesome'}
-            options={options}
-            value={value}
-            onChange={setValue}
+      <Form>
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
+  .add('async options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      provinces()[0]
+    ]);
+
+    return (
+      <Form>
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <IsOptionEqualInfo />
+      </Form>
+    );
+  })
+  .add('custom keyForOption', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      provinces()[0]
+    ]);
+
+    return (
+      <Form>
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          keyForOption={(province) => province.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <KeyForOptionInfo />
+      </Form>
+    );
+  })
+  .add('using reloadOptions', () => {
+    const [limitToNorthern, setLimitToNorthern] = useState(false);
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <p>
+          Limit to northern provinces
+          <Toggle
+            className="ml-2"
+            color="primary"
+            value={limitToNorthern}
+            onChange={() => setLimitToNorthern(!limitToNorthern)}
           />
-        </Form>
-      </div>
+        </p>
+
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces().filter((option) =>
+            limitToNorthern ? option.north : true
+          )}
+          labelForOption={(option) => option.label}
+          value={value}
+          onChange={setValue}
+          reloadOptions={limitToNorthern}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(',')}
+          </p>
+        ) : null}
+
+        <ReloadOptionsInfo />
+      </Form>
+    );
+  })
+  .add('label & placeholder', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <h3>Without label</h3>
+
+        <CheckboxMultipleSelect
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <CheckboxMultipleSelect
+          id="provinces"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>Friends</span>
+              <Tooltip className="ml-1" content="Provinces are nice to have">
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Without placeholder</h3>
+
+        <CheckboxMultipleSelect
+          id="provinces"
+          label="Provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
     );
   })
   .add('horizontal', () => {
-    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
 
     return (
       <div>
         <Form>
           <CheckboxMultipleSelect
-            id="subject"
-            label="Subject"
-            placeholder="Please select your subjects"
-            optionForValue={(option: SubjectOption) => option.label}
-            isOptionEnabled={(option) => option.value !== 'awesome'}
-            options={options.filter((_, index) => index < 5)}
+            id="provinces"
+            label="Provinces"
+            placeholder="Please select your provinces"
+            options={provinces()}
+            labelForOption={(province) => province.label}
             value={value}
             onChange={setValue}
             horizontal={true}
           />
+
+          {value ? (
+            <p>
+              Your chosen provinces are:{' '}
+              {value.map((province) => province.label).join(', ')}
+            </p>
+          ) : null}
 
           <p>
             <strong>Disclaimer:</strong> horizontal mode works best when there
@@ -67,128 +293,19 @@ storiesOf('Form/CheckboxMultipleSelect', module)
       </div>
     );
   })
-  .add('fetched options', () => {
-    const [value, setValue] = useState<User[] | undefined>([]);
-
-    return (
-      <Form>
-        <CheckboxMultipleSelect
-          id="subject"
-          label="Subject"
-          placeholder="Please select your subjects"
-          optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers())}
-          value={value}
-          onChange={setValue}
-        />
-      </Form>
-    );
-  })
-  .add('custom isOptionEqual', () => {
-    const [value, setValue] = useState<User[] | undefined>([userUser()]);
-
-    return (
-      <Form>
-        <CheckboxMultipleSelect
-          id="subject"
-          label="Subject"
-          placeholder="Please select your subjects"
-          optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers())}
-          isOptionEqual={(a: User, b: User) => a.id === b.id}
-          value={value}
-          onChange={setValue}
-        />
-      </Form>
-    );
-  })
-  .add('without placeholder', () => {
-    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
-
-    return (
-      <div>
-        <Form>
-          <CheckboxMultipleSelect
-            id="subject"
-            label="Subject"
-            optionForValue={(option: SubjectOption) => option.label}
-            isOptionEnabled={(option) => option.value !== 'awesome'}
-            options={options}
-            value={value}
-            onChange={setValue}
-          />
-        </Form>
-      </div>
-    );
-  })
-  .add('without label', () => {
-    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
-
-    return (
-      <div>
-        <Form>
-          <CheckboxMultipleSelect
-            id="subject"
-            placeholder="Please select your subjects"
-            optionForValue={(option: SubjectOption) => option.label}
-            isOptionEnabled={(option) => option.value !== 'awesome'}
-            options={options}
-            value={value}
-            onChange={setValue}
-          />
-        </Form>
-      </div>
-    );
-  })
-  .add('with custom label', () => {
-    const [value, setValue] = useState<SubjectOption[] | undefined>([]);
-
-    return (
-      <div>
-        <Form>
-          <CheckboxMultipleSelect
-            id="subject"
-            label={
-              <div className="d-flex justify-content-between">
-                <span>Subject</span>
-                <Tooltip
-                  className="ml-1"
-                  content="Please select your most important subject"
-                >
-                  <Icon icon="info" />
-                </Tooltip>
-              </div>
-            }
-            placeholder="Please select your subjects"
-            optionForValue={(option: SubjectOption) => option.label}
-            isOptionEnabled={(option) => option.value !== 'awesome'}
-            options={options}
-            value={value}
-            onChange={setValue}
-          />
-        </Form>
-      </div>
-    );
-  })
   .add('jarb', () => {
     return (
       <FinalForm>
         <JarbCheckboxMultipleSelect
-          id="subject"
-          name="subject"
-          label="Subject"
-          placeholder="Please select your subjects"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
+          id="provinces"
+          name="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'Hero.name',
-            label: 'Subject'
+            validator: 'User.provinces',
+            label: 'Provinces'
           }}
         />
       </FinalForm>

--- a/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
+++ b/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
     className="text-muted"
   >
     <em>
-      Please select your subjects
+      Please select your provinces
     </em>
   </p>
   <FormGroup
@@ -121,6 +121,40 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
 </FormGroup>
 `;
 
+exports[`Component: CheckboxMultipleSelect ui loading: Component: CheckboxMultipleSelect => ui => loading 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="subject"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Subject
+  </Label>
+  <p
+    className="text-muted"
+  >
+    <em>
+      Please select your provinces
+    </em>
+  </p>
+  <Loading>
+    Loading...
+  </Loading>
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMultipleSelect => ui => with value 1`] = `
 <FormGroup
   className=""
@@ -145,7 +179,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
     className="text-muted"
   >
     <em>
-      Please select your subjects
+      Please select your provinces
     </em>
   </p>
   <Row
@@ -284,7 +318,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
     className="text-muted"
   >
     <em>
-      Please select your subjects
+      Please select your provinces
     </em>
   </p>
   <Row

--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -4,7 +4,7 @@ import { random } from 'lodash';
 import { Moment } from 'moment';
 
 import { JarbInput } from './Input/Input';
-import { FinalForm } from './story-utils';
+import { FinalForm, provinceFetcher, resolveAfter } from './story-utils';
 import {
   isStrongPassword,
   JarbCheckbox,
@@ -260,19 +260,16 @@ export function TotalForm() {
       />
 
       <JarbSelect
-        name="subject"
-        jarb={{ validator: 'User.subject', label: 'Subject' }}
-        id="subject"
-        label="Subject"
-        placeholder="Please enter your subject"
-        optionForValue={(value) => value.label}
-        isOptionEnabled={(option) => option.value !== 'awesome'}
-        options={[
-          { value: 'awesome', label: 'Awesome shit' },
-          { value: 'super', label: 'Super shit' },
-          { value: 'great', label: 'Great shit' },
-          { value: 'good', label: 'good shit' }
-        ]}
+        id="province"
+        name="province"
+        label="Province"
+        placeholder="Please select your province"
+        options={provinceFetcher}
+        labelForOption={(province) => province.label}
+        jarb={{
+          validator: 'User.province',
+          label: 'Province'
+        }}
         validators={requiredValidator}
       />
 
@@ -282,8 +279,8 @@ export function TotalForm() {
         id="nemesis"
         label="Worst enemy"
         placeholder="Select your nemesis"
-        optionForValue={userAsOption}
-        options={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
         validators={requiredValidator}
       />
 
@@ -293,8 +290,8 @@ export function TotalForm() {
         id="bestFriend"
         label="Best friend"
         placeholder="Select your best friend"
-        optionForValue={userAsOption}
-        options={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
         validators={requiredValidator}
       />
 
@@ -303,9 +300,9 @@ export function TotalForm() {
         jarb={{ validator: 'User.bestFriend', label: 'Best friend' }}
         id="bestFriend"
         label="Best friend"
-        optionForValue={userAsOption}
         placeholder="Please provide your best friend"
-        fetchOptions={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
       />
 
       <JarbModalPickerSingle
@@ -315,8 +312,8 @@ export function TotalForm() {
         label="Best friend"
         placeholder="Select your best friend"
         canSearch={true}
-        optionForValue={userAsOption}
-        fetchOptions={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
         validators={requiredValidator}
       />
 
@@ -325,9 +322,9 @@ export function TotalForm() {
         jarb={{ validator: 'User.friends', label: 'Friends' }}
         id="friends"
         label="Friends"
-        optionForValue={userAsOption}
         placeholder="Please provide all your friends"
-        fetchOptions={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
         validators={requiredValidator}
       />
 
@@ -337,8 +334,8 @@ export function TotalForm() {
         id="friends"
         label="Friends"
         placeholder="Please provide all your friends"
-        optionForValue={userAsOption}
-        fetchOptions={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
         canSearch={true}
         validators={requiredValidator}
       />
@@ -349,8 +346,8 @@ export function TotalForm() {
         id="friends"
         label="Friends"
         placeholder="Please provide all your friends"
-        optionForValue={userAsOption}
-        options={() => Promise.resolve(pageOfUsers())}
+        options={() => resolveAfter(pageOfUsers())}
+        labelForOption={userAsOption}
         canSearch={true}
         validators={requiredValidator}
       />

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
@@ -8,18 +8,18 @@ import { ButtonAlignment } from '../types';
 
 describe('Component: ModalPickerOpener', () => {
   function setup({
-    hasValues = false,
+    hasValue = false,
     withTooltip = false,
     alignButton
   }: {
-    hasValues?: boolean;
+    hasValue?: boolean;
     withTooltip?: boolean;
     alignButton?: ButtonAlignment;
   }) {
     const openModalSpy = jest.fn();
     const onClearSpy = jest.fn();
 
-    const values = hasValues ? adminUser().email : undefined;
+    const value = hasValue ? adminUser().email : undefined;
 
     jest
       .spyOn(useComponentOverflow, 'useComponentOverflow')
@@ -29,10 +29,10 @@ describe('Component: ModalPickerOpener', () => {
       <ModalPickerOpener
         openModal={openModalSpy}
         label="Best friend"
-        values={values}
+        value={value}
         onClear={onClearSpy}
         alignButton={alignButton}
-        displayValues={(value: string) =>
+        renderValue={(value: string) =>
           value ? <span>{value.toUpperCase()}</span> : null
         }
       />
@@ -50,7 +50,7 @@ describe('Component: ModalPickerOpener', () => {
     });
 
     test('with values', () => {
-      const { modalPickerOpener } = setup({ hasValues: true });
+      const { modalPickerOpener } = setup({ hasValue: true });
       expect(toJson(modalPickerOpener)).toMatchSnapshot(
         'Component: ModalPickerOpener => ui => with values'
       );
@@ -58,7 +58,7 @@ describe('Component: ModalPickerOpener', () => {
 
     test('tooltip', () => {
       const { modalPickerOpener } = setup({
-        hasValues: true,
+        hasValue: true,
         withTooltip: true
       });
 
@@ -76,7 +76,7 @@ describe('Component: ModalPickerOpener', () => {
 
     test('button aligned right with values', () => {
       const { modalPickerOpener } = setup({
-        hasValues: true,
+        hasValue: true,
         alignButton: 'right'
       });
       expect(toJson(modalPickerOpener)).toMatchSnapshot(
@@ -93,7 +93,7 @@ describe('Component: ModalPickerOpener', () => {
 
     test('button aligned left with values', () => {
       const { modalPickerOpener } = setup({
-        hasValues: true,
+        hasValue: true,
         alignButton: 'left'
       });
       expect(toJson(modalPickerOpener)).toMatchSnapshot(
@@ -117,7 +117,7 @@ describe('Component: ModalPickerOpener', () => {
     });
 
     it('should call onClear when the clear button is clicked', () => {
-      const { modalPickerOpener, onClearSpy } = setup({ hasValues: true });
+      const { modalPickerOpener, onClearSpy } = setup({ hasValue: true });
 
       // @ts-expect-error Test mock
       modalPickerOpener

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -4,8 +4,8 @@ import { ButtonAlignment } from '../types';
 import classNames from 'classnames';
 import { t } from '../../../utilities/translation/translation';
 import TextButton from '../../../core/TextButton/TextButton';
-import { DisplayValue } from '../single/ModalPickerSingle';
-import { DisplayValues } from '../multiple/ModalPickerMultiple';
+import { RenderValue } from '../single/ModalPickerSingle';
+import { RenderValues } from '../multiple/ModalPickerMultiple';
 
 type Text = {
   clear?: string;
@@ -41,13 +41,13 @@ type BaseProps = {
 };
 
 type ModalPickerSingleOpenerProps<T> = BaseProps & {
-  values?: T;
-  displayValues: DisplayValue<T>;
+  value?: T;
+  renderValue: RenderValue<T>;
 };
 
 type ModalPickerMultipleOpenerProps<T> = BaseProps & {
-  values?: T[];
-  displayValues: DisplayValues<T>;
+  value?: T[];
+  renderValue: RenderValues<T>;
 };
 
 type Props<T> =
@@ -58,33 +58,35 @@ export function ModalPickerOpener<T>(props: Props<T>) {
   const {
     openModal,
     label,
-    values,
-    displayValues,
     alignButton,
     onClear,
-    text = {}
+    text = {},
+    renderValue,
+    value
   } = props;
+
+  const hasValue = !!value;
 
   const wrapperClassName = classNames('d-flex', 'align-items-center', {
     'flex-row-reverse': alignButton === 'left',
-    'justify-content-between': alignButton === 'right' && values,
+    'justify-content-between': alignButton === 'right' && hasValue,
     'justify-content-end':
-      alignButton === 'left' || (alignButton === 'right' && !values)
+      alignButton === 'left' || (alignButton === 'right' && !hasValue)
   });
 
   const buttonClassName = classNames('flex-grow-0', 'flex-shrink-0', {
-    'mr-1': values && alignButton === 'left',
-    'ml-1': values && alignButton !== 'left'
+    'mr-1': hasValue && alignButton === 'left',
+    'ml-1': hasValue && alignButton !== 'left'
   });
 
   // @ts-expect-error Accept that DisplayValues is sometimes an array and sometimes not
-  const displayValue = displayValues(values);
+  const displayValue = renderValue(value);
 
   return (
     <div className={wrapperClassName}>
       {displayValue}
 
-      {values && onClear ? (
+      {hasValue && onClear ? (
         <TextButton onClick={onClear} className="mx-3">
           {t({
             overrideText: text.clear,

--- a/src/form/ModalPicker/ModalPickerValueTruncator/ModalPickerValueTruncator.test.tsx
+++ b/src/form/ModalPicker/ModalPickerValueTruncator/ModalPickerValueTruncator.test.tsx
@@ -13,9 +13,9 @@ describe('Component: ModalPickerValueTruncator', () => {
     hasSingleValue?: boolean;
     hasMultipleValues?: boolean;
   }) {
-    const optionForValueSpy = jest.fn(user => user.email);
+    const labelForOptionSpy = jest.fn((user) => user.email);
 
-    const values = hasSingleValue
+    const value = hasSingleValue
       ? userUser()
       : hasMultipleValues
       ? [adminUser(), userUser()]
@@ -23,12 +23,12 @@ describe('Component: ModalPickerValueTruncator', () => {
 
     const modalPickerValueTruncator = shallow(
       <ModalPickerValueTruncator
-        values={values}
-        optionForValue={optionForValueSpy}
+        value={value}
+        labelForOption={labelForOptionSpy}
       />
     );
 
-    return { modalPickerValueTruncator, optionForValueSpy };
+    return { modalPickerValueTruncator, labelForOptionSpy };
   }
 
   describe('ui', () => {

--- a/src/form/ModalPicker/ModalPickerValueTruncator/ModalPickerValueTruncator.tsx
+++ b/src/form/ModalPicker/ModalPickerValueTruncator/ModalPickerValueTruncator.tsx
@@ -1,28 +1,28 @@
 import React, { useRef } from 'react';
 import Tooltip from '../../../core/Tooltip/Tooltip';
-import { OptionForValue } from '../../option';
+import { LabelForOption } from '../../option';
 import { useComponentOverflow } from './useComponentOverflow/useComponentOverflow';
 
 export type Props<T> = {
-  values: T | T[];
-  optionForValue: OptionForValue<T>;
+  value: T | T[];
+  labelForOption: LabelForOption<T>;
 };
 
 export function ModalPickerValueTruncator<T>({
-  values,
-  optionForValue
+  value,
+  labelForOption
 }: Props<T>) {
   const ref = useRef<HTMLElement>(null);
-  const isOverflowing = useComponentOverflow(ref, values);
+  const isOverflowing = useComponentOverflow(ref, value);
 
-  if (!values) {
+  if (!value) {
     return null;
   }
 
-  const text = Array.isArray(values) ? (
-    <>{values.map(optionForValue).join(', ')}</>
+  const text = Array.isArray(value) ? (
+    <>{value.map(labelForOption).join(', ')}</>
   ) : (
-    optionForValue(values)
+    labelForOption(value)
   );
 
   return (

--- a/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
+++ b/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
@@ -66,16 +66,96 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
         }
       >
         <SearchInput
+          debounce={0}
           defaultValue=""
-          onChange={[Function]}
+          onChange={[MockFunction]}
           placeholder="Search..."
         />
       </Col>
     </Row>
-    <h1>
-      Children
-    </h1>
+    <Row
+      className="mt-3"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <h1>
+          Children
+        </h1>
+      </Col>
+    </Row>
   </ModalBody>
+  <ModalFooter
+    className="d-flex justify-content-center"
+    tag="div"
+  >
+    <Pagination
+      onChange={[Function]}
+      page={
+        Object {
+          "content": Array [
+            Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+            Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+            Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          ],
+          "first": false,
+          "last": false,
+          "number": 2,
+          "numberOfElements": 3,
+          "size": 3,
+          "totalElements": 9,
+          "totalPages": 3,
+        }
+      }
+    />
+  </ModalFooter>
   <ModalFooter
     className="d-flex flex-row justify-content-between"
     tag="div"
@@ -151,10 +231,89 @@ exports[`Component: ModalPicker ui without addButton and search: Component: Moda
   <ModalBody
     tag="div"
   >
-    <h1>
-      Children
-    </h1>
+    <Row
+      className="mt-3"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <h1>
+          Children
+        </h1>
+      </Col>
+    </Row>
   </ModalBody>
+  <ModalFooter
+    className="d-flex justify-content-center"
+    tag="div"
+  >
+    <Pagination
+      onChange={[Function]}
+      page={
+        Object {
+          "content": Array [
+            Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+            Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+            Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          ],
+          "first": false,
+          "last": false,
+          "number": 2,
+          "numberOfElements": 3,
+          "size": 3,
+          "totalElements": 9,
+          "totalPages": 3,
+        }
+      }
+    />
+  </ModalFooter>
   <ModalFooter
     className="d-flex flex-row justify-content-between"
     tag="div"

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -1,39 +1,255 @@
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { pageWithContentAndExactSize } from '../../../test/utils';
-import { adminUser, userUser } from '../../../test/fixtures';
+import {
+  adminUser,
+  coordinatorUser,
+  pageOfUsers,
+  userUser
+} from '../../../test/fixtures';
 import { User } from '../../../test/types';
 
 import ModalPickerMultiple, {
   JarbModalPickerMultiple
 } from './ModalPickerMultiple';
 
-import { FinalForm, Form } from '../../story-utils';
-import { Icon, Tooltip } from '../../..';
+import {
+  FinalForm,
+  Form,
+  IsOptionEqualInfo,
+  KeyForOptionInfo,
+  nonExistingProvince,
+  Province,
+  provinceFetcher,
+  provinces,
+  ReloadOptionsInfo,
+  resolveAfter
+} from '../../story-utils';
+import { Icon, Toggle, Tooltip } from '../../..';
 import { ListGroup, ListGroupItem } from 'reactstrap';
 import Avatar from '../../../core/Avatar/Avatar';
+import classNames from 'classnames';
 
 storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
-  .add('default', () => {
-    const [value, setValue] = useState<User[] | undefined>([]);
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
 
     return (
       <Form>
-        <ModalPickerMultiple<User>
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
           value={value}
           onChange={setValue}
         />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
+  .add('async options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      provinces()[0]
+    ]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <IsOptionEqualInfo />
+      </Form>
+    );
+  })
+  .add('custom keyForOption', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      provinces()[0]
+    ]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          keyForOption={(province) => province.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <KeyForOptionInfo />
+      </Form>
+    );
+  })
+  .add('using reloadOptions', () => {
+    const [limitToNorthern, setLimitToNorthern] = useState(false);
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <p>
+          Limit to northern provinces
+          <Toggle
+            className="ml-2"
+            color="primary"
+            value={limitToNorthern}
+            onChange={() => setLimitToNorthern(!limitToNorthern)}
+          />
+        </p>
+
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces().filter((option) =>
+            limitToNorthern ? option.north : true
+          )}
+          labelForOption={(option) => option.label}
+          value={value}
+          onChange={setValue}
+          reloadOptions={limitToNorthern}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(',')}
+          </p>
+        ) : null}
+
+        <ReloadOptionsInfo />
+      </Form>
+    );
+  })
+  .add('using reloadOptions', () => {
+    const [limitToNorthern, setLimitToNorthern] = useState(false);
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <p>
+          Limit to northern provinces
+          <Toggle
+            className="ml-2"
+            color="primary"
+            value={limitToNorthern}
+            onChange={() => setLimitToNorthern(!limitToNorthern)}
+          />
+        </p>
+
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces().filter((option) =>
+            limitToNorthern ? option.north : true
+          )}
+          labelForOption={(option) => option.label}
+          value={value}
+          onChange={setValue}
+          reloadOptions={limitToNorthern}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(',')}
+          </p>
+        ) : null}
+
+        <ReloadOptionsInfo />
       </Form>
     );
   })
@@ -47,8 +263,8 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
+          labelForOption={(user: User) => user.email}
+          options={() =>
             Promise.resolve(pageWithContentAndExactSize([userUser()]))
           }
           addButton={{
@@ -71,55 +287,19 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
     );
   })
   .add('without search', () => {
-    const [value, setValue] = useState<User[] | undefined>([]);
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
 
     return (
       <Form>
-        <ModalPickerMultiple<User>
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
           canSearch={false}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser()]))
-          }
-          addButton={{
-            label: 'Create friend',
-            onClick: () => {
-              // Just a fake implementation of how this could work.
-              // In real life you probably want to pop a modal window
-              // to create the friend.
-              return new Promise((resolve) => {
-                setTimeout(() => {
-                  resolve(adminUser());
-                }, 1000);
-              });
-            }
-          }}
-          value={value}
-          onChange={setValue}
-        />
-      </Form>
-    );
-  })
-  .add('custom isOptionEqual', () => {
-    const [value, setValue] = useState<User[] | undefined>([userUser()]);
-
-    return (
-      <Form>
-        <ModalPickerMultiple<User>
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
-          isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={value}
           onChange={setValue}
         />
@@ -136,20 +316,19 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          isOptionEqual={(a, b) => a.id === b.id}
-          optionForValue={(user: User) => user.email}
+          options={[userUser(), adminUser(), coordinatorUser()]}
+          labelForOption={(user: User) => user.email}
+          isOptionEnabled={(user) => user.email !== 'admin@42.nl'}
           renderOptions={(options) => (
             <ListGroup>
-              {options.map(({ option, isSelected, toggle }) => (
+              {options.map(({ option, isSelected, toggle, enabled }) => (
                 <ListGroupItem
                   key={option.email}
                   onClick={toggle}
-                  className="d-flex justify-content-between align-items-center clickable"
+                  className={classNames(
+                    'd-flex justify-content-between align-items-center',
+                    { clickable: enabled, 'bg-light': !enabled }
+                  )}
                 >
                   <span>
                     <Avatar
@@ -169,55 +348,38 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
       </Form>
     );
   })
-  .add('without label', () => {
+  .add('custom renderValue', () => {
     const [value, setValue] = useState<User[] | undefined>([]);
 
     return (
       <Form>
         <ModalPickerMultiple<User>
           id="bestFriend"
+          label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
+          options={[userUser(), adminUser(), coordinatorUser()]}
+          labelForOption={(user: User) => user.email}
           value={value}
-          onChange={setValue}
-        />
-      </Form>
-    );
-  })
-  .add('with custom label', () => {
-    const [value, setValue] = useState<User[] | undefined>([]);
-
-    return (
-      <Form>
-        <ModalPickerMultiple<User>
-          id="bestFriend"
-          label={
-            <div className="d-flex justify-content-between">
-              <span>Best friend</span>
-              <Tooltip
-                className="ml-1"
-                content="Your best friend is the one you trust the most"
-              >
-                <Icon icon="info" />
-              </Tooltip>
-            </div>
-          }
-          placeholder="Select your best friend"
-          canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
-          value={value}
-          onChange={setValue}
+          onChange={(value) => setValue(value)}
+          renderValue={(users) => {
+            return users ? (
+              <>
+                {users.map((user, index) => (
+                  <Fragment key={user.id}>
+                    {index > 0 ? ', ' : ''}
+                    {user.roles.some((role) => role === 'ADMIN') ? (
+                      <Icon icon="supervised_user_circle" />
+                    ) : (
+                      <Icon icon="supervisor_account" />
+                    )}
+                    {user.firstName}
+                    <b>{user.lastName}</b>
+                  </Fragment>
+                ))}
+              </>
+            ) : null;
+          }}
         />
       </Form>
     );
@@ -232,12 +394,8 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
           label="Default"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
+          options={() => resolveAfter(pageOfUsers())}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -246,12 +404,8 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
           label="Button on the left"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
+          options={() => resolveAfter(pageOfUsers())}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
           alignButton="left"
@@ -261,12 +415,8 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
           label="Button on the right"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
+          options={() => resolveAfter(pageOfUsers())}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
           alignButton="right"
@@ -274,43 +424,61 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
       </Form>
     );
   })
-  .add('display values', () => {
-    const [value, setValue] = useState<User[] | undefined>([]);
+  .add('labels', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
 
     return (
       <Form>
-        <ModalPickerMultiple<User>
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          optionForValue={(user: User) => user.email}
+        <h3>Without label</h3>
+
+        <ModalPickerMultiple
+          id="provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
           value={value}
           onChange={setValue}
-          displayValues={(users) => {
-            return users ? (
-              <>
-                {users.map((user, index) => (
-                  <>
-                    {index > 0 ? ', ' : ''}
-                    {user.roles.some((role) => role === 'ADMIN') ? (
-                      <Icon icon="supervised_user_circle" />
-                    ) : (
-                      <Icon icon="supervisor_account" />
-                    )}
-                    {user.firstName}
-                    <b>{user.lastName}</b>
-                  </>
-                ))}
-              </>
-            ) : null;
-          }}
         />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <ModalPickerMultiple
+          id="provinces"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>Friends</span>
+              <Tooltip
+                className="ml-1"
+                content="It is nice to have lots of friends"
+              >
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
       </Form>
     );
   })
@@ -318,20 +486,15 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
     return (
       <FinalForm>
         <JarbModalPickerMultiple
-          id="bestFriend"
-          name="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
+          id="provinces"
+          name="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'Hero.name',
-            label: 'Best friend'
+            validator: 'User.provinces',
+            label: 'Provinces'
           }}
         />
       </FinalForm>

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -1,5 +1,208 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: ModalPickerMultiple ui renderValue should be able to use custom function to render values: Component: ModalPickerMultiple => ui => should be able to use custom function to render values 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best Friend
+  </Label>
+  <ModalPickerOpener
+    label="Select your best friend"
+    onClear={[Function]}
+    openModal={[Function]}
+    renderValue={[Function]}
+    value={
+      Array [
+        Object {
+          "active": true,
+          "email": "admin@42.nl",
+          "firstName": "Addie",
+          "id": 42,
+          "lastName": "Admin",
+          "roles": Array [
+            "ADMIN",
+          ],
+        },
+      ]
+    }
+  />
+  Some error
+  <ModalPicker
+    canSearch={true}
+    canSearchSync={true}
+    closeModal={[Function]}
+    isOpen={false}
+    loading={false}
+    modalSaved={[Function]}
+    page={
+      Object {
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
+        "first": true,
+        "last": true,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
+      }
+    }
+    pageChanged={[Function]}
+    placeholder="Select your best friend"
+    query=""
+    queryChanged={[Function]}
+    selected={Array []}
+    userHasSearched={false}
+  >
+    <FormGroup
+      check={true}
+      key="42"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
+  </ModalPicker>
+</FormGroup>
+`;
+
+exports[`Component: ModalPickerMultiple ui renderValue should use the default ModalPickerValueTruncator to render values: Component: ModalPickerMultiple => ui => should use the default ModalPickerValueTruncator to render values 1`] = `
+<ModalPickerValueTruncator
+  labelForOption={[Function]}
+  value={
+    Object {
+      "active": true,
+      "email": "admin@42.nl",
+      "firstName": "Addie",
+      "id": 42,
+      "lastName": "Admin",
+      "roles": Array [
+        "ADMIN",
+      ],
+    }
+  }
+/>
+`;
+
 exports[`Component: ModalPickerMultiple ui should render button left: Component: ModalPickerMultiple => ui => should render button left 1`] = `
 <FormGroup
   className=""
@@ -23,18 +226,18 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
   </Label>
   <ModalPickerOpener
     alignButton="left"
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Array [
         Object {
           "active": true,
           "email": "admin@42.nl",
-          "firstName": "admin",
+          "firstName": "Addie",
           "id": 42,
-          "lastName": "user",
+          "lastName": "Admin",
           "roles": Array [
             "ADMIN",
           ],
@@ -45,42 +248,70 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={true}
+    queryChanged={[Function]}
+    selected={Array []}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -91,11 +322,69 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -123,18 +412,18 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
   </Label>
   <ModalPickerOpener
     alignButton="right"
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Array [
         Object {
           "active": true,
           "email": "admin@42.nl",
-          "firstName": "admin",
+          "firstName": "Addie",
           "id": 42,
-          "lastName": "user",
+          "lastName": "Admin",
           "roles": Array [
             "ADMIN",
           ],
@@ -145,42 +434,70 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={true}
+    queryChanged={[Function]}
+    selected={Array []}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -191,11 +508,69 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -223,50 +598,78 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
   </Label>
   <ModalPickerOpener
     alignButton="right"
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
+    renderValue={[Function]}
   />
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={true}
+    queryChanged={[Function]}
+    selected={Array []}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -277,11 +680,69 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -293,18 +754,18 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
   tag="div"
 >
   <ModalPickerOpener
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Array [
         Object {
           "active": true,
           "email": "admin@42.nl",
-          "firstName": "admin",
+          "firstName": "Addie",
           "id": 42,
-          "lastName": "user",
+          "lastName": "Admin",
           "roles": Array [
             "ADMIN",
           ],
@@ -312,9 +773,9 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
         Object {
           "active": false,
           "email": "user@42.nl",
-          "firstName": "test",
+          "firstName": "Ulysses",
           "id": 1337,
-          "lastName": "user",
+          "lastName": "User",
           "roles": Array [
             "USER",
           ],
@@ -325,29 +786,289 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={true}
+    queryChanged={[Function]}
+    selected={Array []}
+    userHasSearched={false}
+  >
+    <FormGroup
+      check={true}
+      key="42"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
+  </ModalPicker>
+</FormGroup>
+`;
+
+exports[`Component: ModalPickerMultiple ui should render the options with the correct checked state: Component: ModalPickerMultiple => ui => should render the options with the correct checked state 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best Friend
+  </Label>
+  <ModalPickerOpener
+    label="Select your best friend"
+    onClear={[Function]}
+    openModal={[Function]}
+    renderValue={[Function]}
+    value={
+      Array [
+        Object {
+          "active": true,
+          "email": "admin@42.nl",
+          "firstName": "Addie",
+          "id": 42,
+          "lastName": "Admin",
+          "roles": Array [
+            "ADMIN",
+          ],
+        },
+        Object {
+          "active": false,
+          "email": "coordinator@42.nl",
+          "firstName": "Cordelia",
+          "id": 777,
+          "lastName": "Coordinator",
+          "roles": Array [
+            "ADMIN",
+            "USER",
+          ],
+        },
+      ]
+    }
+  />
+  Some error
+  <ModalPicker
+    canSearch={true}
+    canSearchSync={true}
+    closeModal={[Function]}
+    isOpen={true}
+    loading={false}
+    modalSaved={[Function]}
+    page={
+      Object {
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
+        "first": true,
+        "last": true,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
+      }
+    }
+    pageChanged={[Function]}
+    placeholder="Select your best friend"
+    query=""
+    queryChanged={[Function]}
+    selected={
+      Array [
+        Object {
+          "active": true,
+          "email": "admin@42.nl",
+          "firstName": "Addie",
+          "id": 42,
+          "lastName": "Admin",
+          "roles": Array [
+            "ADMIN",
+          ],
+        },
+        Object {
+          "active": false,
+          "email": "coordinator@42.nl",
+          "firstName": "Cordelia",
+          "id": 777,
+          "lastName": "Coordinator",
+          "roles": Array [
+            "ADMIN",
+            "USER",
+          ],
+        },
+      ]
+    }
+    userHasSearched={false}
   >
     <Row
-      className="mt-3"
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
       tag="div"
       widths={
         Array [
@@ -371,11 +1092,99 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Tag
+          key="admin@42.nl"
+          onRemove={[Function]}
+          text="admin@42.nl"
+        />
+        <Tag
+          key="coordinator@42.nl"
+          onRemove={[Function]}
+          text="coordinator@42.nl"
         />
       </Col>
     </Row>
+    <FormGroup
+      check={true}
+      key="42"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={true}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={true}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -402,18 +1211,18 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
     Best Friend
   </Label>
   <ModalPickerOpener
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Array [
         Object {
           "active": true,
           "email": "admin@42.nl",
-          "firstName": "admin",
+          "firstName": "Addie",
           "id": 42,
-          "lastName": "user",
+          "lastName": "Admin",
           "roles": Array [
             "ADMIN",
           ],
@@ -421,9 +1230,9 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
         Object {
           "active": false,
           "email": "user@42.nl",
-          "firstName": "test",
+          "firstName": "Ulysses",
           "id": 1337,
-          "lastName": "user",
+          "lastName": "User",
           "roles": Array [
             "USER",
           ],
@@ -434,42 +1243,70 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={true}
+    queryChanged={[Function]}
+    selected={Array []}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -480,95 +1317,23 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
         />
-      </Col>
-    </Row>
-  </ModalPicker>
-</FormGroup>
-`;
-
-exports[`Component: ModalPickerMultiple ui should use custom display function to render values: Component: ModalPickerMultiple => ui => should use custom display function to render values 1`] = `
-<FormGroup
-  className=""
-  color="success"
-  tag="div"
->
-  <Label
-    for="bestFriend"
-    tag="label"
-    widths={
-      Array [
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl",
-      ]
-    }
-  >
-    Best Friend
-  </Label>
-  <ModalPickerOpener
-    displayValues={[Function]}
-    label="Select your best friend"
-    onClear={[Function]}
-    openModal={[Function]}
-    values={
-      Array [
-        Object {
-          "active": true,
-          "email": "admin@42.nl",
-          "firstName": "admin",
-          "id": 42,
-          "lastName": "user",
-          "roles": Array [
-            "ADMIN",
-          ],
-        },
-      ]
-    }
-  />
-  Some error
-  <ModalPicker
-    canSearch={true}
-    closeModal={[Function]}
-    fetchOptions={[Function]}
-    isOpen={false}
-    modalSaved={[Function]}
-    page={
-      Object {
-        "content": Array [],
-        "first": true,
-        "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
-      }
-    }
-    pageChanged={[Function]}
-    placeholder="Select your best friend"
-    query=""
-    saveButtonEnabled={true}
-  >
-    <Row
-      className="mt-3"
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -579,11 +1344,42 @@ exports[`Component: ModalPickerMultiple ui should use custom display function to
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
         />
-      </Col>
-    </Row>
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="checkbox"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -2,34 +2,171 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import ModalPickerSingle, { JarbModalPickerSingle } from './ModalPickerSingle';
-import { FinalForm, Form } from '../../story-utils';
+import {
+  FinalForm,
+  Form,
+  IsOptionEqualInfo,
+  KeyForOptionInfo,
+  Province,
+  provinceFetcher,
+  provinces,
+  ReloadOptionsInfo,
+  resolveAfter
+} from '../../story-utils';
 import { pageWithContentAndExactSize } from '../../../test/utils';
-import { adminUser, userUser } from '../../../test/fixtures';
+import { adminUser, coordinatorUser, userUser } from '../../../test/fixtures';
 import { User } from '../../../test/types';
-import { Icon, Tooltip } from '../../..';
+import { Icon, pageOf, Tooltip } from '../../..';
 import Avatar from '../../../core/Avatar/Avatar';
 import { ListGroup, ListGroupItem } from 'reactstrap';
+import classNames from 'classnames';
 
 storiesOf('Form/ModalPicker/ModalPickerSingle', module)
-  .add('basic', () => {
-    const [value, setValue] = useState<User | undefined>(undefined);
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province | undefined>(undefined);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('async options', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province | undefined>(undefined);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <IsOptionEqualInfo />
+      </Form>
+    );
+  })
+  .add('custom keyForOption', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          keyForOption={(province) => province.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <KeyForOptionInfo />
+      </Form>
+    );
+  })
+  .add('using reloadOptions', () => {
+    const [brand, setBrand] = useState<string>();
+    const [model, setModel] = useState<string>();
+
+    const allOptions = {
+      Audi: ['A1', 'A2', 'A3', 'M5'],
+      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
+      Mercedes: ['Viano', 'Vito', 'Sprinter']
+    };
 
     return (
       <Form>
         <ModalPickerSingle
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          value={value}
-          onChange={setValue}
+          id="brand"
+          label="Brand"
+          placeholder="Please select your brand"
+          options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
+          labelForOption={(option) => option}
+          value={brand}
+          onChange={(value) => {
+            setBrand(value);
+            setModel(undefined);
+          }}
         />
+        <ModalPickerSingle
+          id="model"
+          label="Model"
+          placeholder={
+            brand ? 'Please select your model' : 'Please select a brand first'
+          }
+          options={() =>
+            resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
+          }
+          labelForOption={(option: string) => option}
+          value={model}
+          onChange={setModel}
+          reloadOptions={brand}
+        />
+
+        {brand ? <p>Your chosen brand is: {brand}</p> : null}
+        {model ? <p>Your chosen model is: {model}</p> : null}
+
+        <ReloadOptionsInfo />
       </Form>
     );
   })
@@ -43,8 +180,8 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
+          labelForOption={(user: User) => user.email}
+          options={() =>
             Promise.resolve(pageWithContentAndExactSize([userUser()]))
           }
           addButton={{
@@ -53,7 +190,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
               // Just a fake implementation of how this could work.
               // In real life you probably want to pop a modal window
               // to create the friend.
-              return new Promise(resolve => {
+              return new Promise((resolve) => {
                 setTimeout(() => {
                   resolve(adminUser());
                 }, 1000);
@@ -67,7 +204,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
     );
   })
   .add('without search', () => {
-    const [value, setValue] = useState<User | undefined | null>(undefined);
+    const [value, setValue] = useState<User | undefined>(undefined);
 
     return (
       <Form>
@@ -76,32 +213,9 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={false}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser]))
-          }
-          value={value}
-          onChange={setValue}
-        />
-      </Form>
-    );
-  })
-  .add('custom optionIsEqual', () => {
-    const [value, setValue] = useState<User | undefined>(userUser);
-
-    return (
-      <Form>
-        <ModalPickerSingle
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          optionForValue={(user: User) => user.email}
-          isOptionEqual={(a: User, b: User) => a.id === b.id}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
+          labelForOption={(user: User) => user.email}
+          options={() =>
+            Promise.resolve(pageWithContentAndExactSize([userUser()]))
           }
           value={value}
           onChange={setValue}
@@ -119,14 +233,18 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          renderOptions={options => (
+          options={[userUser(), adminUser(), coordinatorUser()]}
+          labelForOption={(user: User) => user.email}
+          renderOptions={(options) => (
             <ListGroup>
-              {options.map(({ option, isSelected, toggle }) => (
+              {options.map(({ option, isSelected, toggle, enabled }) => (
                 <ListGroupItem
                   key={option.email}
                   onClick={toggle}
-                  className="d-flex justify-content-between align-items-center clickable"
+                  className={classNames(
+                    'd-flex justify-content-between align-items-center',
+                    { clickable: enabled, 'bg-light': !enabled }
+                  )}
                 >
                   <span>
                     <Avatar
@@ -140,64 +258,39 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
               ))}
             </ListGroup>
           )}
-          isOptionEqual={(a: User, b: User) => a.id === b.id}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
           value={value}
           onChange={setValue}
         />
       </Form>
     );
   })
-  .add('without label', () => {
+  .add('custom renderValue', () => {
     const [value, setValue] = useState<User | undefined>(undefined);
 
     return (
       <Form>
         <ModalPickerSingle
           id="bestFriend"
+          label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
+          options={[userUser(), adminUser(), coordinatorUser()]}
+          labelForOption={(user) => user.email}
           value={value}
-          onChange={setValue}
-        />
-      </Form>
-    );
-  })
-  .add('with custom label', () => {
-    const [value, setValue] = useState<User | undefined>(undefined);
-
-    return (
-      <Form>
-        <ModalPickerSingle
-          id="bestFriend"
-          label={
-            <div className="d-flex justify-content-between">
-              <span>Best friend</span>
-              <Tooltip className="ml-1" content="BFF for life!">
-                <Icon icon="info" />
-              </Tooltip>
-            </div>
-          }
-          placeholder="Select your best friend"
-          canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          value={value}
-          onChange={setValue}
+          onChange={(user) => setValue(user)}
+          renderValue={(user) => {
+            return user ? (
+              <>
+                {user.roles.some((role) => role === 'ADMIN') ? (
+                  <Icon icon="supervised_user_circle" />
+                ) : (
+                  <Icon icon="supervisor_account" />
+                )}
+                {user.firstName}
+                <b>{user.lastName}</b>
+              </>
+            ) : null;
+          }}
         />
       </Form>
     );
@@ -212,8 +305,8 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label="Default"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
+          labelForOption={(user: User) => user.email}
+          options={() =>
             Promise.resolve(
               pageWithContentAndExactSize([userUser(), adminUser()])
             )
@@ -227,8 +320,8 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label="Button on the left"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
+          labelForOption={(user: User) => user.email}
+          options={() =>
             Promise.resolve(
               pageWithContentAndExactSize([userUser(), adminUser()])
             )
@@ -242,8 +335,8 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label="Button on the right"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
+          labelForOption={(user: User) => user.email}
+          options={() =>
             Promise.resolve(
               pageWithContentAndExactSize([userUser(), adminUser()])
             )
@@ -255,38 +348,45 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
       </Form>
     );
   })
-  .add('display values', () => {
-    const [value, setValue] = useState<User | undefined>(undefined);
+  .add('label & placeholder', () => {
+    const [value, setValue] = useState<Province | undefined>(undefined);
 
     return (
       <Form>
-        <ModalPickerSingle
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={true}
-          optionForValue={user => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
+        <h3>Without label</h3>
+
+        <ModalPickerSingle<Province>
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
           value={value}
-          onChange={user => setValue(user)}
-          displayValues={user => {
-            return user ? (
-              <>
-                {user.roles.some(role => role === 'ADMIN') ? (
-                  <Icon icon="supervised_user_circle" />
-                ) : (
-                  <Icon icon="supervisor_account" />
-                )}
-                {user.firstName}
-                <b>{user.lastName}</b>
-              </>
-            ) : null;
-          }}
+          onChange={setValue}
         />
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <ModalPickerSingle<Province>
+          id="provinces"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>Subject</span>
+              <Tooltip className="ml-1" content="The province you live in">
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
@@ -294,18 +394,15 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
     return (
       <FinalForm>
         <JarbModalPickerSingle
-          id="bestFriend"
-          name="bestFriend"
-          label="Best friend"
-          placeholder="Select your best friend"
-          canSearch={false}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(pageWithContentAndExactSize([userUser]))
-          }
+          id="province"
+          name="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'Hero.name',
-            label: 'Best friend'
+            validator: 'User.province',
+            label: 'Province'
           }}
         />
       </FinalForm>

--- a/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
+++ b/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
@@ -1,5 +1,205 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: ModalPickerSingle ui renderValue should be able to use custom function to render values: Component: ModalPickerSingle => ui => should be able to use custom function to render values 1`] = `
+<FormGroup
+  className=""
+  color="success"
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best Friend
+  </Label>
+  <ModalPickerOpener
+    label="Select your best friend"
+    onClear={[Function]}
+    openModal={[Function]}
+    renderValue={[Function]}
+    value={
+      Object {
+        "active": true,
+        "email": "admin@42.nl",
+        "firstName": "Addie",
+        "id": 42,
+        "lastName": "Admin",
+        "roles": Array [
+          "ADMIN",
+        ],
+      }
+    }
+  />
+  Some error
+  <ModalPicker
+    canSearch={true}
+    canSearchSync={true}
+    closeModal={[Function]}
+    isOpen={false}
+    loading={false}
+    modalSaved={[Function]}
+    page={
+      Object {
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
+        "first": true,
+        "last": true,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
+      }
+    }
+    pageChanged={[Function]}
+    placeholder="Select your best friend"
+    query=""
+    queryChanged={[Function]}
+    userHasSearched={false}
+  >
+    <FormGroup
+      check={true}
+      key="42"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
+  </ModalPicker>
+</FormGroup>
+`;
+
+exports[`Component: ModalPickerSingle ui renderValue should use the default ModalPickerValueTruncator to render values: Component: ModalPickerSingle => ui => should use the default ModalPickerValueTruncator to render values 1`] = `
+<ModalPickerValueTruncator
+  labelForOption={[Function]}
+  value={
+    Object {
+      "active": true,
+      "email": "admin@42.nl",
+      "firstName": "Addie",
+      "id": 42,
+      "lastName": "Admin",
+      "roles": Array [
+        "ADMIN",
+      ],
+    }
+  }
+/>
+`;
+
 exports[`Component: ModalPickerSingle ui should render button left: Component: ModalPickerSingle => ui => should render button left 1`] = `
 <FormGroup
   className=""
@@ -23,17 +223,17 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
   </Label>
   <ModalPickerOpener
     alignButton="left"
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Object {
         "active": true,
         "email": "admin@42.nl",
-        "firstName": "admin",
+        "firstName": "Addie",
         "id": 42,
-        "lastName": "user",
+        "lastName": "Admin",
         "roles": Array [
           "ADMIN",
         ],
@@ -43,42 +243,69 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={false}
+    queryChanged={[Function]}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -89,11 +316,69 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -121,17 +406,17 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
   </Label>
   <ModalPickerOpener
     alignButton="right"
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Object {
         "active": true,
         "email": "admin@42.nl",
-        "firstName": "admin",
+        "firstName": "Addie",
         "id": 42,
-        "lastName": "user",
+        "lastName": "Admin",
         "roles": Array [
           "ADMIN",
         ],
@@ -141,42 +426,69 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={false}
+    queryChanged={[Function]}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -187,11 +499,69 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -219,50 +589,77 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
   </Label>
   <ModalPickerOpener
     alignButton="right"
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
+    renderValue={[Function]}
   />
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={false}
+    queryChanged={[Function]}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -273,11 +670,69 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -289,17 +744,17 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
   tag="div"
 >
   <ModalPickerOpener
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Object {
         "active": true,
         "email": "admin@42.nl",
-        "firstName": "admin",
+        "firstName": "Addie",
         "id": 42,
-        "lastName": "user",
+        "lastName": "Admin",
         "roles": Array [
           "ADMIN",
         ],
@@ -309,42 +764,69 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={false}
+    queryChanged={[Function]}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -355,11 +837,69 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
         />
-      </Col>
-    </Row>
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;
@@ -386,17 +926,17 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
     Best Friend
   </Label>
   <ModalPickerOpener
-    displayValues={[Function]}
     label="Select your best friend"
     onClear={[Function]}
     openModal={[Function]}
-    values={
+    renderValue={[Function]}
+    value={
       Object {
         "active": true,
         "email": "admin@42.nl",
-        "firstName": "admin",
+        "firstName": "Addie",
         "id": 42,
-        "lastName": "user",
+        "lastName": "Admin",
         "roles": Array [
           "ADMIN",
         ],
@@ -406,42 +946,69 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
   Some error
   <ModalPicker
     canSearch={true}
+    canSearchSync={true}
     closeModal={[Function]}
-    fetchOptions={[Function]}
     isOpen={false}
+    loading={false}
     modalSaved={[Function]}
     page={
       Object {
-        "content": Array [],
+        "content": Array [
+          Object {
+            "active": true,
+            "email": "admin@42.nl",
+            "firstName": "Addie",
+            "id": 42,
+            "lastName": "Admin",
+            "roles": Array [
+              "ADMIN",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "coordinator@42.nl",
+            "firstName": "Cordelia",
+            "id": 777,
+            "lastName": "Coordinator",
+            "roles": Array [
+              "ADMIN",
+              "USER",
+            ],
+          },
+          Object {
+            "active": false,
+            "email": "user@42.nl",
+            "firstName": "Ulysses",
+            "id": 1337,
+            "lastName": "User",
+            "roles": Array [
+              "USER",
+            ],
+          },
+        ],
         "first": true,
         "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
+        "number": 1,
+        "numberOfElements": 3,
+        "size": 3,
+        "totalElements": 3,
+        "totalPages": 1,
       }
     }
     pageChanged={[Function]}
     placeholder="Select your best friend"
     query=""
-    saveButtonEnabled={false}
+    queryChanged={[Function]}
+    userHasSearched={false}
   >
-    <Row
-      className="mt-3"
+    <FormGroup
+      check={true}
+      key="42"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -452,93 +1019,23 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
         />
-      </Col>
-    </Row>
-  </ModalPicker>
-</FormGroup>
-`;
-
-exports[`Component: ModalPickerSingle ui should use custom display function to render values: Component: ModalPickerSingle => ui => should use custom display function to render values 1`] = `
-<FormGroup
-  className=""
-  color="success"
-  tag="div"
->
-  <Label
-    for="bestFriend"
-    tag="label"
-    widths={
-      Array [
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl",
-      ]
-    }
-  >
-    Best Friend
-  </Label>
-  <ModalPickerOpener
-    displayValues={[Function]}
-    label="Select your best friend"
-    onClear={[Function]}
-    openModal={[Function]}
-    values={
-      Object {
-        "active": true,
-        "email": "admin@42.nl",
-        "firstName": "admin",
-        "id": 42,
-        "lastName": "user",
-        "roles": Array [
-          "ADMIN",
-        ],
-      }
-    }
-  />
-  Some error
-  <ModalPicker
-    canSearch={true}
-    closeModal={[Function]}
-    fetchOptions={[Function]}
-    isOpen={false}
-    modalSaved={[Function]}
-    page={
-      Object {
-        "content": Array [],
-        "first": true,
-        "last": true,
-        "number": 0,
-        "numberOfElements": 0,
-        "size": 0,
-        "totalElements": 0,
-        "totalPages": 0,
-      }
-    }
-    pageChanged={[Function]}
-    placeholder="Select your best friend"
-    query=""
-    saveButtonEnabled={false}
-  >
-    <Row
-      className="mt-3"
+        admin@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="777"
       tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
     >
-      <Col
-        tag="div"
+      <Label
+        check={true}
+        tag="label"
         widths={
           Array [
             "xs",
@@ -549,11 +1046,42 @@ exports[`Component: ModalPickerSingle ui should use custom display function to r
           ]
         }
       >
-        <EmptyModal
-          userHasSearched={false}
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
         />
-      </Col>
-    </Row>
+        coordinator@42.nl
+      </Label>
+    </FormGroup>
+    <FormGroup
+      check={true}
+      key="1337"
+      tag="div"
+    >
+      <Label
+        check={true}
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <Input
+          checked={false}
+          disabled={false}
+          onChange={[Function]}
+          type="radio"
+        />
+        user@42.nl
+      </Label>
+    </FormGroup>
   </ModalPicker>
 </FormGroup>
 `;

--- a/src/form/ModalPicker/types.ts
+++ b/src/form/ModalPicker/types.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export type AddButtonCallback<T> = () => Promise<T>;
 
 export type AddButtonOptions<T> = {
@@ -6,3 +8,15 @@ export type AddButtonOptions<T> = {
 };
 
 export type ButtonAlignment = 'left' | 'right' | 'default';
+
+export type RenderOptionsOption<T> = {
+  option: T;
+  isSelected: boolean;
+  enabled: boolean;
+  toggle: () => void;
+};
+
+/**
+ * Callback which renders the options.
+ */
+export type RenderOptions<T> = (options: RenderOptionsOption<T>[]) => ReactNode;

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -1,314 +1,129 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import Checkbox, { JarbRadioGroup } from './RadioGroup';
-import { FinalForm, Form, resolveAfter } from '../story-utils';
-import { pageOfUsers, randomUser } from '../../test/fixtures';
-import { User } from '../../test/types';
+import RadioGroup, { JarbRadioGroup } from './RadioGroup';
+import {
+  FinalForm,
+  Form,
+  IsOptionEqualInfo,
+  KeyForOptionInfo,
+  nonExistingProvince,
+  Province,
+  provinceFetcher,
+  provinces,
+  ReloadOptionsInfo,
+  resolveAfter
+} from '../story-utils';
 import { Icon, pageOf, Tooltip } from '../..';
-import Toggle from '../../core/Toggle/Toggle';
-
-type SubjectOption = {
-  value: string;
-  label: string;
-};
 
 storiesOf('Form/RadioGroup', module)
-  .add('defined options', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
     );
 
     return (
       <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
 
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
-  .add('horizontal', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
-    );
+  .add('async options', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
 
     return (
       <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
-          horizontal={true}
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
 
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-
-        <p>
-          <strong>Disclaimer:</strong> horizontal mode works best when there are
-          not too many items
-        </p>
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
-  .add('horizontal with clear', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
     );
 
     return (
       <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
-          horizontal={true}
-          canClear={true}
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
         />
 
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-
-        <p>
-          <strong>Disclaimer:</strong> horizontal mode works best when there are
-          not too many items
-        </p>
-      </Form>
-    );
-  })
-  .add('with clear button', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
-    );
-
-    return (
-      <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
-          canClear={true}
-        />
-
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-      </Form>
-    );
-  })
-  .add('fetched options', () => {
-    const [subject, setSubject] = useState<User | undefined>(randomUser());
-
-    return (
-      <Form>
-        <Checkbox<User>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(user: User) => user.email}
-          options={() => resolveAfter(pageOfUsers())}
-          value={subject}
-          onChange={setSubject}
-        />
-
-        {subject ? <p>Your chosen subject is: {subject.email}</p> : null}
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
   .add('custom isOptionEqual', () => {
-    const [subject, setSubject] = useState<User | undefined>(undefined);
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
 
     return (
       <Form>
-        <Checkbox<User>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers())}
-          isOptionEqual={(a: User, b: User) => a.id === b.id}
-          value={subject}
-          onChange={setSubject}
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
         />
 
-        {subject ? <p>Your chosen subject is: {subject.email}</p> : null}
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <IsOptionEqualInfo />
       </Form>
     );
   })
-  .add('without placeholder', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
-    );
+  .add('custom keyForOption', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
 
     return (
       <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          keyForOption={(province) => province.value}
+          value={value}
+          onChange={setValue}
         />
 
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <KeyForOptionInfo />
       </Form>
     );
   })
-  .add('without label', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
-    );
-
-    return (
-      <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
-        />
-
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-      </Form>
-    );
-  })
-  .add('with custom label', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
-    );
-
-    return (
-      <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label={
-            <>
-              <span>Subject</span>
-              <Tooltip
-                className="ml-1 position-relative"
-                style={{ top: 4 }}
-                content="Subjects are the best"
-              >
-                <Icon icon="info" />
-              </Tooltip>
-            </>
-          }
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
-        />
-
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-      </Form>
-    );
-  })
-  .add('value based options', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>(
-      undefined
-    );
-    const [filtered, setFiltered] = useState(false);
-
-    const allOptions = [
-      { value: 'awesome', label: 'Awesome shit' },
-      { value: 'super', label: 'Super shit' },
-      { value: 'great', label: 'Great shit' },
-      { value: 'good', label: 'good shit' }
-    ];
-
-    const filteredOptions = allOptions.filter(
-      (option) => option.value !== 'awesome'
-    );
-
-    return (
-      <Form>
-        <div className="mb-3">
-          <Toggle
-            color="primary"
-            onChange={setFiltered}
-            value={filtered}
-            className="mr-2"
-          />
-          Filter options
-        </div>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={filtered ? filteredOptions : allOptions}
-          value={subject}
-          onChange={setSubject}
-        />
-
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-      </Form>
-    );
-  })
-  .add('value based async options', () => {
+  .add('using reloadOptions', () => {
     const [brand, setBrand] = useState<string>();
     const [model, setModel] = useState<string>();
 
@@ -320,82 +135,190 @@ storiesOf('Form/RadioGroup', module)
 
     return (
       <Form>
-        <Checkbox
+        <RadioGroup
           id="brand"
           label="Brand"
           placeholder="Please select your brand"
-          optionForValue={(option) => option}
           options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
+          labelForOption={(option) => option}
           value={brand}
           onChange={(value) => {
             setBrand(value);
             setModel(undefined);
           }}
         />
-        <Checkbox
+        <RadioGroup
           id="model"
           label="Model"
           placeholder={
             brand ? 'Please select your model' : 'Please select a brand first'
           }
-          optionForValue={(option: string) => option}
           options={() =>
             resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
           }
+          labelForOption={(option: string) => option}
           value={model}
           onChange={setModel}
-          watch={brand}
+          reloadOptions={brand}
         />
+
+        {brand ? <p>Your chosen brand is: {brand}</p> : null}
+        {model ? <p>Your chosen model is: {model}</p> : null}
+
+        <ReloadOptionsInfo />
       </Form>
     );
   })
+  .add('label & placeholder', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <h3>Without label</h3>
+
+        <RadioGroup<Province>
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <RadioGroup<Province>
+          id="provinces"
+          label={
+            <div className="d-flex justify-content-between">
+              <span>Subject</span>
+              <Tooltip className="ml-1" content="The province you live in">
+                <Icon icon="info" />
+              </Tooltip>
+            </div>
+          }
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Without placeholder</h3>
+
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('horizontal', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          horizontal={true}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <p>
+          <strong>Disclaimer:</strong> horizontal mode works best when there are
+          not too many items
+        </p>
+      </Form>
+    );
+  })
+  .add('horizontal with clear', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          horizontal={true}
+          canClear={true}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <p>
+          <strong>Disclaimer:</strong> horizontal mode works best when there are
+          not too many items
+        </p>
+      </Form>
+    );
+  })
+  .add('with clear button', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <RadioGroup<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          canClear={true}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+      </Form>
+    );
+  })
+
   .add('jarb', () => {
     return (
       <FinalForm>
         <JarbRadioGroup
-          id="subject"
-          name="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
+          id="province"
+          name="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'Hero.name',
-            label: 'Subject'
+            validator: 'User.province',
+            label: 'Province'
           }}
         />
       </FinalForm>
-    );
-  })
-  .add('default option', () => {
-    const [subject, setSubject] = useState<SubjectOption | undefined>({
-      value: 'great',
-      label: 'Great shit'
-    });
-
-    return (
-      <Form>
-        <Checkbox<SubjectOption>
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          value={subject}
-          onChange={setSubject}
-        />
-        {subject ? <p>Your chosen subject is: {subject.label}</p> : null}
-      </Form>
     );
   });

--- a/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -109,6 +109,28 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
 </FormGroup>
 `;
 
+exports[`Component: RadioGroup ui loading: Component: RadioGroup => ui => loading 1`] = `
+<FormGroup
+  className="radio-group "
+  tag="fieldset"
+>
+  <legend>
+    Subject
+  </legend>
+  <p
+    className="text-muted"
+  >
+    <em>
+      Please enter your subject
+    </em>
+  </p>
+  <Loading>
+    Loading...
+  </Loading>
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => with value 1`] = `
 <FormGroup
   className="radio-group "

--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -1,213 +1,228 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 
 import Select, { JarbSelect } from './Select';
-import { FinalForm, Form, resolveAfter } from '../story-utils';
-import { pageOfUsers, userUser, randomUser } from '../../test/fixtures';
-import { User } from '../../test/types';
+import {
+  FinalForm,
+  Form,
+  IsOptionEqualInfo,
+  KeyForOptionInfo,
+  nonExistingProvince,
+  Province,
+  provinceFetcher,
+  provinces,
+  ReloadOptionsInfo,
+  resolveAfter
+} from '../story-utils';
 import { Icon, pageOf, Tooltip } from '../..';
 
-type SubjectOption = {
-  value: string;
-  label: string;
-};
-
 storiesOf('Form/Select', module)
-  .add('defined options', () => {
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
     return (
       <Form>
-        <Select
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          onChange={(value) => action(`You entered ${value}`)}
+        <Select<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
-  .add('fetched options', () => {
-    const [subject, setSubject] = useState<User>(randomUser());
+  .add('async options', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
 
     return (
       <Form>
-        <Select
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(user: User) => user.email}
-          options={() => resolveAfter(pageOfUsers())}
-          value={subject}
-          onChange={setSubject}
+        <Select<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+      </Form>
+    );
+  })
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <Select<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
   .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
     return (
       <Form>
-        <Select
-          id="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          value={userUser()}
-          optionForValue={(user: User) => user.email}
-          options={() => Promise.resolve(pageOfUsers())}
-          isOptionEqual={(a: User, b: User) => a.id === b.id}
-          onChange={(value) => action(`You entered ${value}`)}
+        <Select<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <IsOptionEqualInfo />
       </Form>
     );
   })
-  .add('without placeholder', () => {
+  .add('custom keyForOption', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
     return (
       <Form>
-        <Select
-          id="subject"
-          label="Subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          onChange={(value) => action(`You entered ${value}`)}
+        <Select<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          keyForOption={(province) => province.value}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <KeyForOptionInfo />
       </Form>
     );
   })
-  .add('without label', () => {
+  .add('using reloadOptions', () => {
+    const [brand, setBrand] = useState<string>();
+    const [model, setModel] = useState<string>();
+
+    const allOptions = {
+      Audi: ['A1', 'A2', 'A3', 'M5'],
+      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
+      Mercedes: ['Viano', 'Vito', 'Sprinter']
+    };
+
     return (
       <Form>
         <Select
-          id="subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          onChange={(value) => action(`You entered ${value}`)}
+          id="brand"
+          label="Brand"
+          placeholder="Please select your brand"
+          options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
+          labelForOption={(option) => option}
+          onChange={(value) => {
+            setBrand(value);
+            setModel(undefined);
+          }}
+          value={brand}
         />
+        <Select
+          id="model"
+          label="Model"
+          placeholder={
+            brand ? 'Please select your model' : 'Please select a brand first'
+          }
+          options={() =>
+            resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
+          }
+          labelForOption={(option: string) => option}
+          onChange={setModel}
+          value={model}
+          reloadOptions={brand}
+        />
+
+        {brand ? <p>Your chosen brand is: {brand}</p> : null}
+        {model ? <p>Your chosen model is: {model}</p> : null}
+
+        <ReloadOptionsInfo />
       </Form>
     );
   })
-  .add('with custom label', () => {
+  .add('label & placeholder', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
     return (
       <Form>
-        <Select
-          id="subject"
+        <h3>Without label</h3>
+
+        <Select<Province>
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <Select<Province>
+          id="provinces"
           label={
             <div className="d-flex justify-content-between">
               <span>Subject</span>
-              <Tooltip className="ml-1" content="The subject of your essay">
+              <Tooltip className="ml-1" content="The province you live in">
                 <Icon icon="info" />
               </Tooltip>
             </div>
           }
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          onChange={(value) => action(`You entered ${value}`)}
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
-      </Form>
-    );
-  })
-  .add('value based options', () => {
-    const [brand, setBrand] = useState<string>();
-    const [model, setModel] = useState<string>();
 
-    const allOptions = {
-      Audi: ['A1', 'A2', 'A3', 'M5'],
-      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
-      Mercedes: ['Viano', 'Vito', 'Sprinter']
-    };
+        <hr />
 
-    return (
-      <Form>
-        <Select
-          id="brand"
-          label="Brand"
-          placeholder="Please select your brand"
-          optionForValue={(option) => option}
-          options={Object.keys(allOptions)}
-          onChange={(value) => {
-            setBrand(value);
-            setModel(undefined);
-          }}
-          value={brand}
-        />
-        <Select
-          id="model"
-          label="Model"
-          placeholder={
-            brand ? 'Please select your model' : 'Please select a brand first'
-          }
-          optionForValue={(option: string) => option}
-          options={brand ? allOptions[brand] : []}
-          onChange={(value) => setModel(value)}
-          value={model}
-        />
-      </Form>
-    );
-  })
-  .add('value based async options', () => {
-    const [brand, setBrand] = useState<string>();
-    const [model, setModel] = useState<string>();
+        <h3>Without placeholder</h3>
 
-    const allOptions = {
-      Audi: ['A1', 'A2', 'A3', 'M5'],
-      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
-      Mercedes: ['Viano', 'Vito', 'Sprinter']
-    };
+        <Select<Province>
+          id="province"
+          label="Province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
 
-    return (
-      <Form>
-        <Select
-          id="brand"
-          label="Brand"
-          placeholder="Please select your brand"
-          optionForValue={(option) => option}
-          options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
-          onChange={(value) => {
-            setBrand(value);
-            setModel(undefined);
-          }}
-          value={brand}
-        />
-        <Select
-          id="model"
-          label="Model"
-          placeholder={
-            brand ? 'Please select your model' : 'Please select a brand first'
-          }
-          optionForValue={(option: string) => option}
-          options={() =>
-            resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
-          }
-          onChange={(value: string) => setModel(value)}
-          value={model}
-          watch={brand}
-        />
+        <hr />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
@@ -215,45 +230,17 @@ storiesOf('Form/Select', module)
     return (
       <FinalForm>
         <JarbSelect
-          id="subject"
-          name="subject"
-          label="Subject"
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          isOptionEnabled={(option) => option.value !== 'awesome'}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
+          id="province"
+          name="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'Hero.name',
-            label: 'Subject'
+            validator: 'User.province',
+            label: 'Province'
           }}
         />
       </FinalForm>
-    );
-  })
-  .add('default option', () => {
-    const [value, setValue] = useState({ value: 'great', label: 'Great shit' });
-
-    return (
-      <Form>
-        <Select<SubjectOption>
-          id="subject"
-          label="Subject"
-          value={value}
-          placeholder="Please enter your subject"
-          optionForValue={(option: SubjectOption) => option.label}
-          options={[
-            { value: 'awesome', label: 'Awesome shit' },
-            { value: 'super', label: 'Super shit' },
-            { value: 'great', label: 'Great shit' },
-            { value: 'good', label: 'good shit' }
-          ]}
-          onChange={setValue}
-        />
-      </Form>
     );
   });

--- a/src/form/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/form/Select/__snapshots__/Select.test.tsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: Select ui loading: Component: Select => ui => loading 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="subject"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Subject
+  </Label>
+  <Loading
+    className="mt-2"
+  >
+    Loading...
+  </Loading>
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: Select ui with value: Component: Select => ui => with value 1`] = `
 <FormGroup
   className=""
@@ -23,12 +52,11 @@ exports[`Component: Select ui with value: Component: Select => ui => with value 
   <Input
     className=""
     id="subject"
-    invalid={true}
     onBlur={[MockFunction]}
     onChange={[Function]}
     placeholder="Please enter your subject"
     type="select"
-    valid={false}
+    valid={true}
     value={0}
   >
     <option>
@@ -68,12 +96,10 @@ exports[`Component: Select ui without label: Component: Select => ui => without 
   <Input
     className=""
     id="1"
-    invalid={true}
     onBlur={[MockFunction]}
     onChange={[Function]}
     placeholder="Please enter your subject"
     type="select"
-    valid={false}
     value={0}
   >
     <option>
@@ -128,11 +154,9 @@ exports[`Component: Select ui without placeholder: Component: Select => ui => wi
   <Input
     className=""
     id="subject"
-    invalid={true}
     onBlur={[MockFunction]}
     onChange={[Function]}
     type="select"
-    valid={false}
     value={0}
   >
     <option />

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
@@ -1,93 +1,231 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 
-import { pageWithContentAndExactSize } from '../../../test/utils';
-import { Form, FinalForm } from '../../story-utils';
-import { userUser, adminUser } from '../../../test/fixtures';
-import { User } from '../../../test/types';
+import {
+  Form,
+  FinalForm,
+  IsOptionEqualInfo,
+  ReloadOptionsInfo,
+  Province,
+  provinces,
+  provinceFetcher,
+  nonExistingProvince
+} from '../../story-utils';
 
 import TypeaheadMultiple, { JarbTypeaheadMultiple } from './TypeaheadMultiple';
 import { Icon, Tooltip } from '../../..';
+import Toggle from '../../../core/Toggle/Toggle';
 
 storiesOf('Form/Typeahead/JarbTypeaheadMultiple', module)
-  .add('basic', () => {
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
     return (
       <Form>
         <TypeaheadMultiple
-          id="friends"
-          label="Friends"
-          placeholder="Please provide all your friends"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
       </Form>
     );
   })
-  .add('without placeholder', () => {
+  .add('async options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
     return (
       <Form>
         <TypeaheadMultiple
-          id="friends"
-          label="Friends"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
       </Form>
     );
   })
-  .add('without label', () => {
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
     return (
       <Form>
         <TypeaheadMultiple
-          id="friends"
-          placeholder="Please provide all your friends"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
       </Form>
     );
   })
-  .add('with custom label', () => {
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      provinces()[0]
+    ]);
+
     return (
       <Form>
         <TypeaheadMultiple
-          id="friends"
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <IsOptionEqualInfo />
+      </Form>
+    );
+  })
+  .add('using reloadOptions', () => {
+    const [limitToNorthern, setLimitToNorthern] = useState(false);
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <p>
+          Limit to northern provinces
+          <Toggle
+            className="ml-2"
+            color="primary"
+            value={limitToNorthern}
+            onChange={() => setLimitToNorthern(!limitToNorthern)}
+          />
+        </p>
+
+        <TypeaheadMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces().filter((option) =>
+            limitToNorthern ? option.north : true
+          )}
+          labelForOption={(option) => option.label}
+          value={value}
+          onChange={setValue}
+          reloadOptions={limitToNorthern}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(',')}
+          </p>
+        ) : null}
+
+        <ReloadOptionsInfo />
+      </Form>
+    );
+  })
+  .add('label & placeholder', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <h3>Without label</h3>
+
+        <TypeaheadMultiple
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <TypeaheadMultiple
+          id="provinces"
           label={
             <div className="d-flex justify-content-between">
               <span>Friends</span>
-              <Tooltip
-                className="ml-1"
-                content="It is nice to have lots of friends"
-              >
+              <Tooltip className="ml-1" content="Provinces are nice to have">
                 <Icon icon="info" />
               </Tooltip>
             </div>
           }
-          placeholder="Please provide all your friends"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        <hr />
+
+        <h3>Without placeholder</h3>
+
+        <TypeaheadMultiple
+          id="provinces"
+          label="Provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
       </Form>
     );
   })
@@ -95,19 +233,15 @@ storiesOf('Form/Typeahead/JarbTypeaheadMultiple', module)
     return (
       <FinalForm>
         <JarbTypeaheadMultiple
-          id="friends"
-          name="friends"
-          label="Friends"
-          placeholder="Please provide all your friends"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
+          id="provinces"
+          name="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'User.friends',
-            label: 'Friends'
+            validator: 'User.provinces',
+            label: 'Provinces'
           }}
         />
       </FinalForm>

--- a/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
+++ b/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
@@ -33,7 +33,8 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
     className=""
   >
     <withAsync(Component)
-      delay={200}
+      delay={0}
+      filterBy={[Function]}
       id="bestFriend"
       inputProps={
         Object {
@@ -42,9 +43,9 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
             Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -57,7 +58,37 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
       multiple={true}
       onChange={[Function]}
       onSearch={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       renderToken={[Function]}
@@ -69,9 +100,9 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -95,7 +126,8 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
     className=""
   >
     <withAsync(Component)
-      delay={200}
+      delay={0}
+      filterBy={[Function]}
       inputProps={
         Object {
           "className": "form-control",
@@ -103,9 +135,9 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
             Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -118,7 +150,37 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
       multiple={true}
       onChange={[Function]}
       onSearch={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       renderToken={[Function]}
@@ -130,9 +192,9 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -171,7 +233,8 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
     className=""
   >
     <withAsync(Component)
-      delay={200}
+      delay={0}
+      filterBy={[Function]}
       id="bestFriend"
       inputProps={
         Object {
@@ -180,9 +243,9 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
             Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -195,7 +258,37 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
       multiple={true}
       onChange={[Function]}
       onSearch={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
       promptText="Type to search..."
       renderToken={[Function]}
       searchText="Searching..."
@@ -206,9 +299,9 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],

--- a/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
@@ -1,92 +1,204 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
-
-import { pageWithContentAndExactSize } from '../../../test/utils';
-import { Form, FinalForm } from '../../story-utils';
-import { userUser, adminUser } from '../../../test/fixtures';
-import { User } from '../../../test/types';
+import React, { useState } from 'react';
+import { Icon, pageOf, Tooltip } from '../../..';
+import {
+  FinalForm,
+  Form,
+  IsOptionEqualInfo,
+  nonExistingProvince,
+  Province,
+  provinceFetcher,
+  provinces,
+  ReloadOptionsInfo,
+  resolveAfter
+} from '../../story-utils';
 import TypeaheadSingle, { JarbTypeaheadSingle } from './TypeaheadSingle';
-import { Tooltip, Icon } from '../../..';
 
 storiesOf('Form/Typeahead/JarbTypeaheadSingle', module)
-  .add('basic', () => {
+  .add('predefined options', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
     return (
       <Form>
-        <TypeaheadSingle
-          id="bestFriend"
-          label="Best friend"
-          placeholder="Please provide your best friend"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+        <TypeaheadSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
-  .add('without placeholder', () => {
+  .add('async options', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
     return (
       <Form>
-        <TypeaheadSingle
-          id="bestFriend"
-          label="Best friend"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+        <TypeaheadSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
-  .add('without label', () => {
+  .add('disabled options', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
     return (
       <Form>
-        <TypeaheadSingle
-          id="bestFriend"
-          placeholder="Please provide your best friend"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+        <TypeaheadSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEnabled={(option) => !option.label.startsWith('Z')}
+          value={value}
+          onChange={setValue}
         />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
-  .add('with custom label', () => {
+  .add('custom isOptionEqual', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
+    return (
+      <Form>
+        <TypeaheadSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          isOptionEqual={(a, b) => a.value === b.value}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <IsOptionEqualInfo />
+      </Form>
+    );
+  })
+  .add('using reloadOptions', () => {
+    const [brand, setBrand] = useState<string>();
+    const [model, setModel] = useState<string>();
+
+    const allOptions = {
+      Audi: ['A1', 'A2', 'A3', 'M5'],
+      BMW: ['series 1', 'series 2', 'series 3', 'series 4', 'series 5'],
+      Mercedes: ['Viano', 'Vito', 'Sprinter']
+    };
+
     return (
       <Form>
         <TypeaheadSingle
-          id="bestFriend"
+          id="brand"
+          label="Brand"
+          placeholder="Please select your brand"
+          options={() => resolveAfter(pageOf(Object.keys(allOptions), 1))}
+          labelForOption={(option) => option}
+          onChange={(value) => {
+            setBrand(value);
+            setModel(undefined);
+          }}
+          value={brand}
+        />
+        <TypeaheadSingle
+          id="model"
+          label="Model"
+          placeholder={
+            brand ? 'Please select your model' : 'Please select a brand first'
+          }
+          options={() =>
+            resolveAfter(pageOf(brand ? allOptions[brand] : [], 1))
+          }
+          labelForOption={(option: string) => option}
+          onChange={setModel}
+          value={model}
+          reloadOptions={brand}
+        />
+
+        {brand ? <p>Your chosen brand is: {brand}</p> : null}
+        {model ? <p>Your chosen model is: {model}</p> : null}
+
+        <ReloadOptionsInfo />
+      </Form>
+    );
+  })
+  .add('label & placeholder', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <h3>Without label</h3>
+
+        <TypeaheadSingle<Province>
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        <h3>Custom label</h3>
+
+        <TypeaheadSingle<Province>
+          id="provinces"
           label={
             <div className="d-flex justify-content-between">
-              <span>Best friend</span>
-              <Tooltip
-                className="ml-1"
-                content="Are you your best friend's best friend?"
-              >
+              <span>Subject</span>
+              <Tooltip className="ml-1" content="The province you live in">
                 <Icon icon="info" />
               </Tooltip>
             </div>
           }
-          placeholder="Please provide your best friend"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
-          onChange={(value) => action(`onChange: ${value}`)}
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
         />
+
+        <hr />
+
+        <h3>Without placeholder</h3>
+
+        <TypeaheadSingle<Province>
+          id="province"
+          label="Province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+        />
+
+        <hr />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
       </Form>
     );
   })
@@ -94,19 +206,15 @@ storiesOf('Form/Typeahead/JarbTypeaheadSingle', module)
     return (
       <FinalForm>
         <JarbTypeaheadSingle
-          id="bestFriend"
-          name="bestFriend"
-          label="Best friend"
-          placeholder="Please provide your best friend"
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() =>
-            Promise.resolve(
-              pageWithContentAndExactSize([userUser(), adminUser()])
-            )
-          }
+          id="province"
+          name="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
           jarb={{
-            validator: 'User.bestFriend',
-            label: 'Best friend'
+            validator: 'User.province',
+            label: 'Province'
           }}
         />
       </FinalForm>

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -24,7 +24,8 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
     className=""
   >
     <withAsync(Component)
-      delay={200}
+      delay={0}
+      filterBy={[Function]}
       id="bestFriend"
       inputProps={
         Object {
@@ -32,12 +33,41 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
         }
       }
       isLoading={false}
-      labelKey="label"
       minLength={2}
       multiple={false}
       onChange={[Function]}
       onSearch={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       searchText="Searching..."
@@ -48,9 +78,9 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -74,19 +104,49 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
     className=""
   >
     <withAsync(Component)
-      delay={200}
+      delay={0}
+      filterBy={[Function]}
       inputProps={
         Object {
           "className": "form-control",
         }
       }
       isLoading={false}
-      labelKey="label"
       minLength={2}
       multiple={false}
       onChange={[Function]}
       onSearch={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       searchText="Searching..."
@@ -97,9 +157,9 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],
@@ -138,7 +198,8 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
     className=""
   >
     <withAsync(Component)
-      delay={200}
+      delay={0}
+      filterBy={[Function]}
       id="bestFriend"
       inputProps={
         Object {
@@ -146,12 +207,41 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
         }
       }
       isLoading={false}
-      labelKey="label"
       minLength={2}
       multiple={false}
       onChange={[Function]}
       onSearch={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
       promptText="Type to search..."
       searchText="Searching..."
       selected={
@@ -161,9 +251,9 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
             "value": Object {
               "active": true,
               "email": "admin@42.nl",
-              "firstName": "admin",
+              "firstName": "Addie",
               "id": 42,
-              "lastName": "user",
+              "lastName": "Admin",
               "roles": Array [
                 "ADMIN",
               ],

--- a/src/form/Typeahead/single/useAutoSelectOptionWhenQueryMatchesExactly.test.ts
+++ b/src/form/Typeahead/single/useAutoSelectOptionWhenQueryMatchesExactly.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useAutoSelectOptionWhenQueryMatchesExactly } from './useAutoSelectOptionWhenQueryMatchesExactly';
+
+describe('useAutoSelectOptionWhenQueryMatchesExactly', () => {
+  it('should auto select the value when a lowercased exact match is found', () => {
+    const onChangeSpy = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ query }) => {
+        return useAutoSelectOptionWhenQueryMatchesExactly({
+          typeaheadOptions: [
+            { label: 'Aap', value: 'AAP' },
+            { label: 'Noot', value: 'NOOT' },
+            { label: 'Mies', value: 'MIES' }
+          ],
+          query,
+          onChange: onChangeSpy
+        });
+      },
+      {
+        initialProps: {
+          query: ''
+        }
+      }
+    );
+
+    // Initially there is no match
+    expect(onChangeSpy).toBeCalledTimes(0);
+
+    // User starts typing the first letter, still no exact match
+    rerender({ query: 'a' });
+    expect(onChangeSpy).toBeCalledTimes(0);
+
+    // User starts typing the second letter, still no exact match
+    rerender({ query: 'aa' });
+    expect(onChangeSpy).toBeCalledTimes(0);
+
+    // User starts typing the third letter, now there is a match
+    rerender({ query: 'aap' });
+    expect(onChangeSpy).toBeCalledTimes(1);
+    expect(onChangeSpy).toBeCalledWith('AAP');
+  });
+});

--- a/src/form/Typeahead/single/useAutoSelectOptionWhenQueryMatchesExactly.ts
+++ b/src/form/Typeahead/single/useAutoSelectOptionWhenQueryMatchesExactly.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { TypeaheadOption } from '../types';
+
+type Config<T> = {
+  typeaheadOptions: TypeaheadOption<T>[];
+  query: string;
+  onChange: (value: T) => void;
+};
+
+export function useAutoSelectOptionWhenQueryMatchesExactly<T>({
+  typeaheadOptions,
+  onChange,
+  query
+}: Config<T>): void {
+  // When value matches the query exactly select it.
+  useEffect(() => {
+    const lowerCasedQuery = query.toLowerCase();
+
+    const selectedValue = typeaheadOptions.find(
+      ({ label }) => label.toLowerCase() === lowerCasedQuery
+    );
+
+    if (selectedValue) {
+      onChange(selectedValue.value);
+    }
+  }, [typeaheadOptions, onChange, query]);
+}

--- a/src/form/Typeahead/types.ts
+++ b/src/form/Typeahead/types.ts
@@ -1,11 +1,3 @@
-import { Page } from '@42.nl/spring-connect';
-
-/**
- * Callback which takes a query string and is expected to return
- * a Promise which resolves to a Page of T.
- */
-export type FetchOptionsCallback<T> = (query: string) => Promise<Page<T>>;
-
 /**
  * Represents the value of a Typeahead.
  */

--- a/src/form/Typeahead/utils.test.ts
+++ b/src/form/Typeahead/utils.test.ts
@@ -1,4 +1,4 @@
-import { valueToTypeaheadOption } from './utils';
+import { optionToTypeaheadOption } from './utils';
 
 type User = {
   id: number;
@@ -13,7 +13,7 @@ test('valueToTypeAheadOption', () => {
 
   const optionFor = (v: User) => v.name;
 
-  expect(valueToTypeaheadOption(user, optionFor)).toEqual({
+  expect(optionToTypeaheadOption(user, optionFor)).toEqual({
     label: 'Maarten Hus',
     value: user
   });

--- a/src/form/Typeahead/utils.ts
+++ b/src/form/Typeahead/utils.ts
@@ -1,10 +1,11 @@
+import { LabelForOption } from '../option';
 import { TypeaheadOption } from './types';
 
-export function valueToTypeaheadOption<T>(
-  value: T,
-  optionFor: (value: T) => string
+export function optionToTypeaheadOption<T>(
+  option: T,
+  labelForOption: LabelForOption<T>
 ): TypeaheadOption<T> {
-  const label = optionFor(value);
+  const label = labelForOption(option);
 
-  return { label, value };
+  return { label, value: option };
 }

--- a/src/form/ValuePicker/ValuePicker.stories.tsx
+++ b/src/form/ValuePicker/ValuePicker.stories.tsx
@@ -80,8 +80,8 @@ storiesOf('Form/ValuePicker/multiple', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -109,8 +109,8 @@ storiesOf('Form/ValuePicker/multiple', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={value}
           onChange={setValue}
@@ -138,8 +138,8 @@ storiesOf('Form/ValuePicker/multiple', module)
           id="bestFriend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -177,8 +177,8 @@ storiesOf('Form/ValuePicker/multiple', module)
           }
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -205,8 +205,8 @@ storiesOf('Form/ValuePicker/multiple', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() => promise}
+          labelForOption={(user: User) => user.email}
+          options={() => promise}
           jarb={{
             validator: 'Hero.name',
             label: 'Best friend'
@@ -239,8 +239,8 @@ storiesOf('Form/ValuePicker/single', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -271,8 +271,8 @@ storiesOf('Form/ValuePicker/single', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           isOptionEqual={(a: User, b: User) => a.id === b.id}
           value={value}
           onChange={setValue}
@@ -303,8 +303,8 @@ storiesOf('Form/ValuePicker/single', module)
           id="bestFriend"
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -345,8 +345,8 @@ storiesOf('Form/ValuePicker/single', module)
           }
           placeholder="Select your best friend"
           canSearch={true}
-          fetchOptions={() => promise}
-          optionForValue={(user: User) => user.email}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           value={value}
           onChange={setValue}
         />
@@ -376,8 +376,8 @@ storiesOf('Form/ValuePicker/single', module)
           label="Best friend"
           placeholder="Select your best friend"
           canSearch={true}
-          optionForValue={(user: User) => user.email}
-          fetchOptions={() => promise}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
           jarb={{
             validator: 'Hero.name',
             label: 'Best friend'

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -1,20 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelect\` component when \`totalElements\` is less than 11 1`] = `
+exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should render a \`CheckboxMultipleSelect\` component async page \`totalElements\` is less than 11 1`] = `
 <ValuePicker
   canSearch={true}
-  fetchOptions={
+  id="bestFriend"
+  label="Best friend"
+  labelForOption={[Function]}
+  multiple={true}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  options={
     [MockFunction] {
       "calls": Array [
         Array [
-          "",
-          1,
-          1,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 1,
+          },
         ],
         Array [
-          "",
-          1,
-          10,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 100,
+          },
         ],
       ],
       "results": Array [
@@ -29,22 +39,45 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
       ],
     }
   }
-  id="bestFriend"
-  label="Best friend"
-  multiple={true}
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  optionForValue={[Function]}
   placeholder="Select your best friend"
 >
   <CheckboxMultipleSelect
     canSearch={true}
     id="bestFriend"
     label="Best friend"
+    labelForOption={[Function]}
     onBlur={[MockFunction]}
     onChange={[MockFunction]}
-    optionForValue={[Function]}
-    options={[Function]}
+    options={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 1,
+            },
+          ],
+          Array [
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 100,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      }
+    }
     placeholder="Select your best friend"
   >
     <FormGroup
@@ -274,21 +307,31 @@ exports[`Component: ValuePicker multiple should render a \`CheckboxMultipleSelec
 </ValuePicker>
 `;
 
-exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\` when \`totalElements\` is more than 10 1`] = `
+exports[`Component: ValuePicker multiple when ModalPickerMultiple should render a \`ModalPickerMultiple\` async page \`totalElements\` is more than 10 1`] = `
 <ValuePicker
   canSearch={true}
-  fetchOptions={
+  id="bestFriend"
+  label="Best friend"
+  labelForOption={[Function]}
+  multiple={true}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  options={
     [MockFunction] {
       "calls": Array [
         Array [
-          "",
-          1,
-          1,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 1,
+          },
         ],
         Array [
-          "",
-          1,
-          10,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 10,
+          },
         ],
       ],
       "results": Array [
@@ -303,28 +346,31 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
       ],
     }
   }
-  id="bestFriend"
-  label="Best friend"
-  multiple={true}
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  optionForValue={[Function]}
   placeholder="Select your best friend"
 >
   <ModalPickerMultiple
     canSearch={true}
-    fetchOptions={
+    id="bestFriend"
+    label="Best friend"
+    labelForOption={[Function]}
+    onBlur={[MockFunction]}
+    onChange={[MockFunction]}
+    options={
       [MockFunction] {
         "calls": Array [
           Array [
-            "",
-            1,
-            1,
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 1,
+            },
           ],
           Array [
-            "",
-            1,
-            10,
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 10,
+            },
           ],
         ],
         "results": Array [
@@ -339,11 +385,6 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
         ],
       }
     }
-    id="bestFriend"
-    label="Best friend"
-    onBlur={[MockFunction]}
-    onChange={[MockFunction]}
-    optionForValue={[Function]}
     placeholder="Select your best friend"
   >
     <FormGroup
@@ -374,16 +415,16 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
           </label>
         </Label>
         <ModalPickerOpener
-          displayValues={[Function]}
           label="Select your best friend"
           onClear={[Function]}
           openModal={[Function]}
+          renderValue={[Function]}
         >
           <div
             className="d-flex align-items-center"
           >
             <ModalPickerValueTruncator
-              optionForValue={[Function]}
+              labelForOption={[Function]}
             />
             <Button
               className="flex-grow-0 flex-shrink-0"
@@ -404,9 +445,10 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
         </ModalPickerOpener>
         <ModalPicker
           canSearch={true}
+          canSearchSync={false}
           closeModal={[Function]}
-          fetchOptions={[Function]}
           isOpen={false}
+          loading={false}
           modalSaved={[Function]}
           page={
             Object {
@@ -414,9 +456,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": true,
                   "email": "admin@42.nl",
-                  "firstName": "admin",
+                  "firstName": "Addie",
                   "id": 42,
-                  "lastName": "user",
+                  "lastName": "Admin",
                   "roles": Array [
                     "ADMIN",
                   ],
@@ -424,9 +466,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": false,
                   "email": "coordinator@42.nl",
-                  "firstName": "coordinator",
+                  "firstName": "Cordelia",
                   "id": 777,
-                  "lastName": "user",
+                  "lastName": "Coordinator",
                   "roles": Array [
                     "ADMIN",
                     "USER",
@@ -435,9 +477,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
                 Object {
                   "active": false,
                   "email": "user@42.nl",
-                  "firstName": "test",
+                  "firstName": "Ulysses",
                   "id": 1337,
-                  "lastName": "user",
+                  "lastName": "User",
                   "roles": Array [
                     "USER",
                   ],
@@ -455,7 +497,9 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
           pageChanged={[Function]}
           placeholder="Select your best friend"
           query=""
-          saveButtonEnabled={true}
+          queryChanged={[Function]}
+          selected={Array []}
+          userHasSearched={false}
         >
           <Modal
             autoFocus={true}
@@ -495,13 +539,21 @@ exports[`Component: ValuePicker multiple should render a \`ModalPickerMultiple\`
 exports[`Component: ValuePicker should when booting render a loading spinner and request an initial page 1`] = `
 <ValuePicker
   canSearch={true}
-  fetchOptions={
+  id="bestFriend"
+  label="Best friend"
+  labelForOption={[Function]}
+  multiple={false}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  options={
     [MockFunction] {
       "calls": Array [
         Array [
-          "",
-          1,
-          1,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 1,
+          },
         ],
       ],
       "results": Array [
@@ -512,12 +564,6 @@ exports[`Component: ValuePicker should when booting render a loading spinner and
       ],
     }
   }
-  id="bestFriend"
-  label="Best friend"
-  multiple={false}
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  optionForValue={[Function]}
   placeholder="Select your best friend"
 >
   <div>
@@ -551,21 +597,31 @@ exports[`Component: ValuePicker should when booting render a loading spinner and
 </ValuePicker>
 `;
 
-exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` when \`totalElements\` is more than than 10 1`] = `
+exports[`Component: ValuePicker single when ModalPickerSingle should render a \`ModalPickerSingle\` when async page \`totalElements\` is more than than 10 1`] = `
 <ValuePicker
   canSearch={true}
-  fetchOptions={
+  id="bestFriend"
+  label="Best friend"
+  labelForOption={[Function]}
+  multiple={false}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  options={
     [MockFunction] {
       "calls": Array [
         Array [
-          "",
-          1,
-          1,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 1,
+          },
         ],
         Array [
-          "",
-          1,
-          10,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 10,
+          },
         ],
       ],
       "results": Array [
@@ -580,28 +636,31 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
       ],
     }
   }
-  id="bestFriend"
-  label="Best friend"
-  multiple={false}
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  optionForValue={[Function]}
   placeholder="Select your best friend"
 >
   <ModalPickerSingle
     canSearch={true}
-    fetchOptions={
+    id="bestFriend"
+    label="Best friend"
+    labelForOption={[Function]}
+    onBlur={[MockFunction]}
+    onChange={[MockFunction]}
+    options={
       [MockFunction] {
         "calls": Array [
           Array [
-            "",
-            1,
-            1,
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 1,
+            },
           ],
           Array [
-            "",
-            1,
-            10,
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 10,
+            },
           ],
         ],
         "results": Array [
@@ -616,11 +675,6 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
         ],
       }
     }
-    id="bestFriend"
-    label="Best friend"
-    onBlur={[MockFunction]}
-    onChange={[MockFunction]}
-    optionForValue={[Function]}
     placeholder="Select your best friend"
   >
     <FormGroup
@@ -651,16 +705,16 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
           </label>
         </Label>
         <ModalPickerOpener
-          displayValues={[Function]}
           label="Select your best friend"
           onClear={[Function]}
           openModal={[Function]}
+          renderValue={[Function]}
         >
           <div
             className="d-flex align-items-center"
           >
             <ModalPickerValueTruncator
-              optionForValue={[Function]}
+              labelForOption={[Function]}
             />
             <Button
               className="flex-grow-0 flex-shrink-0"
@@ -681,9 +735,10 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
         </ModalPickerOpener>
         <ModalPicker
           canSearch={true}
+          canSearchSync={false}
           closeModal={[Function]}
-          fetchOptions={[Function]}
           isOpen={false}
+          loading={false}
           modalSaved={[Function]}
           page={
             Object {
@@ -691,9 +746,9 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": true,
                   "email": "admin@42.nl",
-                  "firstName": "admin",
+                  "firstName": "Addie",
                   "id": 42,
-                  "lastName": "user",
+                  "lastName": "Admin",
                   "roles": Array [
                     "ADMIN",
                   ],
@@ -701,9 +756,9 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": false,
                   "email": "coordinator@42.nl",
-                  "firstName": "coordinator",
+                  "firstName": "Cordelia",
                   "id": 777,
-                  "lastName": "user",
+                  "lastName": "Coordinator",
                   "roles": Array [
                     "ADMIN",
                     "USER",
@@ -712,9 +767,9 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
                 Object {
                   "active": false,
                   "email": "user@42.nl",
-                  "firstName": "test",
+                  "firstName": "Ulysses",
                   "id": 1337,
-                  "lastName": "user",
+                  "lastName": "User",
                   "roles": Array [
                     "USER",
                   ],
@@ -732,7 +787,8 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
           pageChanged={[Function]}
           placeholder="Select your best friend"
           query=""
-          saveButtonEnabled={false}
+          queryChanged={[Function]}
+          userHasSearched={false}
         >
           <Modal
             autoFocus={true}
@@ -769,21 +825,31 @@ exports[`Component: ValuePicker single should render a \`ModalPickerSingle\` whe
 </ValuePicker>
 `;
 
-exports[`Component: ValuePicker single should render a \`RadioGroup\` component when \`totalElements\` is less than 4 1`] = `
+exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGroup\` component when async page \`totalElements\` is less than 4 1`] = `
 <ValuePicker
   canSearch={true}
-  fetchOptions={
+  id="bestFriend"
+  label="Best friend"
+  labelForOption={[Function]}
+  multiple={false}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  options={
     [MockFunction] {
       "calls": Array [
         Array [
-          "",
-          1,
-          1,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 1,
+          },
         ],
         Array [
-          "",
-          1,
-          3,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 10,
+          },
         ],
       ],
       "results": Array [
@@ -798,12 +864,6 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
       ],
     }
   }
-  id="bestFriend"
-  label="Best friend"
-  multiple={false}
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  optionForValue={[Function]}
   placeholder="Select your best friend"
 >
   <RadioGroup
@@ -811,10 +871,39 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
     canSearch={true}
     id="bestFriend"
     label="Best friend"
+    labelForOption={[Function]}
     onBlur={[MockFunction]}
     onChange={[MockFunction]}
-    optionForValue={[Function]}
-    options={[Function]}
+    options={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 1,
+            },
+          ],
+          Array [
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 10,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      }
+    }
     placeholder="Select your best friend"
   >
     <FormGroup
@@ -981,21 +1070,31 @@ exports[`Component: ValuePicker single should render a \`RadioGroup\` component 
 </ValuePicker>
 `;
 
-exports[`Component: ValuePicker single should render a \`Select\` component when \`totalElements\` is less than 11 but more than 3 1`] = `
+exports[`Component: ValuePicker single when Select should render a \`Select\` component when async page \`totalElements\` is less than 11 but more than 3 1`] = `
 <ValuePicker
   canSearch={true}
-  fetchOptions={
+  id="bestFriend"
+  label="Best friend"
+  labelForOption={[Function]}
+  multiple={false}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  options={
     [MockFunction] {
       "calls": Array [
         Array [
-          "",
-          1,
-          1,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 1,
+          },
         ],
         Array [
-          "",
-          1,
-          10,
+          Object {
+            "page": 1,
+            "query": "",
+            "size": 10,
+          },
         ],
       ],
       "results": Array [
@@ -1010,22 +1109,45 @@ exports[`Component: ValuePicker single should render a \`Select\` component when
       ],
     }
   }
-  id="bestFriend"
-  label="Best friend"
-  multiple={false}
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  optionForValue={[Function]}
   placeholder="Select your best friend"
 >
   <Select
     canSearch={true}
     id="bestFriend"
     label="Best friend"
+    labelForOption={[Function]}
     onBlur={[MockFunction]}
     onChange={[MockFunction]}
-    optionForValue={[Function]}
-    options={[Function]}
+    options={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 1,
+            },
+          ],
+          Array [
+            Object {
+              "page": 1,
+              "query": "",
+              "size": 10,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      }
+    }
     placeholder="Select your best friend"
   >
     <FormGroup

--- a/src/form/option.test.tsx
+++ b/src/form/option.test.tsx
@@ -1,4 +1,4 @@
-import { isOptionSelected, keyForOption } from './option';
+import { isOptionSelected, getKeyForOption } from './option';
 
 type Boat = {
   id?: number;
@@ -34,13 +34,13 @@ function setup() {
     name: 'Speedie'
   };
 
-  const uniqueKeyForValue = (boat: Boat) => `${boat.uniqueKey}`;
-  const optionForValue = (boat: Boat) => boat.name;
+  const keyForOption = (boat: Boat) => `${boat.uniqueKey}`;
+  const labelForOption = (boat: Boat) => boat.name;
   const isOptionEqual = (a: Boat, b: Boat) => a.id === b.id;
 
   return {
-    uniqueKeyForValue,
-    optionForValue,
+    keyForOption,
+    labelForOption,
     isOptionEqual,
     speedBoat,
     tugBoat,
@@ -51,14 +51,14 @@ function setup() {
 
 describe('Util: isOptionSelected', () => {
   it('should when the value is undefined return false', () => {
-    const { uniqueKeyForValue, optionForValue, speedBoat } = setup();
+    const { keyForOption, labelForOption, speedBoat } = setup();
 
     expect(
       isOptionSelected({
         value: undefined,
         option: speedBoat,
-        uniqueKeyForValue,
-        optionForValue
+        keyForOption,
+        labelForOption
       })
     ).toBe(false);
   });
@@ -67,8 +67,8 @@ describe('Util: isOptionSelected', () => {
     describe('when "isOptionEqual" is defined', () => {
       it('should consider a value selected when the "isOptionEqual" returns true for one item in the array', () => {
         const {
-          uniqueKeyForValue,
-          optionForValue,
+          keyForOption,
+          labelForOption,
           isOptionEqual,
           speedBoat,
           speedBoatCopy
@@ -78,8 +78,8 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: [speedBoatCopy],
             option: speedBoat,
-            uniqueKeyForValue,
-            optionForValue,
+            keyForOption,
+            labelForOption,
             isOptionEqual
           })
         ).toBe(true);
@@ -87,8 +87,8 @@ describe('Util: isOptionSelected', () => {
 
       it('should not consider a value selected when "isOptionEqual" returns false for every item in the array', () => {
         const {
-          uniqueKeyForValue,
-          optionForValue,
+          keyForOption,
+          labelForOption,
           isOptionEqual,
           tugBoat,
           anotherTugBoat
@@ -98,8 +98,8 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: [tugBoat],
             option: anotherTugBoat,
-            uniqueKeyForValue,
-            optionForValue,
+            keyForOption,
+            labelForOption,
             isOptionEqual
           })
         ).toBe(false);
@@ -109,8 +109,8 @@ describe('Util: isOptionSelected', () => {
     describe('when "isOptionEqual" is not defined', () => {
       it('should consider a value selected when "keyForOption" returns the same string for one item in the array', () => {
         const {
-          uniqueKeyForValue,
-          optionForValue,
+          keyForOption,
+          labelForOption,
           speedBoat,
           speedBoatCopy,
           tugBoat,
@@ -121,30 +121,30 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: [tugBoat],
             option: { ...anotherTugBoat, uniqueKey: tugBoat.uniqueKey },
-            optionForValue,
-            uniqueKeyForValue
+            labelForOption,
+            keyForOption
           })
         ).toBe(true);
         expect(
           isOptionSelected({
             value: [speedBoat],
             option: speedBoatCopy,
-            optionForValue
+            labelForOption
           })
         ).toBe(true);
         expect(
           isOptionSelected({
             value: [{ ...tugBoat, id: undefined }],
             option: { ...anotherTugBoat, id: undefined },
-            optionForValue
+            labelForOption
           })
         ).toBe(true);
       });
 
       it('should not consider a value selected when "keyForOption" does not return the same string for any item in the array', () => {
         const {
-          uniqueKeyForValue,
-          optionForValue,
+          keyForOption,
+          labelForOption,
           speedBoat,
           speedBoatCopy,
           tugBoat,
@@ -155,22 +155,22 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: [speedBoatCopy],
             option: speedBoat,
-            optionForValue,
-            uniqueKeyForValue
+            labelForOption,
+            keyForOption
           })
         ).toBe(false);
         expect(
           isOptionSelected({
             value: [tugBoat],
             option: anotherTugBoat,
-            optionForValue
+            labelForOption
           })
         ).toBe(false);
         expect(
           isOptionSelected({
             value: [{ ...speedBoatCopy, id: undefined }],
             option: { ...speedBoat, id: undefined },
-            optionForValue
+            labelForOption
           })
         ).toBe(false);
       });
@@ -181,7 +181,7 @@ describe('Util: isOptionSelected', () => {
     describe('when "isOptionEqual" is defined', () => {
       it('should consider a value selected when the "isOptionEqual" returns true', () => {
         const {
-          optionForValue,
+          labelForOption,
           isOptionEqual,
           speedBoat,
           speedBoatCopy
@@ -191,7 +191,7 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: speedBoatCopy,
             option: speedBoat,
-            optionForValue,
+            labelForOption,
             isOptionEqual
           })
         ).toBe(true);
@@ -199,7 +199,7 @@ describe('Util: isOptionSelected', () => {
 
       it('should not consider a value selected when "isOptionEqual" returns false', () => {
         const {
-          optionForValue,
+          labelForOption,
           isOptionEqual,
           tugBoat,
           anotherTugBoat
@@ -209,7 +209,7 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: tugBoat,
             option: anotherTugBoat,
-            optionForValue,
+            labelForOption,
             isOptionEqual
           })
         ).toBe(false);
@@ -219,8 +219,8 @@ describe('Util: isOptionSelected', () => {
     describe('when "isOptionEqual" is not defined', () => {
       it('should consider a value selected when "keyForOption" returns the same string', () => {
         const {
-          uniqueKeyForValue,
-          optionForValue,
+          keyForOption,
+          labelForOption,
           tugBoat,
           anotherTugBoat
         } = setup();
@@ -229,30 +229,30 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: tugBoat,
             option: { ...anotherTugBoat, uniqueKey: tugBoat.uniqueKey },
-            optionForValue,
-            uniqueKeyForValue
+            labelForOption,
+            keyForOption
           })
         ).toBe(true);
         expect(
           isOptionSelected({
             value: tugBoat,
             option: { ...anotherTugBoat, id: tugBoat.id },
-            optionForValue
+            labelForOption
           })
         ).toBe(true);
         expect(
           isOptionSelected({
             value: { ...tugBoat, id: undefined },
             option: { ...anotherTugBoat, id: undefined },
-            optionForValue
+            labelForOption
           })
         ).toBe(true);
       });
 
       it('should not consider a value selected when "keyForOption" does not return the same string', () => {
         const {
-          uniqueKeyForValue,
-          optionForValue,
+          keyForOption,
+          labelForOption,
           speedBoat,
           speedBoatCopy,
           tugBoat
@@ -262,22 +262,22 @@ describe('Util: isOptionSelected', () => {
           isOptionSelected({
             value: speedBoatCopy,
             option: speedBoat,
-            optionForValue,
-            uniqueKeyForValue
+            labelForOption,
+            keyForOption
           })
         ).toBe(false);
         expect(
           isOptionSelected({
             value: tugBoat,
             option: speedBoat,
-            optionForValue
+            labelForOption
           })
         ).toBe(false);
         expect(
           isOptionSelected({
             value: speedBoatCopy,
             option: { ...speedBoat, id: undefined },
-            optionForValue
+            labelForOption
           })
         ).toBe(false);
       });
@@ -285,30 +285,33 @@ describe('Util: isOptionSelected', () => {
   });
 });
 
-describe('util: keyForOption', () => {
-  it('should return uniqueKey property when uniqueKeyForValue is defined', () => {
-    const { optionForValue, uniqueKeyForValue, speedBoat, tugBoat } = setup();
+describe('util: getKeyForOption', () => {
+  it('should return uniqueKey property when keyForOption is defined', () => {
+    const { labelForOption, keyForOption, speedBoat, tugBoat } = setup();
     expect(
-      keyForOption({ option: speedBoat, optionForValue, uniqueKeyForValue })
+      getKeyForOption({ option: speedBoat, labelForOption, keyForOption })
     ).toBe('s');
     expect(
-      keyForOption({ option: tugBoat, optionForValue, uniqueKeyForValue })
+      getKeyForOption({ option: tugBoat, labelForOption, keyForOption })
     ).toBe('t');
   });
 
   it('should return id property when option is an object with an id', () => {
-    const { optionForValue, speedBoat, tugBoat } = setup();
-    expect(keyForOption({ option: speedBoat, optionForValue })).toBe('1');
-    expect(keyForOption({ option: tugBoat, optionForValue })).toBe('2');
+    const { labelForOption, speedBoat, tugBoat } = setup();
+    expect(getKeyForOption({ option: speedBoat, labelForOption })).toBe('1');
+    expect(getKeyForOption({ option: tugBoat, labelForOption })).toBe('2');
   });
 
-  it('should return name property when optionForValue is defined', () => {
-    const { optionForValue, speedBoat, tugBoat } = setup();
+  it('should return name property when labelForOption is defined', () => {
+    const { labelForOption, speedBoat, tugBoat } = setup();
     expect(
-      keyForOption({ option: { ...speedBoat, id: undefined }, optionForValue })
+      getKeyForOption({
+        option: { ...speedBoat, id: undefined },
+        labelForOption
+      })
     ).toBe('Speedy');
     expect(
-      keyForOption({ option: { ...tugBoat, id: undefined }, optionForValue })
+      getKeyForOption({ option: { ...tugBoat, id: undefined }, labelForOption })
     ).toBe('Tugger');
   });
 });

--- a/src/form/option.ts
+++ b/src/form/option.ts
@@ -1,37 +1,104 @@
 import { Page } from '@42.nl/spring-connect';
-import { ReactNode } from 'react';
+
+export type Options<T> = FetchOptionsCallback<T> | T[];
+
+/**
+ * Variant of field compatible where the options the user can choose
+ * are predetermined.
+ */
+export type FieldCompatibleWithPredeterminedOptions<T> = {
+  /**
+   * Is either a callback to fetch the options to display to the user.
+   * When options is a callback it will not execute when the callback
+   * changes, only when the `reloadOptions` changes will the callback
+   * be executed again. This means that it is safe to pass in a
+   * lambda / anonymous / unstable function here.
+   *
+   * Or an array of fixed options.
+   */
+  options: Options<T>;
+
+  /**
+   * Callback to convert an value of type T to an option to show
+   * to the user.
+   */
+  labelForOption: LabelForOption<T>;
+
+  /**
+   * Optional callback which is used to determine if two options
+   * of type T are equal.
+   *
+   * When `isOptionEqual` is not defined the outcome of `labelForOption`
+   * is used to test equality.
+   */
+  isOptionEqual?: IsOptionEqual<T>;
+
+  /**
+   * Optional callback to get a unique key for an option.
+   * This is used to provide each option in the form element a unique key.
+   * Defaults to the 'id' property if it exists, otherwise uses labelForOption.
+   */
+  keyForOption?: KeyForOption<T>;
+
+  /**
+   * Optional callback which is called for every option to determine
+   * if the option can be selected. By default all options can be
+   * selected.
+   */
+  isOptionEnabled?: IsOptionEnabled<T>;
+
+  /**
+   * Optionally a value to detect changes and trigger the
+   * `options` to reload the options, by fetching them again.
+   *
+   * Whenever the value of `reloadOptions` changes the options are
+   * reloaded. This gives the developer an external way to trigger
+   * the reloading of the options.
+   */
+  reloadOptions?: string | number | boolean | null | undefined;
+};
 
 /**
  * Callback to determine the label for a given value of type T.
  * Aka the text the user sees when selecting a value.
  */
-export type OptionForValue<T> = (value: T) => string;
+export type LabelForOption<T> = (option: T) => string;
 
 /**
  * Callback to determine the unique identifier for a given value of type T.
  */
-export type UniqueKeyForValue<T> = (value: T) => string;
+export type KeyForOption<T> = (value: T) => React.Key;
 
-export type OptionEqual<T> = (a: T, b: T) => boolean;
-
-export type RenderOptionsOption<T> = {
-  option: T;
-  isSelected: boolean;
-  toggle: () => void;
-};
-
-export type RenderOptions<T> = (options: RenderOptionsOption<T>[]) => ReactNode;
+/**
+ * Callback to determine if two options are equal to each other
+ */
+export type IsOptionEqual<T> = (a: T, b: T) => boolean;
 
 /**
  * Callback to determine if the option is currently enabled.
  */
-export type OptionEnabledCallback<T> = (option: T) => boolean;
+export type IsOptionEnabled<T> = (option: T) => boolean;
 
-/**
- * Callback which should return a Page of options which can
- * be selected by the user.
- */
-export type OptionsFetcher<T> = () => Promise<Page<T>>;
+export type FetchOptionsCallbackConfig = {
+  /**
+   * The query which was provided by the component. If no query is
+   * present an empty string is provided.
+   */
+  query: string;
+
+  /**
+   * The page number the developer must fetch from the back-end.
+   * Starts at 1.
+   */
+  page: number;
+
+  /**
+   * The desired size which the form component accepts. The developer
+   * should not provide more items than the size, otherwise unintended
+   * things may happen.
+   */
+  size: number;
+};
 
 /**
  * Callback which should return a Page of options which can
@@ -52,66 +119,36 @@ export type OptionsFetcher<T> = () => Promise<Page<T>>;
  * through this parameter.
  */
 export type FetchOptionsCallback<T> = (
-  query: string,
-  page: number,
-  size: number
+  config: FetchOptionsCallbackConfig
 ) => Promise<Page<T>>;
-
-type IsOptionSelectedConfig<T> = {
-  option: T;
-  uniqueKeyForValue?: UniqueKeyForValue<T>;
-  optionForValue: OptionForValue<T>;
-  isOptionEqual?: OptionEqual<T>;
-  value?: T[] | T;
-};
-
-export function isOptionSelected<T>({
-  option,
-  uniqueKeyForValue,
-  optionForValue,
-  isOptionEqual,
-  value
-}: IsOptionSelectedConfig<T>): boolean {
-  if (!value) {
-    return false;
-  }
-
-  if (Array.isArray(value)) {
-    if (isOptionEqual) {
-      return value.some((v) => isOptionEqual(v, option));
-    } else {
-      const key = keyForOption({ option, uniqueKeyForValue, optionForValue });
-      return value.some(
-        (v) =>
-          key === keyForOption({ option: v, uniqueKeyForValue, optionForValue })
-      );
-    }
-  } else {
-    if (isOptionEqual) {
-      return isOptionEqual(value, option);
-    } else {
-      const key = keyForOption({ option, uniqueKeyForValue, optionForValue });
-      return (
-        key ===
-        keyForOption({ option: value, uniqueKeyForValue, optionForValue })
-      );
-    }
-  }
-}
 
 type KeyForOptionConfig<T> = {
   option: T;
-  uniqueKeyForValue?: UniqueKeyForValue<T>;
-  optionForValue: OptionForValue<T>;
+  keyForOption?: KeyForOption<T>;
+  labelForOption: LabelForOption<T>;
 };
 
-export function keyForOption<T>({
+/**
+ * Returns a unique key for an option.
+ *
+ * Will try the following ways to get a unique key in this order:
+ *
+ * 1. Will use: `keyForOption` if provided. In this case we
+ *    must trust the developer to implement it correctly.
+ *
+ * 2. If the options has an `id` we expect that id to be unique and
+ *    that `id` is used as the key.
+ *
+ * 3. As a last resort we will use the `labelForOption` in this case
+ *    the label of the option will become the key.
+ */
+export function getKeyForOption<T>({
   option,
-  uniqueKeyForValue,
-  optionForValue
+  keyForOption,
+  labelForOption
 }: KeyForOptionConfig<T>) {
-  if (uniqueKeyForValue) {
-    return uniqueKeyForValue(option);
+  if (keyForOption) {
+    return keyForOption(option);
   }
 
   // @ts-expect-error Accept that the option could have an id
@@ -120,5 +157,55 @@ export function keyForOption<T>({
     return `${option.id}`;
   }
 
-  return optionForValue(option);
+  return labelForOption(option);
+}
+
+type IsOptionSelectedConfig<T> = {
+  option: T;
+  keyForOption?: KeyForOption<T>;
+  labelForOption: LabelForOption<T>;
+  isOptionEqual?: IsOptionEqual<T>;
+  value?: T[] | T;
+};
+
+/**
+ * Determines if is the option is selected given the value.
+ *
+ * Will prefer to use the `isOptionEqual` to check if the value is
+ * selected, otherwise it will fallback to checking the key.
+ *
+ * Note: always pass along every argument even the optional ones.
+ * so `isOptionSelected` can perform its function best.
+ */
+export function isOptionSelected<T>(
+  config: IsOptionSelectedConfig<T>
+): boolean {
+  const { value } = config;
+
+  if (!value) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((value) => isValueSelected(value, config));
+  } else {
+    return isValueSelected(value, config);
+  }
+}
+
+// Helper for isOptionSelected
+function isValueSelected<T>(
+  value: T,
+  config: IsOptionSelectedConfig<T>
+): boolean {
+  const { option, isOptionEqual, labelForOption, keyForOption } = config;
+
+  if (isOptionEqual) {
+    return isOptionEqual(value, option);
+  } else {
+    const key = getKeyForOption({ option, keyForOption, labelForOption });
+    return (
+      key === getKeyForOption({ option: value, keyForOption, labelForOption })
+    );
+  }
 }

--- a/src/form/story-utils.tsx
+++ b/src/form/story-utils.tsx
@@ -3,6 +3,9 @@ import { Form as ReactFinalForm } from 'react-final-form';
 import { Row, Col, Card, CardBody } from 'reactstrap';
 import SubmitButton from '../core/SubmitButton/SubmitButton';
 import { action } from '@storybook/addon-actions';
+import { Page } from '@42.nl/spring-connect';
+import { FetchOptionsCallbackConfig } from './option';
+import { pageOf } from '../utilities/page/page';
 
 type Props = {
   children: React.ReactNode;
@@ -56,4 +59,142 @@ export function resolveAfter<T>(value: T, after = 1000): Promise<T> {
       resolve(value);
     }, after);
   });
+}
+
+export function IsOptionEqualInfo() {
+  return (
+    <>
+      <p>
+        By default when <strong>isOptionEqual</strong> is not provided the ids
+        of the objects will be compared. If id does not exist the labels for the
+        options coming from <strong>labelForOption</strong> will be compared.
+      </p>
+
+      <p>
+        <strong>
+          You will rarely need <em>isOptionEqual</em> in practice.
+        </strong>
+      </p>
+
+      <p>
+        You will only need to provide a custom <strong>isOptionEqual</strong>{' '}
+        when your objects do not have an <strong>id</strong> or when options
+        will have the same <strong>label</strong>.
+      </p>
+    </>
+  );
+}
+
+export function KeyForOptionInfo() {
+  return (
+    <>
+      <p>
+        By default when <strong>keyForOption</strong> is not provided the id of
+        the object will be used the key. If id does not exist the labels for the
+        options coming from <strong>labelForOption</strong> will be used as the
+        key.
+      </p>
+
+      <p>
+        <strong>
+          You will rarely need <em>keyForOption</em> in practice.
+        </strong>
+      </p>
+
+      <p>
+        You will rarely need <strong>keyForOption</strong> in practice. You will
+        only need to provide a custom <strong>keyForOption</strong> when your
+        objects do not have an <strong>id</strong> or when options will have the
+        same <strong>label</strong>.
+      </p>
+    </>
+  );
+}
+
+export function ReloadOptionsInfo() {
+  return (
+    <p>
+      Whenever <strong>reloadOptions</strong> changes the options are fetched
+      again. Should only be used when <strong>options</strong> is a function
+      which fetches data.
+    </p>
+  );
+}
+
+export type Province = {
+  id: number;
+  label: string;
+  value: string;
+  north: boolean;
+};
+
+export function provinceFetcher({
+  query,
+  page,
+  size
+}: FetchOptionsCallbackConfig): Promise<Page<Province>> {
+  const content = provinces().filter((province) =>
+    province.label.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const result = pageOf(content, page, size);
+
+  return resolveAfter(result);
+}
+
+export function nonExistingProvince(): Province {
+  // Used to test if the option which came from the back-end is
+  // always added even though it does not exist.
+  return {
+    id: 13,
+    value: 'VLAANDEREN',
+    label: 'Vlaanderen',
+    north: false
+  };
+}
+
+export function provinces(): Province[] {
+  return [
+    { id: 1, value: 'GRONINGEN', label: 'Groningen', north: true },
+    { id: 2, value: 'FRIESLAND', label: 'Friesland', north: true },
+    { id: 3, value: 'DRENTHE', label: 'Drenthe', north: true },
+    { id: 4, value: 'OVERIJSSEL', label: 'Overijssel', north: false },
+    { id: 5, value: 'FLEVOLAND', label: 'Flevoland', north: false },
+    { id: 6, value: 'GELDERLAND', label: 'Gelderland', north: false },
+    { id: 7, value: 'UTRECHT', label: 'Utrecht', north: false },
+    {
+      id: 8,
+      value: 'NOORD-HOLLAND',
+      label: 'Noord-Holland',
+      north: true
+    },
+    {
+      id: 9,
+      value: 'ZUID-HOLLAND',
+      label: 'Zuid-Holland',
+      north: false
+    },
+    { id: 10, value: 'ZEELAND', label: 'Zeeland', north: false },
+    {
+      id: 11,
+      value: 'NOORD-BRABANT',
+      label: 'Noord-Brabant',
+      north: false
+    },
+    { id: 12, value: 'LIMBURG', label: 'Limburg', north: false }
+  ];
+}
+
+export function cityFetcher({
+  query,
+  page,
+  size
+}: FetchOptionsCallbackConfig): Promise<Page<Province>> {
+  const content = provinces().filter((province) =>
+    province.label.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const result = pageOf(content, page, size);
+
+  return resolveAfter(result);
 }

--- a/src/form/utils.test.ts
+++ b/src/form/utils.test.ts
@@ -1,33 +1,25 @@
-import { getState, doBlur } from './utils';
+import { getState, doBlur, alwaysTrue } from './utils';
 
 describe('getState', () => {
-  expect(getState({ hasErrors: true, touched: true})).toEqual(
-    {
-      color: 'danger',
-      valid: false
-    }
-  );
+  expect(getState({ hasErrors: true, touched: true })).toEqual({
+    color: 'danger',
+    valid: false
+  });
 
-  expect(getState({ hasErrors: true, touched: false})).toEqual(
-    {
-      color: '',
-      valid: undefined
-    }
-  );
+  expect(getState({ hasErrors: true, touched: false })).toEqual({
+    color: '',
+    valid: undefined
+  });
 
-  expect(getState({ hasErrors: false, touched: false})).toEqual(
-    {
-      color: '',
-      valid: undefined
-    }
-  );
+  expect(getState({ hasErrors: false, touched: false })).toEqual({
+    color: '',
+    valid: undefined
+  });
 
-  expect(getState({ hasErrors: false, touched: undefined})).toEqual(
-    {
-      color: '',
-      valid: undefined
-    }
-  );
+  expect(getState({ hasErrors: false, touched: undefined })).toEqual({
+    color: '',
+    valid: undefined
+  });
 });
 
 test('doBlur', () => {
@@ -36,4 +28,13 @@ test('doBlur', () => {
   const onBlur = jest.fn();
   expect(doBlur(onBlur)).toBe(undefined);
   expect(onBlur).toBeCalledTimes(1);
+});
+
+test('alwaysTrue', () => {
+  expect(alwaysTrue()).toBe(true);
+  expect(alwaysTrue()).toBe(true);
+  expect(alwaysTrue()).toBe(true);
+  expect(alwaysTrue()).toBe(true);
+  expect(alwaysTrue()).toBe(true);
+  expect(alwaysTrue()).toBe(true);
 });

--- a/src/form/utils.ts
+++ b/src/form/utils.ts
@@ -19,3 +19,7 @@ export function doBlur(onBlur?: () => void): void {
     onBlur();
   }
 }
+
+export function alwaysTrue(): true {
+  return true;
+}

--- a/src/table/FormTable/FormTable.stories.tsx
+++ b/src/table/FormTable/FormTable.stories.tsx
@@ -265,7 +265,7 @@ storiesOf('table/FormTable', module)
                     name="eyeColor"
                     placeholder="Enter eye color"
                     options={['green', 'blue', 'brown']}
-                    optionForValue={(option) => option}
+                    labelForOption={(option) => option}
                     jarb={{
                       validator: 'Person.eyeColor',
                       label: 'Eye color'
@@ -325,8 +325,7 @@ storiesOf('table/FormTable', module)
                       label: 'Favorite movie'
                     }}
                     multiple={false}
-                    optionForValue={(option) => option.name}
-                    fetchOptions={(query, page, size) =>
+                    options={({ query, page, size }) =>
                       Promise.resolve(
                         pageOf(
                           movies
@@ -341,6 +340,7 @@ storiesOf('table/FormTable', module)
                         )
                       )
                     }
+                    labelForOption={(option) => option.name}
                     errorMode="tooltip"
                     alignButton="right"
                   />
@@ -382,7 +382,7 @@ storiesOf('table/FormTable', module)
                     name="sex"
                     className="ml-1"
                     options={['male', 'female']}
-                    optionForValue={(option) => option}
+                    labelForOption={(option) => option}
                     horizontal={true}
                     jarb={{
                       validator: 'Person.sex',
@@ -648,7 +648,7 @@ storiesOf('table/FormTable', module)
                       name="eyeColor"
                       placeholder="Enter eye color"
                       options={['green', 'blue', 'brown']}
-                      optionForValue={(option) => option}
+                      labelForOption={(option) => option}
                       jarb={{
                         validator: 'Person.eyeColor',
                         label: 'Eye color'
@@ -708,8 +708,8 @@ storiesOf('table/FormTable', module)
                         label: 'Favorite movie'
                       }}
                       multiple={false}
-                      optionForValue={(option) => option.name}
-                      fetchOptions={(query, page, size) =>
+                      labelForOption={(option) => option.name}
+                      options={({ query, page, size }) =>
                         Promise.resolve(
                           pageOf(
                             movies
@@ -764,7 +764,7 @@ storiesOf('table/FormTable', module)
                       name="sex"
                       className="ml-1"
                       options={['male', 'female']}
-                      optionForValue={(option) => option}
+                      labelForOption={(option) => option}
                       horizontal={true}
                       jarb={{
                         validator: 'Person.sex',
@@ -1093,7 +1093,7 @@ storiesOf('table/FormTable', module)
                     name="eyeColor"
                     placeholder="Enter eye color"
                     options={['green', 'blue', 'brown']}
-                    optionForValue={(option) => option}
+                    labelForOption={(option) => option}
                     jarb={{
                       validator: 'Person.eyeColor',
                       label: 'Eye color'
@@ -1153,8 +1153,7 @@ storiesOf('table/FormTable', module)
                       label: 'Favorite movie'
                     }}
                     multiple={false}
-                    optionForValue={(option) => option.name}
-                    fetchOptions={(query, page, size) =>
+                    options={({ query, page, size }) =>
                       Promise.resolve(
                         pageOf(
                           movies
@@ -1169,6 +1168,7 @@ storiesOf('table/FormTable', module)
                         )
                       )
                     }
+                    labelForOption={(option) => option.name}
                     errorMode="tooltip"
                     alignButton="right"
                   />
@@ -1210,7 +1210,7 @@ storiesOf('table/FormTable', module)
                     name="sex"
                     className="ml-1"
                     options={['male', 'female']}
-                    optionForValue={(option) => option}
+                    labelForOption={(option) => option}
                     horizontal={true}
                     jarb={{
                       validator: 'Person.sex',
@@ -1585,7 +1585,7 @@ storiesOf('table/FormTable', module)
                     name="eyeColor"
                     placeholder="Enter eye color"
                     options={['green', 'blue', 'brown']}
-                    optionForValue={(option) => option}
+                    labelForOption={(option) => option}
                     jarb={{
                       validator: 'Person.eyeColor',
                       label: 'Eye color'
@@ -1645,8 +1645,7 @@ storiesOf('table/FormTable', module)
                       label: 'Favorite movie'
                     }}
                     multiple={false}
-                    optionForValue={(option) => option.name}
-                    fetchOptions={(query, page, size) =>
+                    options={({ query, page, size }) =>
                       Promise.resolve(
                         pageOf(
                           movies
@@ -1661,6 +1660,7 @@ storiesOf('table/FormTable', module)
                         )
                       )
                     }
+                    labelForOption={(option) => option.name}
                     errorMode="tooltip"
                     alignButton="right"
                   />
@@ -1702,7 +1702,7 @@ storiesOf('table/FormTable', module)
                     name="sex"
                     className="ml-1"
                     options={['male', 'female']}
-                    optionForValue={(option) => option}
+                    labelForOption={(option) => option}
                     horizontal={true}
                     jarb={{
                       validator: 'Person.sex',

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -30,8 +30,8 @@ export function adminUser(): User {
   return {
     id: 42,
     email: 'admin@42.nl',
-    firstName: 'admin',
-    lastName: 'user',
+    firstName: 'Addie',
+    lastName: 'Admin',
     active: true,
     roles: ['ADMIN']
   };
@@ -41,8 +41,8 @@ export function userUser(): User {
   return {
     id: 1337,
     email: 'user@42.nl',
-    firstName: 'test',
-    lastName: 'user',
+    firstName: 'Ulysses',
+    lastName: 'User',
     active: false,
     roles: ['USER']
   };
@@ -52,8 +52,8 @@ export function coordinatorUser(): User {
   return {
     id: 777,
     email: 'coordinator@42.nl',
-    firstName: 'coordinator',
-    lastName: 'user',
+    firstName: 'Cordelia',
+    lastName: 'Coordinator',
     active: false,
     roles: ['ADMIN', 'USER']
   };
@@ -70,9 +70,13 @@ export function nobodyUser(): User {
   };
 }
 
+export function listOfUsers(): User[] {
+  return [adminUser(), coordinatorUser(), userUser()];
+}
+
 export function pageOfUsers(): Page<User> {
   return {
-    content: [adminUser(), coordinatorUser(), userUser()],
+    content: listOfUsers(),
     last: false,
     totalElements: 9,
     totalPages: 3,
@@ -81,4 +85,10 @@ export function pageOfUsers(): Page<User> {
     first: false,
     numberOfElements: 3
   };
+}
+
+export function pageOfUsersFetcher(): Promise<Page<User>> {
+  return new Promise((resolve) => {
+    resolve(pageOfUsers());
+  });
 }


### PR DESCRIPTION
There exists a class of form components within 42.nl/ui which allow
the user to select values from predefined options. These are:

1. Select
2. RadioGroup,
3. ModalPickerSingle
4. TypeaheadSingle
5. ModalPickerMultiple
6. TypeaheadMultiple
7. CheckboxMultipleSelect,
8. ValuePicker

Before this commit they were not fully exchangeable with each other.
This was because some components supported only fetching the options
asynchronously, and others supported both.

With this commit the props have been unified for the aforementioned
components, this allows the user to more quickly swap between the
components.

This does not mean that all props are now unified. Some props will still
be unique to the components. Take for example the `addButton` prop on
the `ModalPicker*` that is still unique to the modal pickers.

The achieve this the following has been done:

1. Created a type called `FieldCompatibleWithPredeterminedOptions` which
   holds all common props for the components. This way the typings are
   shared which leads to less code. But more importantly a new component
   would know more easily which props to accept to be uniform.

2. All components now use the `useOptions` hook. This way the logic of
   either fetching options or using options as an array is in one place.

   To support all components `useOptions` has been extended to
   understand that not every components wants the selected value to
   be added, this prop is called `optionsShouldAlwaysContainValue`.

   The `useOptions` now returns a Page instead of an array to support
   paging which the modal pickers needed. This means accepting the
   page number and size as well.

   It will also accept a `query` and pass that along to the fetcher.
   When the options is an array it will use the query to filter based
   on the label.

   The `FetchOptionsCallback` now gives the user an object instead of
   three separate parameters, this should make it easier for our users
   to pick out the `size` without having to define two dud parameters.

   It has also been refactored so it uses one less effect.

3. In order to use the `useOptions` hook `ModalPickerSingle`,
   `ModalPickerMultiple` and the `CheckboxMultipleSelect` had to
   become functional components. This also meant updating all tests.

4. Moved more behavior from `ModalPicker*` to `ModalPicker` to make
   testing easier, and to reduce code. It now renders the loading state,
   empty state and renderOptions variant.

5. `ModalPickerSingleOpenerProps` renam

Also took the opportunity rename the props to make them more easy to
understand. This is a breaking change. The following renames occurred:

1 `optionForValue` is now `labelForOption`. Reason: `options` is what
  the developer must provide as a prop. We want for each of those
  `options` to get a `label` to display to the end user. The term
  `value` was just confusing as it could be interpreted as the `value`
  prop from the form component.

2 `uniqueKeyForValue` is now `keyForOption`. Reason: keys in react are
  unique and react developers know this. So it could be shorter.

3. ModalPicker: `displayValues` is now `renderValue`. Reason render
   props start with render by convention in react.

4. `ModalPickerValueTruncator` and `ModalPickerOpener` renamed `values`
   prop to `value` this is also a react convention. It is called value
   even if it might be an array.

Also updated the stories of the components so they more closely match
each other. Also added a more lively example by using dutch provinces
as the options. Added explanations to the stories for `isOptionEqual`,
`keyForOption` and `reloadOptions`.

Added a function which always returns `true` called `alwaysTrue` which
is the default for `isOptionEnabled`.

The fixtures for the users now have more unique sounding names, to make
distinguishing between them easier.