### PR TITLE
improvement: the isDateBetween and isDateBetweenValidator work better

### DIFF
--- a/src/form/DateTimeInput/checkers.test.ts
+++ b/src/form/DateTimeInput/checkers.test.ts
@@ -176,8 +176,8 @@ describe('isDateAfter', () => {
 });
 
 describe('isDateBetween', () => {
-  it('should when start is undefined allow every date', () => {
-    const isBetween = isDateBetween(undefined, '2020-05-09');
+  it('should when start, and end are both undefined allow every date', () => {
+    const isBetween = isDateBetween(undefined, undefined);
 
     expect(isBetween('2020-05-05')).toBe(true);
     expect(isBetween('2020-05-06')).toBe(true);
@@ -185,13 +185,44 @@ describe('isDateBetween', () => {
     expect(isBetween('2020-05-08')).toBe(true);
   });
 
-  it('should when end is undefined allow every date', () => {
-    const isBetween = isDateBetween('2020-05-07', undefined);
+  describe('only start should fallback to after', () => {
+    test('exclusive', () => {
+      const isBetween = isDateBetween('2020-05-07', undefined);
 
-    expect(isBetween('2020-05-05')).toBe(true);
-    expect(isBetween('2020-05-06')).toBe(true);
-    expect(isBetween('2020-05-07')).toBe(true);
-    expect(isBetween('2020-05-08')).toBe(true);
+      expect(isBetween('2020-05-06')).toBe(false);
+      expect(isBetween('2020-05-07')).toBe(false);
+      expect(isBetween('2020-05-08')).toBe(true);
+    });
+
+    test('inclusive', () => {
+      const isBetween = isDateBetween('2020-05-07', undefined, {
+        startInclusive: true
+      });
+
+      expect(isBetween('2020-05-06')).toBe(false);
+      expect(isBetween('2020-05-07')).toBe(true);
+      expect(isBetween('2020-05-08')).toBe(true);
+    });
+  });
+
+  describe('only end should fallback to before', () => {
+    it('exclusive', () => {
+      const isBetween = isDateBetween(undefined, '2020-05-09');
+
+      expect(isBetween('2020-05-08')).toBe(true);
+      expect(isBetween('2020-05-09')).toBe(false);
+      expect(isBetween('2020-05-10')).toBe(false);
+    });
+
+    it('inclusive', () => {
+      const isBetween = isDateBetween(undefined, '2020-05-09', {
+        endInclusive: true
+      });
+
+      expect(isBetween('2020-05-08')).toBe(true);
+      expect(isBetween('2020-05-09')).toBe(true);
+      expect(isBetween('2020-05-10')).toBe(false);
+    });
   });
 
   describe('start and end exclusive', () => {

--- a/src/form/DateTimeInput/checkers.ts
+++ b/src/form/DateTimeInput/checkers.ts
@@ -139,15 +139,24 @@ export function isDateBetween(
     endInclusive: false
   }
 ): DateChecker {
-  if (!start) {
-    return alwaysTrue;
-  }
-
-  if (!end) {
+  // If there is no start and end allow the user to pick all dates
+  if (!start && !end) {
     return alwaysTrue;
   }
 
   const { startInclusive, endInclusive } = config;
+
+  if (!end) {
+    // If there is no end but a start then the date must at least
+    // lie after the start.
+    return isDateAfter(start, { inclusive: startInclusive });
+  }
+
+  if (!start) {
+    // If there is no start but an end then the date must at least
+    // lie before the end.
+    return isDateBefore(end, { inclusive: endInclusive });
+  }
 
   return (date?: MomentInput) => {
     if (!date) {

--- a/src/form/DateTimeInput/validators.test.ts
+++ b/src/form/DateTimeInput/validators.test.ts
@@ -235,7 +235,7 @@ describe('isDateAfter', () => {
 });
 
 describe('isDateBetween', () => {
-  it('should when start is undefined allow every date', () => {
+  it('should when start, and end are both undefined allow every date', () => {
     const isBetween = isDateBetweenValidator({
       label: 'reminder',
       start: { path: 'start', label: 'start' },
@@ -253,22 +253,88 @@ describe('isDateBetween', () => {
     expect(isBetween('2020-05-08', values)).toBe(undefined);
   });
 
-  it('should when end is undefined allow every date', () => {
-    const isBetween = isDateBetweenValidator({
-      label: 'reminder',
-      start: { path: 'start', label: 'start' },
-      end: { path: 'end', label: 'end' }
+  describe('only start should fallback to after', () => {
+    test('exclusive', () => {
+      const isBetween = isDateBetweenValidator({
+        label: 'reminder',
+        start: { path: 'start', label: 'start' },
+        end: { path: 'end', label: 'end' }
+      });
+
+      const values = {
+        start: '2020-05-07',
+        end: undefined
+      };
+
+      expect(isBetween('2020-05-06', values)).toBe(
+        `The "reminder" must be after the "start"`
+      );
+      expect(isBetween('2020-05-07', values)).toBe(
+        `The "reminder" must be after the "start"`
+      );
+      expect(isBetween('2020-05-08', values)).toBe(undefined);
     });
 
-    const values = {
-      start: '2020-05-07',
-      end: undefined
-    };
+    test('inclusive', () => {
+      const isBetween = isDateBetweenValidator({
+        label: 'reminder',
+        start: { path: 'start', label: 'start', inclusive: true },
+        end: { path: 'end', label: 'end' }
+      });
 
-    expect(isBetween('2020-05-05', values)).toBe(undefined);
-    expect(isBetween('2020-05-06', values)).toBe(undefined);
-    expect(isBetween('2020-05-07', values)).toBe(undefined);
-    expect(isBetween('2020-05-08', values)).toBe(undefined);
+      const values = {
+        start: '2020-05-07',
+        end: undefined
+      };
+
+      expect(isBetween('2020-05-06', values)).toBe(
+        `The "reminder" must be after the "start"`
+      );
+      expect(isBetween('2020-05-07', values)).toBe(undefined);
+      expect(isBetween('2020-05-08', values)).toBe(undefined);
+    });
+  });
+
+  describe('only end should fallback to before', () => {
+    it('exclusive', () => {
+      const isBetween = isDateBetweenValidator({
+        label: 'reminder',
+        start: { path: 'start', label: 'start' },
+        end: { path: 'end', label: 'end' }
+      });
+
+      const values = {
+        start: undefined,
+        end: '2020-05-09'
+      };
+
+      expect(isBetween('2020-05-08', values)).toBe(undefined);
+      expect(isBetween('2020-05-09', values)).toBe(
+        `The "reminder" must be before the "end"`
+      );
+      expect(isBetween('2020-05-10', values)).toBe(
+        `The "reminder" must be before the "end"`
+      );
+    });
+
+    it('inclusive', () => {
+      const isBetween = isDateBetweenValidator({
+        label: 'reminder',
+        start: { path: 'start', label: 'start' },
+        end: { path: 'end', label: 'end', inclusive: true }
+      });
+
+      const values = {
+        start: undefined,
+        end: '2020-05-09'
+      };
+
+      expect(isBetween('2020-05-08', values)).toBe(undefined);
+      expect(isBetween('2020-05-09', values)).toBe(undefined);
+      expect(isBetween('2020-05-10', values)).toBe(
+        `The "reminder" must be before the "end"`
+      );
+    });
   });
 
   it('should support a custom error message', () => {

--- a/src/form/DateTimeInput/validators.ts
+++ b/src/form/DateTimeInput/validators.ts
@@ -131,12 +131,7 @@ export function isDateBeforeValidator(
     if (result) {
       return undefined;
     } else {
-      return t({
-        key: 'DateTimeInput.DATE_BEFORE_ERROR',
-        fallback: `The "${label}" must be before the "${end.label}"`,
-        data: { start: label, end: end.label },
-        overrideText: overrideErrorText
-      });
+      return dateBeforeError({ label, end, overrideErrorText });
     }
   };
 }
@@ -186,12 +181,7 @@ export function isDateAfterValidator(
     if (result) {
       return undefined;
     } else {
-      return t({
-        key: 'DateTimeInput.DATE_AFTER_ERROR',
-        fallback: `The "${label}" must be after the "${start.label}"`,
-        data: { start: start.label, end: label },
-        overrideText: overrideErrorText
-      });
+      return dateAfterError({ label, start, overrideErrorText });
     }
   };
 }
@@ -248,6 +238,14 @@ export function isDateBetweenValidator(
     if (result) {
       return undefined;
     } else {
+      if (!before) {
+        return dateAfterError({ label, start, overrideErrorText });
+      }
+
+      if (!after) {
+        return dateBeforeError({ label, end, overrideErrorText });
+      }
+
       return t({
         key: 'DateTimeInput.DATE_BETWEEN_ERROR',
         fallback: `The "${label}" must be between the "${start.label}" and "${end.label}"`,
@@ -256,4 +254,38 @@ export function isDateBetweenValidator(
       });
     }
   };
+}
+
+function dateAfterError({
+  label,
+  start,
+  overrideErrorText
+}: {
+  label;
+  start: Start;
+  overrideErrorText?: string;
+}): string {
+  return t({
+    key: 'DateTimeInput.DATE_AFTER_ERROR',
+    fallback: `The "${label}" must be after the "${start.label}"`,
+    data: { start: start.label, end: label },
+    overrideText: overrideErrorText
+  });
+}
+
+function dateBeforeError({
+  label,
+  end,
+  overrideErrorText
+}: {
+  label;
+  end: End;
+  overrideErrorText?: string;
+}): string {
+  return t({
+    key: 'DateTimeInput.DATE_BEFORE_ERROR',
+    fallback: `The "${label}" must be before the "${end.label}"`,
+    data: { start: label, end: end.label },
+    overrideText: overrideErrorText
+  });
 }


### PR DESCRIPTION
Before the `isDateBetween` and `isDateBetweenValidator` would only
check if both the start and end date were provided. Now they work when
either are provided.

The reason that this can work is that when the start is 2020-01-01 we
and there is no end. A date of 2000-01-01 can never pass because it lies
before the start date. The same is true for when you only have an end
date and no start date.