### PR TITLE
improvement: Button's now accept margin top and bottom.

### DIFF
--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -158,7 +158,14 @@ export default function Button({
     ) : null;
 
     return (
-      <span className={classNames('button', className, color)}>
+      <span
+        className={classNames(
+          'button',
+          fullWidth ? 'd-block' : 'd-inline-block',
+          className,
+          color
+        )}
+      >
         <RSButton
           onClick={handleOnClick}
           disabled={inProgress || disabled}
@@ -181,8 +188,8 @@ export default function Button({
           color,
           fullWidth ? 'd-flex' : 'd-inline-block',
           {
-            'justify-contents-start': fullWidth && iconPosition === 'left',
-            'justify-contents-end': fullWidth && iconPosition === 'right'
+            'justify-content-start': fullWidth && iconPosition === 'left',
+            'justify-content-end': fullWidth && iconPosition === 'right'
           }
         )}
       >

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component: Button ui button disabled is disabled 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -23,7 +23,7 @@ exports[`Component: Button ui button disabled is disabled 1`] = `
 
 exports[`Component: Button ui button disabled is enabled 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -44,7 +44,7 @@ exports[`Component: Button ui button disabled is enabled 1`] = `
 
 exports[`Component: Button ui button full-width 1`] = `
 <span
-  className="button primary"
+  className="button d-block primary"
 >
   <Button
     block={true}
@@ -65,7 +65,7 @@ exports[`Component: Button ui button full-width 1`] = `
 
 exports[`Component: Button ui button normal inProgress is false 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -85,7 +85,7 @@ exports[`Component: Button ui button normal inProgress is false 1`] = `
 
 exports[`Component: Button ui button normal inProgress is true 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -111,7 +111,7 @@ exports[`Component: Button ui button normal inProgress is true 1`] = `
 
 exports[`Component: Button ui button outline inProgress is false 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -132,7 +132,7 @@ exports[`Component: Button ui button outline inProgress is false 1`] = `
 
 exports[`Component: Button ui button outline inProgress is true 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -159,7 +159,7 @@ exports[`Component: Button ui button outline inProgress is true 1`] = `
 
 exports[`Component: Button ui button size can override size 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -179,7 +179,7 @@ exports[`Component: Button ui button size can override size 1`] = `
 
 exports[`Component: Button ui button size use md by default 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -199,7 +199,7 @@ exports[`Component: Button ui button size use md by default 1`] = `
 
 exports[`Component: Button ui button with icon normal inProgress is false 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -223,7 +223,7 @@ exports[`Component: Button ui button with icon normal inProgress is false 1`] = 
 
 exports[`Component: Button ui button with icon normal inProgress is true 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -249,7 +249,7 @@ exports[`Component: Button ui button with icon normal inProgress is true 1`] = `
 
 exports[`Component: Button ui button with icon normal with icon on the right 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -273,7 +273,7 @@ exports[`Component: Button ui button with icon normal with icon on the right 1`]
 
 exports[`Component: Button ui button with icon outline inProgress is false 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -298,7 +298,7 @@ exports[`Component: Button ui button with icon outline inProgress is false 1`] =
 
 exports[`Component: Button ui button with icon outline inProgress is true 1`] = `
 <span
-  className="button primary"
+  className="button d-inline-block primary"
 >
   <Button
     color="primary"
@@ -353,7 +353,7 @@ exports[`Component: Button ui icon only disabled is enabled 1`] = `
 
 exports[`Component: Button ui icon only full-width full width and icon left 1`] = `
 <span
-  className="button primary d-flex justify-contents-start"
+  className="button primary d-flex justify-content-start"
 >
   <Icon
     color="primary"
@@ -366,7 +366,7 @@ exports[`Component: Button ui icon only full-width full width and icon left 1`] 
 
 exports[`Component: Button ui icon only full-width full width and icon right 1`] = `
 <span
-  className="button primary d-flex justify-contents-end"
+  className="button primary d-flex justify-content-end"
 >
   <Icon
     color="primary"


### PR DESCRIPTION
Before the `Button` component would not accept `my`, `mt` or `mb`
bootstrap margin classes because a `<span>` is rendered which has
`display: inline;`

The reason for this is because `display: inline;` cannot use top or
bottom margins. Now it is a `display: inline-block` which does support
top and bottom margins when not rendered at `fullWidth`, and `d-block`
when rendered as `fullWidth`.

Now the `Button` is rendered as an `

Also fixed the full-width mode of the `Button` icon it misspelled:
`justify-content-start` as `justify-contents-start` and
`justify-end-start` as `justify-contents-end`.

Closes #458