### PR TITLE
improvement: now exposing more types and utils. Changed names of types.

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
-type Config = {
+export type Config = {
   showRequiredMarkInLabel: boolean;
 };
 

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
-export type IconPosition = 'left' | 'right';
+export type ButtonIconPosition = 'left' | 'right';
 
 export type Props = {
   /**
@@ -63,7 +63,7 @@ export type Props = {
    *
    * Only applicable when the `icon` prop is set.
    */
-  iconPosition?: IconPosition;
+  iconPosition?: ButtonIconPosition;
 
   /**
    * Optionally whether or not to show the button only as an outline.

--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -13,7 +13,7 @@ import { Icon } from '../Icon';
 import { BootstrapSize } from '../types';
 import { useId } from '../../hooks/useId/useId';
 
-type SearchInputApi = {
+export type SearchInputApi = {
   /**
    * Sets the value of the SearchInput's inner <input> element
    * cancels any active debounce, and calls props.onChange with

--- a/src/form/DateTimeInput/DateTimeInput.stories.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.stories.tsx
@@ -306,9 +306,15 @@ storiesOf('Form/DateTimeInput', module)
     );
   })
   .add('jarb range', () => {
+    type AppointmentFormData = {
+      start: Date;
+      end: Date;
+    };
+
     return (
-      <ReactFinalForm
+      <ReactFinalForm<AppointmentFormData>
         onSubmit={() => action('form submitted')}
+        initialValues={{ start: new Date(), end: new Date() }}
         render={({ handleSubmit, submitting, values, errors }) => (
           // Do not render a <form> here as it will submit the form when
           // the submit button is pressed.

--- a/src/form/DateTimeInput/DateTimeInput.test.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.test.tsx
@@ -5,7 +5,10 @@ import toJson from 'enzyme-to-json';
 import moment from 'moment';
 import Datetime from 'react-datetime';
 
-import DateTimeInput, { IsDateAllowed, Mode } from './DateTimeInput';
+import DateTimeInput, {
+  DateTimeInputIsDateAllowed,
+  DateTimeInputMode
+} from './DateTimeInput';
 import * as FormatError from './hooks/useHasFormatError';
 import * as IsModalOpen from './hooks/useIsModalOpen';
 import * as UseSetLastStringValue from './hooks/useSetLastStringValue';
@@ -25,9 +28,9 @@ describe('Component: DateTimeInput', () => {
     mode
   }: {
     value?: Date;
-    isDateAllowed?: IsDateAllowed;
+    isDateAllowed?: DateTimeInputIsDateAllowed;
     hasLabel?: boolean;
-    mode?: Mode;
+    mode?: DateTimeInputMode;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();

--- a/src/form/DateTimeInput/DateTimeInput.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.tsx
@@ -23,9 +23,12 @@ import { FieldCompatible } from '../types';
 /**
  * Callback which returns whether a date is selectable.
  */
-export type IsDateAllowed = (date: Moment, selectedDate?: Moment) => boolean;
+export type DateTimeInputIsDateAllowed = (
+  date: Moment,
+  selectedDate?: Moment
+) => boolean;
 
-export type Mode = 'modal' | 'default';
+export type DateTimeInputMode = 'modal' | 'default';
 
 export type Props = FieldCompatible<Date, Date | undefined> & {
   /**
@@ -53,7 +56,7 @@ export type Props = FieldCompatible<Date, Date | undefined> & {
    * Is ran for every date which is displayed. By default every
    * date can be selected.
    */
-  isDateAllowed?: IsDateAllowed;
+  isDateAllowed?: DateTimeInputIsDateAllowed;
 
   /**
    * Optionally the locale moment js should use.
@@ -73,7 +76,7 @@ export type Props = FieldCompatible<Date, Date | undefined> & {
    * Whether or not the date picker should be displayed in a modal.
    * Defaults to opening in a tooltip-like layout.
    */
-  mode?: Mode;
+  mode?: DateTimeInputMode;
 
   /**
    * Optionally customized text within the DateTimeModal component.

--- a/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
+++ b/src/form/DateTimeInput/DateTimeModal/DateTimeModal.tsx
@@ -3,7 +3,7 @@ import Datetime from 'react-datetime';
 import moment, { Moment } from 'moment';
 import { constant, get } from 'lodash';
 
-import { IsDateAllowed } from '../DateTimeInput';
+import { DateTimeInputIsDateAllowed } from '../DateTimeInput';
 import { DateFormat, TimeFormat } from '../types';
 import { t } from '../../../utilities/translation/translation';
 import { useValue } from './useValue';
@@ -70,7 +70,7 @@ type Props = {
    * Is ran for every date which is displayed. By default every
    * date can be selected.
    */
-  isDateAllowed?: IsDateAllowed;
+  isDateAllowed?: DateTimeInputIsDateAllowed;
 
   /**
    * When true, input time values will be interpreted as UTC (Zulu time)
@@ -126,7 +126,7 @@ export function DateTimeModal(props: Props) {
         input={false}
         open={true}
         closeOnSelect={false}
-        onChange={x => setValue(x)}
+        onChange={(x) => setValue(x)}
         value={value}
         dateFormat={dateFormat}
         timeFormat={timeFormat}

--- a/src/form/DateTimeInput/checkers.ts
+++ b/src/form/DateTimeInput/checkers.ts
@@ -6,9 +6,9 @@ import { alwaysTrue } from '../utils';
  * or not by returning a boolean. When `true` is returned the date
  * passes, when `false` is returned the date failed the check.
  */
-type DateChecker = (date?: MomentInput) => boolean;
+export type DateChecker = (date?: MomentInput) => boolean;
 
-type isDateBeforeConfig = {
+type IsDateBeforeConfig = {
   /**
    * Whether or not the end date should be inclusive or not.
    *
@@ -27,12 +27,12 @@ type isDateBeforeConfig = {
  * Useful for the `DateTimeInput` components `isDateAllowed` prop.
  *
  * @param {MomentInput} end The end date to which the date must be before.
- * @param {Config} config The configuration of the isDateBefore function.
+ * @param {IsDateBeforeConfig} config The configuration of the isDateBefore function.
  * @returns {DateValidator} A date validator function which checks if the date lies before the end date.
  */
 export function isDateBefore(
   end: MomentInput,
-  config: isDateBeforeConfig = { inclusive: false }
+  config: IsDateBeforeConfig = { inclusive: false }
 ): DateChecker {
   const { inclusive } = config;
 
@@ -53,7 +53,7 @@ export function isDateBefore(
   };
 }
 
-type isDateAfterConfig = {
+type IsDateAfterConfig = {
   /**
    * Whether or not the start date should be inclusive or not.
    *
@@ -72,12 +72,12 @@ type isDateAfterConfig = {
  * Useful for the `DateTimeInput` components `isDateAllowed` prop.
  *
  * @param {MomentInput} start The start date to which the date must be after.
- * @param {Config} config The configuration of the isDateAfter function.
+ * @param {IsDateAfterConfig} config The configuration of the isDateAfter function.
  * @returns {DateValidator} A date validator function which checks if the date lies after the start date.
  */
 export function isDateAfter(
   start: MomentInput,
-  config: isDateAfterConfig = { inclusive: false }
+  config: IsDateAfterConfig = { inclusive: false }
 ): DateChecker {
   const { inclusive } = config;
 

--- a/src/form/DateTimeInput/utils.ts
+++ b/src/form/DateTimeInput/utils.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { Mask } from '../Input/Input';
+import { InputMask } from '../Input/Input';
 import { DateFormat, TimeFormat } from './types';
 
 export function combineFormat(
@@ -22,7 +22,7 @@ export function combineFormat(
 export function formatToMask(
   dateFormat: DateFormat,
   timeFormat: TimeFormat
-): Mask {
+): InputMask {
   const dateMask = dateFormatToMask(dateFormat);
 
   const timeMask = timeFormatToMask(timeFormat);
@@ -38,7 +38,7 @@ export function formatToMask(
   }
 }
 
-function timeFormatToMask(timeFormat: TimeFormat): Mask {
+function timeFormatToMask(timeFormat: TimeFormat): InputMask {
   if (timeFormat === false) {
     return [];
   }
@@ -46,7 +46,7 @@ function timeFormatToMask(timeFormat: TimeFormat): Mask {
   return timeFormat.split('').map((char) => (char === ':' ? ':' : /\d/));
 }
 
-function dateFormatToMask(dateFormat: DateFormat): Mask {
+function dateFormatToMask(dateFormat: DateFormat): InputMask {
   if (dateFormat === false) {
     return [];
   }

--- a/src/form/DateTimeInput/validators.test.ts
+++ b/src/form/DateTimeInput/validators.test.ts
@@ -15,10 +15,10 @@ describe('isDateBefore', () => {
       end: undefined
     };
 
-    expect(isBefore('2020-05-05', values)).toBe(undefined);
-    expect(isBefore('2020-05-06', values)).toBe(undefined);
-    expect(isBefore('2020-05-07', values)).toBe(undefined);
-    expect(isBefore('2020-05-08', values)).toBe(undefined);
+    expect(isBefore(new Date('2020-05-05'), values)).toBe(undefined);
+    expect(isBefore(new Date('2020-05-06'), values)).toBe(undefined);
+    expect(isBefore(new Date('2020-05-07'), values)).toBe(undefined);
+    expect(isBefore(new Date('2020-05-08'), values)).toBe(undefined);
   });
 
   it('should support a custom error message', () => {
@@ -29,10 +29,10 @@ describe('isDateBefore', () => {
     });
 
     const values = {
-      end: '2020-05-08 12:00:00'
+      end: new Date('2020-05-08 12:00:00')
     };
 
-    expect(isBefore('2020-05-08 12:00:01', values)).toBe(
+    expect(isBefore(new Date('2020-05-08 12:00:01'), values)).toBe(
       'This is a custom error'
     );
   });
@@ -45,16 +45,17 @@ describe('isDateBefore', () => {
       });
 
       const values = {
-        end: '2020-05-08'
+        end: new Date('2020-05-08')
       };
 
-      expect(isBefore('2020-05-07', values)).toBe(undefined);
-      expect(isBefore('2020-05-08', values)).toBe(
+      expect(isBefore(new Date('2020-05-07'), values)).toBe(undefined);
+      expect(isBefore(new Date('2020-05-08'), values)).toBe(
         `The "start" must be before the "end"`
       );
-      expect(isBefore('2020-05-09', values)).toBe(
+      expect(isBefore(new Date('2020-05-09'), values)).toBe(
         `The "start" must be before the "end"`
       );
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBefore(undefined, values)).toBe(undefined);
     });
 
@@ -65,16 +66,17 @@ describe('isDateBefore', () => {
       });
 
       const values = {
-        end: '2020-05-08 12:00:00'
+        end: new Date('2020-05-08 12:00:00')
       };
 
-      expect(isBefore('2020-05-08 11:59:59', values)).toBe(undefined);
-      expect(isBefore('2020-05-08 12:00:00', values)).toBe(
+      expect(isBefore(new Date('2020-05-08 11:59:59'), values)).toBe(undefined);
+      expect(isBefore(new Date('2020-05-08 12:00:00'), values)).toBe(
         `The "start" must be before the "end"`
       );
-      expect(isBefore('2020-05-08 12:00:01', values)).toBe(
+      expect(isBefore(new Date('2020-05-08 12:00:01'), values)).toBe(
         `The "start" must be before the "end"`
       );
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBefore(undefined, values)).toBe(undefined);
     });
   });
@@ -87,14 +89,15 @@ describe('isDateBefore', () => {
       });
 
       const values = {
-        end: '2020-05-08'
+        end: new Date('2020-05-08')
       };
 
-      expect(isBefore('2020-05-07', values)).toBe(undefined);
-      expect(isBefore('2020-05-08', values)).toBe(undefined);
-      expect(isBefore('2020-05-09', values)).toBe(
+      expect(isBefore(new Date('2020-05-07'), values)).toBe(undefined);
+      expect(isBefore(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBefore(new Date('2020-05-09'), values)).toBe(
         `The "start" must be before the "end"`
       );
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBefore(undefined, values)).toBe(undefined);
     });
 
@@ -105,15 +108,16 @@ describe('isDateBefore', () => {
       });
 
       const values = {
-        end: '2020-05-08 12:00:00'
+        end: new Date('2020-05-08 12:00:00')
       };
 
-      expect(isBefore('2020-05-08 11:59:59', values)).toBe(undefined);
-      expect(isBefore('2020-05-08 12:00:00', values)).toBe(undefined);
-      expect(isBefore('2020-05-08 12:00:01', values)).toBe(
+      expect(isBefore(new Date('2020-05-08 11:59:59'), values)).toBe(undefined);
+      expect(isBefore(new Date('2020-05-08 12:00:00'), values)).toBe(undefined);
+      expect(isBefore(new Date('2020-05-08 12:00:01'), values)).toBe(
         `The "start" must be before the "end"`
       );
 
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBefore(undefined, values)).toBe(undefined);
     });
   });
@@ -130,10 +134,10 @@ describe('isDateAfter', () => {
       start: undefined
     };
 
-    expect(isAfter('2020-05-05', values)).toBe(undefined);
-    expect(isAfter('2020-05-06', values)).toBe(undefined);
-    expect(isAfter('2020-05-07', values)).toBe(undefined);
-    expect(isAfter('2020-05-08', values)).toBe(undefined);
+    expect(isAfter(new Date('2020-05-05'), values)).toBe(undefined);
+    expect(isAfter(new Date('2020-05-06'), values)).toBe(undefined);
+    expect(isAfter(new Date('2020-05-07'), values)).toBe(undefined);
+    expect(isAfter(new Date('2020-05-08'), values)).toBe(undefined);
   });
 
   it('should support a custom error message', () => {
@@ -144,10 +148,10 @@ describe('isDateAfter', () => {
     });
 
     const values = {
-      start: '2020-05-08'
+      start: new Date('2020-05-08')
     };
 
-    expect(isAfter('2020-05-07', values)).toBe(
+    expect(isAfter(new Date('2020-05-07'), values)).toBe(
       'This is a custom error message'
     );
   });
@@ -160,16 +164,18 @@ describe('isDateAfter', () => {
       });
 
       const values = {
-        start: '2020-05-08'
+        start: new Date('2020-05-08')
       };
 
-      expect(isAfter('2020-05-07', values)).toBe(
+      expect(isAfter(new Date('2020-05-07'), values)).toBe(
         `The "end" must be after the "start"`
       );
-      expect(isAfter('2020-05-08', values)).toBe(
+      expect(isAfter(new Date('2020-05-08'), values)).toBe(
         `The "end" must be after the "start"`
       );
-      expect(isAfter('2020-05-09', values)).toBe(undefined);
+      expect(isAfter(new Date('2020-05-09'), values)).toBe(undefined);
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isAfter(undefined, values)).toBe(undefined);
     });
 
@@ -180,17 +186,18 @@ describe('isDateAfter', () => {
       });
 
       const values = {
-        start: '2020-05-08 12:00:00'
+        start: new Date('2020-05-08 12:00:00')
       };
 
-      expect(isAfter('2020-05-08 11:59:59', values)).toBe(
+      expect(isAfter(new Date('2020-05-08 11:59:59'), values)).toBe(
         `The "end" must be after the "start"`
       );
-      expect(isAfter('2020-05-08 12:00:00', values)).toBe(
+      expect(isAfter(new Date('2020-05-08 12:00:00'), values)).toBe(
         `The "end" must be after the "start"`
       );
-      expect(isAfter('2020-05-08 12:00:01', values)).toBe(undefined);
+      expect(isAfter(new Date('2020-05-08 12:00:01'), values)).toBe(undefined);
 
+      // @ts-expect-error undefined should work and be guarded against
       expect(isAfter(undefined, values)).toBe(undefined);
     });
   });
@@ -203,14 +210,16 @@ describe('isDateAfter', () => {
       });
 
       const values = {
-        start: '2020-05-08'
+        start: new Date('2020-05-08')
       };
 
-      expect(isAfter('2020-05-07', values)).toBe(
+      expect(isAfter(new Date('2020-05-07'), values)).toBe(
         `The "end" must be after the "start"`
       );
-      expect(isAfter('2020-05-08', values)).toBe(undefined);
-      expect(isAfter('2020-05-09', values)).toBe(undefined);
+      expect(isAfter(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isAfter(new Date('2020-05-09'), values)).toBe(undefined);
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isAfter(undefined, values)).toBe(undefined);
     });
 
@@ -221,14 +230,16 @@ describe('isDateAfter', () => {
       });
 
       const values = {
-        start: '2020-05-08 12:00:00'
+        start: new Date('2020-05-08 12:00:00')
       };
 
-      expect(isAfter('2020-05-08 11:59:59', values)).toBe(
+      expect(isAfter(new Date('2020-05-08 11:59:59'), values)).toBe(
         `The "end" must be after the "start"`
       );
-      expect(isAfter('2020-05-08 12:00:00', values)).toBe(undefined);
-      expect(isAfter('2020-05-08 12:00:01', values)).toBe(undefined);
+      expect(isAfter(new Date('2020-05-08 12:00:00'), values)).toBe(undefined);
+      expect(isAfter(new Date('2020-05-08 12:00:01'), values)).toBe(undefined);
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isAfter(undefined, values)).toBe(undefined);
     });
   });
@@ -244,13 +255,13 @@ describe('isDateBetween', () => {
 
     const values = {
       start: undefined,
-      end: '2020-05-09'
+      end: new Date('2020-05-09')
     };
 
-    expect(isBetween('2020-05-05', values)).toBe(undefined);
-    expect(isBetween('2020-05-06', values)).toBe(undefined);
-    expect(isBetween('2020-05-07', values)).toBe(undefined);
-    expect(isBetween('2020-05-08', values)).toBe(undefined);
+    expect(isBetween(new Date('2020-05-05'), values)).toBe(undefined);
+    expect(isBetween(new Date('2020-05-06'), values)).toBe(undefined);
+    expect(isBetween(new Date('2020-05-07'), values)).toBe(undefined);
+    expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
   });
 
   describe('only start should fallback to after', () => {
@@ -262,17 +273,17 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-07',
+        start: new Date('2020-05-07'),
         end: undefined
       };
 
-      expect(isBetween('2020-05-06', values)).toBe(
+      expect(isBetween(new Date('2020-05-06'), values)).toBe(
         `The "reminder" must be after the "start"`
       );
-      expect(isBetween('2020-05-07', values)).toBe(
+      expect(isBetween(new Date('2020-05-07'), values)).toBe(
         `The "reminder" must be after the "start"`
       );
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
     });
 
     test('inclusive', () => {
@@ -283,15 +294,15 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-07',
+        start: new Date('2020-05-07'),
         end: undefined
       };
 
-      expect(isBetween('2020-05-06', values)).toBe(
+      expect(isBetween(new Date('2020-05-06'), values)).toBe(
         `The "reminder" must be after the "start"`
       );
-      expect(isBetween('2020-05-07', values)).toBe(undefined);
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-07'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
     });
   });
 
@@ -305,14 +316,14 @@ describe('isDateBetween', () => {
 
       const values = {
         start: undefined,
-        end: '2020-05-09'
+        end: new Date('2020-05-09')
       };
 
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
-      expect(isBetween('2020-05-09', values)).toBe(
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-09'), values)).toBe(
         `The "reminder" must be before the "end"`
       );
-      expect(isBetween('2020-05-10', values)).toBe(
+      expect(isBetween(new Date('2020-05-10'), values)).toBe(
         `The "reminder" must be before the "end"`
       );
     });
@@ -326,12 +337,12 @@ describe('isDateBetween', () => {
 
       const values = {
         start: undefined,
-        end: '2020-05-09'
+        end: new Date('2020-05-09')
       };
 
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
-      expect(isBetween('2020-05-09', values)).toBe(undefined);
-      expect(isBetween('2020-05-10', values)).toBe(
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-09'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-10'), values)).toBe(
         `The "reminder" must be before the "end"`
       );
     });
@@ -346,11 +357,11 @@ describe('isDateBetween', () => {
     });
 
     const values = {
-      start: '2020-05-07',
-      end: '2020-05-09'
+      start: new Date('2020-05-07'),
+      end: new Date('2020-05-09')
     };
 
-    expect(isBetween('2020-05-07', values)).toBe(
+    expect(isBetween(new Date('2020-05-07'), values)).toBe(
       'This is a custom error message'
     );
   });
@@ -364,17 +375,19 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-07',
-        end: '2020-05-09'
+        start: new Date('2020-05-07'),
+        end: new Date('2020-05-09')
       };
 
-      expect(isBetween('2020-05-07', values)).toBe(
+      expect(isBetween(new Date('2020-05-07'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
-      expect(isBetween('2020-05-09', values)).toBe(
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-09'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
 
@@ -386,17 +399,21 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-08 12:00:00',
-        end: '2020-05-08 12:00:02'
+        start: new Date('2020-05-08 12:00:00'),
+        end: new Date('2020-05-08 12:00:02')
       };
 
-      expect(isBetween('2020-05-08 12:00:00', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 12:00:00'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-08 12:00:01', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:02', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 12:00:01'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:02'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
   });
@@ -410,19 +427,21 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-07',
-        end: '2020-05-09'
+        start: new Date('2020-05-07'),
+        end: new Date('2020-05-09')
       };
 
-      expect(isBetween('2020-05-06', values)).toBe(
+      expect(isBetween(new Date('2020-05-06'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-07', values)).toBe(undefined);
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
-      expect(isBetween('2020-05-09', values)).toBe(undefined);
-      expect(isBetween('2020-05-10', values)).toBe(
+      expect(isBetween(new Date('2020-05-07'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-09'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-10'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
 
@@ -434,19 +453,27 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-08 12:00:00',
-        end: '2020-05-08 12:00:02'
+        start: new Date('2020-05-08 12:00:00'),
+        end: new Date('2020-05-08 12:00:02')
       };
 
-      expect(isBetween('2020-05-08 11:59:59', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 11:59:59'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-08 12:00:00', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:01', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:02', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:03', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 12:00:00'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:01'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:02'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:03'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
   });
@@ -460,18 +487,20 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-07',
-        end: '2020-05-09'
+        start: new Date('2020-05-07'),
+        end: new Date('2020-05-09')
       };
 
-      expect(isBetween('2020-05-06', values)).toBe(
+      expect(isBetween(new Date('2020-05-06'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-07', values)).toBe(undefined);
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
-      expect(isBetween('2020-05-09', values)).toBe(
+      expect(isBetween(new Date('2020-05-07'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-09'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
 
@@ -483,18 +512,24 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-08 12:00:00',
-        end: '2020-05-08 12:00:02'
+        start: new Date('2020-05-08 12:00:00'),
+        end: new Date('2020-05-08 12:00:02')
       };
 
-      expect(isBetween('2020-05-08 11:59:59', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 11:59:59'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-08 12:00:00', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:01', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:02', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 12:00:00'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:01'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:02'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
   });
@@ -508,18 +543,20 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-07',
-        end: '2020-05-09'
+        start: new Date('2020-05-07'),
+        end: new Date('2020-05-09')
       };
 
-      expect(isBetween('2020-05-07', values)).toBe(
+      expect(isBetween(new Date('2020-05-07'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-08', values)).toBe(undefined);
-      expect(isBetween('2020-05-09', values)).toBe(undefined);
-      expect(isBetween('2020-05-10', values)).toBe(
+      expect(isBetween(new Date('2020-05-08'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-09'), values)).toBe(undefined);
+      expect(isBetween(new Date('2020-05-10'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
 
@@ -531,18 +568,24 @@ describe('isDateBetween', () => {
       });
 
       const values = {
-        start: '2020-05-08 12:00:00',
-        end: '2020-05-08 12:00:02'
+        start: new Date('2020-05-08 12:00:00'),
+        end: new Date('2020-05-08 12:00:02')
       };
 
-      expect(isBetween('2020-05-08 12:00:00', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 12:00:00'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
-      expect(isBetween('2020-05-08 12:00:01', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:02', values)).toBe(undefined);
-      expect(isBetween('2020-05-08 12:00:03', values)).toBe(
+      expect(isBetween(new Date('2020-05-08 12:00:01'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:02'), values)).toBe(
+        undefined
+      );
+      expect(isBetween(new Date('2020-05-08 12:00:03'), values)).toBe(
         `The "reminder" must be between the "start" and "end"`
       );
+
+      // @ts-expect-error undefined should work and be guarded against
       expect(isBetween(undefined, values)).toBe(undefined);
     });
   });

--- a/src/form/DateTimeInput/validators.ts
+++ b/src/form/DateTimeInput/validators.ts
@@ -112,12 +112,12 @@ type IsDateBeforeValidatorConfig = {
  *
  * Useful for the `JarbDateTimeInput` components `validators` prop.
  *
- * @param {isDateAfterValidatorConfig} config The configuration for the isDateBeforeValidator
+ * @param {IsDateAfterValidatorConfig} config The configuration for the isDateBeforeValidator
  * @returns {FieldValidator<Date>} A date validator function which checks if the date lies before the end date.
  */
 export function isDateBeforeValidator(
   config: IsDateBeforeValidatorConfig
-): FieldValidator<MomentInput> {
+): FieldValidator<Date> {
   const { end, label, overrideErrorText } = config;
 
   return (
@@ -136,7 +136,7 @@ export function isDateBeforeValidator(
   };
 }
 
-type isDateAfterValidatorConfig = {
+type IsDateAfterValidatorConfig = {
   start: Start;
 
   /**
@@ -162,12 +162,12 @@ type isDateAfterValidatorConfig = {
  *
  * Useful for the `JarbDateTimeInput` components `validators` prop.
  *
- * @param {isDateAfterValidatorConfig} config The configuration for the isDateBeforeValidator
+ * @param {IsDateAfterValidatorConfig} config The configuration for the isDateBeforeValidator
  * @returns {FieldValidator<Date>} A date validator function which checks if the date lies after the start date.
  */
 export function isDateAfterValidator(
-  config: isDateAfterValidatorConfig
-): FieldValidator<MomentInput> {
+  config: IsDateAfterValidatorConfig
+): FieldValidator<Date> {
   const { start, label, overrideErrorText } = config;
 
   return (
@@ -186,16 +186,7 @@ export function isDateAfterValidator(
   };
 }
 
-/**
- * Creates a final form date validator function which validates if
- * the date lies after the start date, and before the end date.
- *
- * Useful for the `JarbDateTimeInput` components `validators` prop.
- *
- * @param {isDateBetweenValidatorConfig} config The configuration for the isDateBetweenValidatorConfig
- * @returns {FieldValidator<Date>} A date validator function which checks if the date lies after the start date, and before the end date.
- */
-type isDateBetweenValidatorConfig = IsDateBetweenConfig & {
+type IsDateBetweenValidatorConfig = IsDateBetweenConfig & {
   start: Start;
 
   end: End;
@@ -218,9 +209,18 @@ type isDateBetweenValidatorConfig = IsDateBetweenConfig & {
   overrideErrorText?: string;
 };
 
+/**
+ * Creates a final form date validator function which validates if
+ * the date lies after the start date, and before the end date.
+ *
+ * Useful for the `JarbDateTimeInput` components `validators` prop.
+ *
+ * @param {isDateBetweenValidatorConfig} config The configuration for the isDateBetweenValidatorConfig
+ * @returns {FieldValidator<Date>} A date validator function which checks if the date lies after the start date, and before the end date.
+ */
 export function isDateBetweenValidator(
-  config: isDateBetweenValidatorConfig
-): FieldValidator<MomentInput> {
+  config: IsDateBetweenValidatorConfig
+): FieldValidator<Date> {
   const { start, end, label, overrideErrorText } = config;
 
   return (

--- a/src/form/FileInput/FileInput.tsx
+++ b/src/form/FileInput/FileInput.tsx
@@ -113,7 +113,7 @@ export const JarbFileInput = withJarb<File, File | null, Props>(FileInput);
  * A FileValidator is a FieldValidator which checks if the `File`
  * is valid.
  */
-type FileValidator = FieldValidator<File>;
+export type FileValidator = FieldValidator<File>;
 
 /**
  * Takes a `label` and returns a validator which can check if the

--- a/src/form/FormError/FormError.tsx
+++ b/src/form/FormError/FormError.tsx
@@ -6,7 +6,7 @@ import { Meta, MetaError } from '../types';
 import { errorMessage } from './utils';
 import { useSettledErrors } from './useSettledErrors';
 import { useOnChange } from './useOnChange';
-import { OnChange } from './types';
+import { FormErrorOnChange } from './types';
 
 type Props = {
   /**
@@ -28,7 +28,7 @@ type Props = {
    * Optionally: callback which is called when there are errors or
    * they are removed.
    */
-  onChange?: OnChange;
+  onChange?: FormErrorOnChange;
 
   /**
    * Optionally: classes to put on the div around the errors.

--- a/src/form/FormError/types.ts
+++ b/src/form/FormError/types.ts
@@ -1,1 +1,1 @@
-export type OnChange = (hasErrors: boolean) => void;
+export type FormErrorOnChange = (hasErrors: boolean) => void;

--- a/src/form/FormError/useOnChange.test.ts
+++ b/src/form/FormError/useOnChange.test.ts
@@ -1,16 +1,16 @@
 import { renderHook } from '@testing-library/react-hooks';
 
 import { useOnChange } from './useOnChange';
-import { OnChange } from './types';
+import { FormErrorOnChange } from './types';
 
 describe('useOnChange', () => {
   test('that it passes values only when they change', () => {
     const onChange = jest.fn();
 
     const { rerender } = renderHook<
-      { hasErrors: boolean; onChange: OnChange },
+      { hasErrors: boolean; onChange: FormErrorOnChange },
       void
-    >(props => useOnChange(props.hasErrors, props.onChange), {
+    >((props) => useOnChange(props.hasErrors, props.onChange), {
       initialProps: {
         hasErrors: true,
         onChange

--- a/src/form/FormError/useOnChange.ts
+++ b/src/form/FormError/useOnChange.ts
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
-import { OnChange } from './types';
+import { FormErrorOnChange } from './types';
 
-export function useOnChange(hasErrors: boolean, onChange?: OnChange): void {
+export function useOnChange(
+  hasErrors: boolean,
+  onChange?: FormErrorOnChange
+): void {
   useEffect(() => {
     if (onChange) {
       onChange(hasErrors);

--- a/src/form/ImageUpload/ImageUpload.test.tsx
+++ b/src/form/ImageUpload/ImageUpload.test.tsx
@@ -5,7 +5,7 @@ import toJson from 'enzyme-to-json';
 import * as imgUploadUtils from './utils';
 
 import ImageUpload, {
-  Crop,
+  ImageUploadCrop,
   limitImageSize,
   requireImage,
   Text
@@ -37,7 +37,7 @@ describe('Component: ImageUpload', () => {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
 
-    const crop: Crop =
+    const crop: ImageUploadCrop =
       cropType === 'rect'
         ? { width: 500, height: 500, type: 'rect' }
         : { size: 250, type: 'circle' };

--- a/src/form/ImageUpload/ImageUpload.tsx
+++ b/src/form/ImageUpload/ImageUpload.tsx
@@ -26,7 +26,7 @@ export type Text = {
   done?: string;
 };
 
-type CropRect = {
+export type ImageUploadCropRect = {
   /**
    * Crop is a rectangle
    */
@@ -43,7 +43,7 @@ type CropRect = {
   height: number;
 };
 
-type CropCircle = {
+export type ImageUploadCropCircle = {
   /**
    * Crop is a circle
    */
@@ -58,7 +58,7 @@ type CropCircle = {
 /**
  * Crop is either a rectangle or a circle.
  */
-export type Crop = CropRect | CropCircle;
+export type ImageUploadCrop = ImageUploadCropRect | ImageUploadCropCircle;
 
 type Value = File | string;
 type ChangeValue = File | null;
@@ -70,7 +70,7 @@ export type Props = Omit<
   /**
    * Whether to crop as a circle or as a rectangle.
    */
-  crop: Crop;
+  crop: ImageUploadCrop;
 
   /**
    * Optionally customized text you want to use in this component.

--- a/src/form/ImageUpload/utils.ts
+++ b/src/form/ImageUpload/utils.ts
@@ -1,6 +1,6 @@
 // TODO: Declarations
 import picaFn from 'pica';
-import { Crop } from './ImageUpload';
+import { ImageUploadCrop } from './ImageUpload';
 
 let picaInstance: any;
 export function getPicaInstance() {
@@ -34,7 +34,9 @@ type AvatarEditorConfig = {
   height: number;
 };
 
-export function cropToAvatarEditorConfig(crop: Crop): AvatarEditorConfig {
+export function cropToAvatarEditorConfig(
+  crop: ImageUploadCrop
+): AvatarEditorConfig {
   if (crop.type === 'rect') {
     const { width, height } = crop;
 

--- a/src/form/Input/Input.test.tsx
+++ b/src/form/Input/Input.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import Input, { reactStrapInput, Mask } from './Input';
+import Input, { reactStrapInput, InputMask } from './Input';
 
 import { InputType } from 'reactstrap/lib/Input';
 import { Addon } from '../addons/Addon/Addon';
 
-const mask: Mask = [
+const mask: InputMask = [
   '(',
   /[1-9]/,
   /\d/,
@@ -42,7 +42,7 @@ describe('Component: Input', () => {
   }: {
     value?: string;
     type?: InputType;
-    mask?: Mask;
+    mask?: InputMask;
     addon?: React.ReactElement;
     valid?: boolean;
     hasPlaceholder?: boolean;

--- a/src/form/Input/Input.tsx
+++ b/src/form/Input/Input.tsx
@@ -4,7 +4,7 @@ import { FormGroup, Input as RSInput, InputGroup, Label } from 'reactstrap';
 import { InputType } from 'reactstrap/lib/Input';
 import withJarb from '../withJarb/withJarb';
 
-export type Mask = (string | RegExp)[];
+export type InputMask = (string | RegExp)[];
 
 import { FieldCompatible } from '../types';
 import { useId } from '../../hooks/useId/useId';
@@ -20,7 +20,7 @@ export type Props = FieldCompatible<string, string> & {
    *
    * @see https://text-mask.github.io/text-mask/
    */
-  mask?: Mask;
+  mask?: InputMask;
 
   /**
    * Optional addon to display to the left or right of the input

--- a/src/form/ModalPicker/ModalPicker.test.tsx
+++ b/src/form/ModalPicker/ModalPicker.test.tsx
@@ -8,7 +8,7 @@ import { ContentState } from '../..';
 import EmptyModal from './EmptyModal';
 import { User } from '../../test/types';
 import { adminUser, coordinatorUser, pageOfUsers } from '../../test/fixtures';
-import { RenderOptionsOption } from './types';
+import { ModalPickerRenderOptionsOption } from './types';
 import { ListGroup, ListGroupItem } from 'reactstrap';
 
 describe('Component: ModalPicker', () => {
@@ -244,12 +244,16 @@ describe('Component: ModalPicker', () => {
     const onChangeSpy = jest.fn();
 
     function renderOptions(
-      options: RenderOptionsOption<User>[]
+      options: ModalPickerRenderOptionsOption<User>[]
     ): React.ReactNode {
       return (
         <ListGroup>
           {options.map(
-            ({ option, toggle, enabled }: RenderOptionsOption<User>) => (
+            ({
+              option,
+              toggle,
+              enabled
+            }: ModalPickerRenderOptionsOption<User>) => (
               <ListGroupItem
                 key={option.id}
                 onClick={toggle}

--- a/src/form/ModalPicker/ModalPicker.tsx
+++ b/src/form/ModalPicker/ModalPicker.tsx
@@ -16,7 +16,10 @@ import SearchInput from '../../core/SearchInput/SearchInput';
 import { useBodyFixOnModalClose } from '../../core/useBodyFixOnModalClose/useBodyFixOnModalClose';
 import ContentState from '../../core/ContentState/ContentState';
 import EmptyModal from './EmptyModal';
-import { RenderOptions, RenderOptionsOption } from './types';
+import {
+  ModalPickerRenderOptions,
+  ModalPickerRenderOptionsOption
+} from './types';
 import {
   FieldCompatibleWithPredeterminedOptions,
   isOptionSelected,
@@ -133,7 +136,7 @@ export type RenderOptionsConfig<T> = Omit<
   /**
    * Callback to customize display of options.
    */
-  renderOptions: RenderOptions<T>;
+  renderOptions: ModalPickerRenderOptions<T>;
 
   onChange: (option: T, isSelected: boolean) => void;
 };
@@ -255,7 +258,7 @@ export default function ModalPicker<T>(props: Props<T>) {
 
   function mapOptions(
     renderOptionsConfig: RenderOptionsConfig<T>
-  ): RenderOptionsOption<T>[] {
+  ): ModalPickerRenderOptionsOption<T>[] {
     const {
       onChange,
       labelForOption,

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.test.tsx
@@ -4,7 +4,7 @@ import { ModalPickerOpener } from './ModalPickerOpener';
 import { adminUser } from '../../../test/fixtures';
 import toJson from 'enzyme-to-json';
 import * as useComponentOverflow from '../ModalPickerValueTruncator/useComponentOverflow/useComponentOverflow';
-import { ButtonAlignment } from '../types';
+import { ModalPickerButtonAlignment } from '../types';
 
 describe('Component: ModalPickerOpener', () => {
   function setup({
@@ -14,7 +14,7 @@ describe('Component: ModalPickerOpener', () => {
   }: {
     hasValue?: boolean;
     withTooltip?: boolean;
-    alignButton?: ButtonAlignment;
+    alignButton?: ModalPickerButtonAlignment;
   }) {
     const openModalSpy = jest.fn();
     const onClearSpy = jest.fn();

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Button } from 'reactstrap';
-import { ButtonAlignment } from '../types';
+import { ModalPickerButtonAlignment } from '../types';
 import classNames from 'classnames';
 import { t } from '../../../utilities/translation/translation';
 import TextButton from '../../../core/TextButton/TextButton';
-import { RenderValue } from '../single/ModalPickerSingle';
-import { RenderValues } from '../multiple/ModalPickerMultiple';
+import { ModalPickerSingleRenderValue } from '../single/ModalPickerSingle';
+import { ModalPickerMultipleRenderValues } from '../multiple/ModalPickerMultiple';
 
 type Text = {
   clear?: string;
@@ -31,7 +31,7 @@ type BaseProps = {
    * Optionally the position the button should be aligned to
    * within it's container.
    */
-  alignButton?: ButtonAlignment;
+  alignButton?: ModalPickerButtonAlignment;
 
   /**
    * Optionally customized text within the component.
@@ -42,12 +42,12 @@ type BaseProps = {
 
 type ModalPickerSingleOpenerProps<T> = BaseProps & {
   value?: T;
-  renderValue: RenderValue<T>;
+  renderValue: ModalPickerSingleRenderValue<T>;
 };
 
 type ModalPickerMultipleOpenerProps<T> = BaseProps & {
   value?: T[];
-  renderValue: RenderValues<T>;
+  renderValue: ModalPickerMultipleRenderValues<T>;
 };
 
 type Props<T> =

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -15,7 +15,7 @@ import {
 
 import { User } from '../../../test/types';
 import * as testUtils from '../../../test/utils';
-import { ButtonAlignment } from '../types';
+import { ModalPickerButtonAlignment } from '../types';
 import { pageOf } from '../../../utilities/page/page';
 import { useOptions } from '../../useOptions';
 import { Color } from '../../../core/types';
@@ -45,7 +45,7 @@ describe('Component: ModalPickerMultiple', () => {
     canSearch?: boolean;
     hasLabel?: boolean;
     spyOnRenderOptions?: boolean;
-    alignButton?: ButtonAlignment;
+    alignButton?: ModalPickerButtonAlignment;
     hasRenderValue?: boolean;
     hasRenderOptions?: boolean;
     loading?: boolean;

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -6,10 +6,10 @@ import { alwaysTrue, doBlur } from '../../utils';
 import Tag from '../../../core/Tag/Tag';
 import ModalPicker from '../ModalPicker';
 import {
-  AddButtonCallback,
-  AddButtonOptions,
-  ButtonAlignment,
-  RenderOptions
+  ModalPickerAddButtonCallback,
+  ModalPickerAddButtonOptions,
+  ModalPickerButtonAlignment,
+  ModalPickerRenderOptions
 } from '../types';
 import {
   FieldCompatibleWithPredeterminedOptions,
@@ -22,7 +22,9 @@ import { FieldCompatible } from '../../types';
 import { useId } from '../../../hooks/useId/useId';
 import { useOptions } from '../../useOptions';
 
-export type RenderValues<T> = (value?: T[]) => React.ReactNode;
+export type ModalPickerMultipleRenderValues<T> = (
+  value?: T[]
+) => React.ReactNode;
 
 export type Props<T> = Omit<
   FieldCompatible<T[], T[] | undefined>,
@@ -45,23 +47,23 @@ export type Props<T> = Omit<
      * be used to dynamically add an option which was not there
      * before.
      */
-    addButton?: AddButtonOptions<T>;
+    addButton?: ModalPickerAddButtonOptions<T>;
 
     /**
      * Optionally the position the button should be aligned to
      * within it's container.
      */
-    alignButton?: ButtonAlignment;
+    alignButton?: ModalPickerButtonAlignment;
 
     /**
      * Optionally callback to display the selected items.
      */
-    renderValue?: RenderValues<T>;
+    renderValue?: ModalPickerMultipleRenderValues<T>;
 
     /**
      * Callback to customize display of options.
      */
-    renderOptions?: RenderOptions<T>;
+    renderOptions?: ModalPickerRenderOptions<T>;
   };
 
 /**
@@ -171,7 +173,7 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
     setSelected(newSelected);
   }
 
-  async function addButtonClicked(callback: AddButtonCallback<T>) {
+  async function addButtonClicked(callback: ModalPickerAddButtonCallback<T>) {
     setIsOpen(false);
 
     try {

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -14,7 +14,7 @@ import {
   randomUser,
   userUser
 } from '../../../test/fixtures';
-import { ButtonAlignment } from '../types';
+import { ModalPickerButtonAlignment } from '../types';
 
 import { pageOf } from '../../../utilities/page/page';
 import { useOptions } from '../../useOptions';
@@ -44,7 +44,7 @@ describe('Component: ModalPickerSingle', () => {
     showAddButton?: boolean;
     canSearch?: boolean;
     hasLabel?: boolean;
-    alignButton?: ButtonAlignment;
+    alignButton?: ModalPickerButtonAlignment;
     hasRenderValue?: boolean;
     hasRenderOptions?: boolean;
     loading?: boolean;

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -14,13 +14,13 @@ import ModalPicker from '../ModalPicker';
 import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
 import { ModalPickerValueTruncator } from '../ModalPickerValueTruncator/ModalPickerValueTruncator';
 import {
-  AddButtonCallback,
-  AddButtonOptions,
-  ButtonAlignment,
-  RenderOptions
+  ModalPickerAddButtonCallback,
+  ModalPickerAddButtonOptions,
+  ModalPickerButtonAlignment,
+  ModalPickerRenderOptions
 } from '../types';
 
-export type RenderValue<T> = (value?: T) => React.ReactNode;
+export type ModalPickerSingleRenderValue<T> = (value?: T) => React.ReactNode;
 
 type Props<T> = Omit<
   FieldCompatible<T, T | undefined>,
@@ -43,23 +43,23 @@ type Props<T> = Omit<
      * be used to dynamically add an option which was not there
      * before.
      */
-    addButton?: AddButtonOptions<T>;
+    addButton?: ModalPickerAddButtonOptions<T>;
 
     /**
      * Optionally the position the button should be aligned to
      * within it's container.
      */
-    alignButton?: ButtonAlignment;
+    alignButton?: ModalPickerButtonAlignment;
 
     /**
      * Optionally callback to display the selected item.
      */
-    renderValue?: RenderValue<T>;
+    renderValue?: ModalPickerSingleRenderValue<T>;
 
     /**
      * Callback to customize display of options.
      */
-    renderOptions?: RenderOptions<T>;
+    renderOptions?: ModalPickerRenderOptions<T>;
   };
 
 /**
@@ -136,7 +136,7 @@ export default function ModalPickerSingle<T>(props: Props<T>) {
     setUserHasSearched(false);
   }
 
-  async function addButtonClicked(callback: AddButtonCallback<T>) {
+  async function addButtonClicked(callback: ModalPickerAddButtonCallback<T>) {
     setIsOpen(false);
 
     try {

--- a/src/form/ModalPicker/types.ts
+++ b/src/form/ModalPicker/types.ts
@@ -1,15 +1,15 @@
 import { ReactNode } from 'react';
 
-export type AddButtonCallback<T> = () => Promise<T>;
+export type ModalPickerAddButtonCallback<T> = () => Promise<T>;
 
-export type AddButtonOptions<T> = {
+export type ModalPickerAddButtonOptions<T> = {
   label: string;
-  onClick: AddButtonCallback<T>;
+  onClick: ModalPickerAddButtonCallback<T>;
 };
 
-export type ButtonAlignment = 'left' | 'right' | 'default';
+export type ModalPickerButtonAlignment = 'left' | 'right' | 'default';
 
-export type RenderOptionsOption<T> = {
+export type ModalPickerRenderOptionsOption<T> = {
   option: T;
   isSelected: boolean;
   enabled: boolean;
@@ -19,4 +19,6 @@ export type RenderOptionsOption<T> = {
 /**
  * Callback which renders the options.
  */
-export type RenderOptions<T> = (options: RenderOptionsOption<T>[]) => ReactNode;
+export type ModalPickerRenderOptions<T> = (
+  options: ModalPickerRenderOptionsOption<T>[]
+) => ReactNode;

--- a/src/form/NewPasswordInput/NewPasswordInput.tsx
+++ b/src/form/NewPasswordInput/NewPasswordInput.tsx
@@ -12,9 +12,9 @@ import {
   hasNoSpaces,
   hasNumber,
   hasSpecialChar,
-  hasUppercase,
-  Rule
+  hasUppercase
 } from './PasswordStrength/rules';
+import { NewPasswordInputRule } from './types';
 
 type PasswordProps = {
   /**
@@ -109,7 +109,7 @@ export const JarbNewPasswordInput = withJarb<string, string, Props>(
   NewPasswordInput
 );
 
-function getRulesFromProps(props: PasswordProps): Rule[] {
+function getRulesFromProps(props: PasswordProps): NewPasswordInputRule[] {
   const {
     lowercase = true,
     uppercase = true,
@@ -119,7 +119,7 @@ function getRulesFromProps(props: PasswordProps): Rule[] {
     noSpace = true
   } = props;
 
-  const rules: Rule[] = [];
+  const rules: NewPasswordInputRule[] = [];
   if (lowercase) {
     rules.push('lowercase');
   }
@@ -158,7 +158,7 @@ type PasswordValidator = FieldValidator<string>;
  * @returns {(FieldValidator<string>)}
  */
 export function isStrongPassword(
-  rules: Rule[],
+  rules: NewPasswordInputRule[],
   minimumLength: number
 ): PasswordValidator {
   return (value?: string): Translation | undefined => {

--- a/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
+++ b/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
@@ -5,7 +5,7 @@ import { t } from '../../../utilities/translation/translation';
 import Icon from '../../../core/Icon/Icon';
 import { useMeterWidth } from './useMeterWidth/useMeterWidth';
 import { useRules } from './useRules/useRules';
-import { Rule } from './rules';
+import { NewPasswordInputRule } from '../types';
 
 type Props = {
   /**
@@ -16,7 +16,7 @@ type Props = {
   /**
    * The list of rules to be matched.
    */
-  rules: Rule[];
+  rules: NewPasswordInputRule[];
 
   /**
    * Optionally the minimum length of the password.
@@ -55,7 +55,7 @@ export default function PasswordStrength(props: Props) {
         />
       ) : null}
       <div className="mb-2">
-        {rules.map(rule => {
+        {rules.map((rule) => {
           const isCompliant = compliant[rule];
           return (
             <div key={rule}>
@@ -74,7 +74,10 @@ export default function PasswordStrength(props: Props) {
   );
 }
 
-export function labelForRule(rule: Rule, minimumLength: number) {
+export function labelForRule(
+  rule: NewPasswordInputRule,
+  minimumLength: number
+) {
   switch (rule) {
     case 'lowercase':
       return {

--- a/src/form/NewPasswordInput/PasswordStrength/rules.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/rules.ts
@@ -1,31 +1,23 @@
-export type Rule =
-  | 'lowercase'
-  | 'uppercase'
-  | 'number'
-  | 'specialChar'
-  | 'minimumLength'
-  | 'noSpace';
-
-export function hasLowercase(value?: string) {
+export function hasLowercase(value?: string): boolean {
   return !!value && /(?=.*[a-z])/.test(value);
 }
 
-export function hasUppercase(value?: string) {
+export function hasUppercase(value?: string): boolean {
   return !!value && /(?=.*[A-Z])/.test(value);
 }
 
-export function hasNumber(value?: string) {
+export function hasNumber(value?: string): boolean {
   return !!value && /(?=.*[0-9])/.test(value);
 }
 
-export function hasSpecialChar(value?: string) {
+export function hasSpecialChar(value?: string): boolean {
   return !!value && /(?=.*[@#$%^&+=.,?!])/.test(value);
 }
 
-export function hasMinimumLength(length: number, value?: string) {
+export function hasMinimumLength(length: number, value?: string): boolean {
   return !!value && new RegExp(`.{${length},}`).test(value);
 }
 
-export function hasNoSpaces(value?: string) {
+export function hasNoSpaces(value?: string): boolean {
   return /^\S*$/.test(value ?? '');
 }

--- a/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Rule } from '../rules';
+import { NewPasswordInputRule } from '../../types';
 
-export function useMeterWidth(compliant: { [key in Rule]?: boolean }): number {
+export function useMeterWidth(
+  compliant: { [key in NewPasswordInputRule]?: boolean }
+): number {
   const [meterWidth, setMeterWidth] = useState(0);
 
   useEffect(() => {

--- a/src/form/NewPasswordInput/PasswordStrength/useRules/useRules.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/useRules/useRules.ts
@@ -1,20 +1,22 @@
 import { useEffect, useState } from 'react';
+import { NewPasswordInputRule } from '../../types';
 import {
   hasLowercase,
   hasMinimumLength,
   hasNoSpaces,
   hasNumber,
   hasSpecialChar,
-  hasUppercase,
-  Rule
+  hasUppercase
 } from '../rules';
 
 export function useRules(
-  rules: Rule[],
+  rules: NewPasswordInputRule[],
   password: string,
   minimumLength: number
 ) {
-  const [compliant, setCompliant] = useState<{ [key in Rule]?: boolean }>(
+  const [compliant, setCompliant] = useState<
+    { [key in NewPasswordInputRule]?: boolean }
+  >(
     rules.reduce(
       (obj, rule) => checkRule(obj, rule, password, minimumLength),
       {}
@@ -35,7 +37,7 @@ export function useRules(
 
 export function checkRule(
   obj: Record<string, boolean>,
-  rule: Rule,
+  rule: NewPasswordInputRule,
   value: string,
   minimumLength: number
 ) {

--- a/src/form/NewPasswordInput/types.ts
+++ b/src/form/NewPasswordInput/types.ts
@@ -1,0 +1,7 @@
+export type NewPasswordInputRule =
+  | 'lowercase'
+  | 'uppercase'
+  | 'number'
+  | 'specialChar'
+  | 'minimumLength'
+  | 'noSpace';

--- a/src/form/addons/Addon/Addon.test.tsx
+++ b/src/form/addons/Addon/Addon.test.tsx
@@ -3,10 +3,10 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import { Addon } from './Addon';
-import { IconPosition } from '../../../core/Button/Button';
+import { ButtonIconPosition } from '../../../core/Button/Button';
 
 describe('Component: Addon', () => {
-  function setup({ position }: { position?: IconPosition }) {
+  function setup({ position }: { position?: ButtonIconPosition }) {
     const addon = shallow(<Addon position={position}>42</Addon>);
 
     return { addon };

--- a/src/form/addons/Addon/Addon.tsx
+++ b/src/form/addons/Addon/Addon.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { InputGroupAddon } from 'reactstrap';
 
-export type Position = 'left' | 'right';
+export type AddonPosition = 'left' | 'right';
 
 export type Props = {
   /**
@@ -15,7 +15,7 @@ export type Props = {
    *
    * Defaults to 'left'
    */
-  position?: Position;
+  position?: AddonPosition;
 
   /**
    * Optional extra CSS class you want to add to the component.

--- a/src/form/addons/AddonButton/AddonButton.test.tsx
+++ b/src/form/addons/AddonButton/AddonButton.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import { AddonButton } from './AddonButton';
-import { IconPosition } from '../../../core/Button/Button';
+import { ButtonIconPosition } from '../../../core/Button/Button';
 import { Color } from '../../../core/types';
 
 describe('Component: AddonButton', () => {
@@ -11,7 +11,7 @@ describe('Component: AddonButton', () => {
     position,
     color
   }: {
-    position?: IconPosition;
+    position?: ButtonIconPosition;
     color?: Color;
   }) {
     const onClickSpy = jest.fn();

--- a/src/form/addons/AddonButton/AddonButton.tsx
+++ b/src/form/addons/AddonButton/AddonButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from 'reactstrap';
 import { Color } from '../../../core/types';
 
-import { Addon, Position, Props as AddonProps } from '../Addon/Addon';
+import { Addon, AddonPosition, Props as AddonProps } from '../Addon/Addon';
 
 export type Props = Omit<AddonProps, 'position'> & {
   /**
@@ -18,7 +18,7 @@ export type Props = Omit<AddonProps, 'position'> & {
    *
    * Defaults to 'right'
    */
-  position?: Position;
+  position?: AddonPosition;
 
   /**
    * Callback for when the addon is clicked.

--- a/src/form/types.ts
+++ b/src/form/types.ts
@@ -16,11 +16,6 @@ export type Meta = {
   error?: MetaError | MetaError[];
 };
 
-export type UnionKeys<T> = T extends any ? keyof T : never;
-export type DistributiveOmit<T, K extends UnionKeys<T>> = T extends any
-  ? Omit<T, Extract<keyof T, K>>
-  : never;
-
 export type FieldCompatible<Value, ChangeValue> = {
   /**
    * Optionally the id of the form element. Will be automatically

--- a/src/form/withJarb/withJarb.tsx
+++ b/src/form/withJarb/withJarb.tsx
@@ -28,7 +28,7 @@ const managedProps = [
   'error'
 ];
 
-type JarbFieldCompatible<Value, ChangeValue> = FieldCompatible<
+export type JarbFieldCompatible<Value, ChangeValue> = FieldCompatible<
   Value,
   ChangeValue
 > & {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -91,6 +91,7 @@ describe('index', () => {
         "TypeaheadSingle": [Function],
         "ValuePicker": [Function],
         "configure": [Function],
+        "errorMessage": [Function],
         "isDateAfter": [Function],
         "isDateAfterValidator": [Function],
         "isDateBefore": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 // Core
 export { default as Avatar } from './core/Avatar/Avatar';
 export { default as AvatarStack } from './core/Avatar/AvatarStack';
-export { default as Button } from './core/Button/Button';
+export {
+  default as Button,
+  ButtonIconPosition,
+  ButtonSize
+} from './core/Button/Button';
 export { default as useShowSpinner } from './core/Button/useShowSpinner';
 export { default as ConfirmButton } from './core/ConfirmButton/ConfirmButton';
 export { default as ConfirmModal } from './core/ConfirmModal/ConfirmModal';
@@ -25,7 +29,10 @@ export { default as Tooltip } from './core/Tooltip/Tooltip';
 export { default as AsyncContent } from './core/AsyncContent/AsyncContent';
 export { default as AsyncPage } from './core/AsyncPage/AsyncPage';
 export { default as AsyncList } from './core/AsyncList/AsyncList';
-export { default as SearchInput } from './core/SearchInput/SearchInput';
+export {
+  default as SearchInput,
+  SearchInputApi
+} from './core/SearchInput/SearchInput';
 export { default as Pager } from './core/Pager/Pager';
 export { OpenCloseModal } from './core/OpenCloseModal/OpenCloseModal';
 export { default as Popover } from './core/Popover/Popover';
@@ -34,8 +41,11 @@ export { useShowAfter } from './core/useShowAfter/useShowAfter';
 
 // Form
 export { AutoSave } from './form/AutoSave/AutoSave';
-export { default as withJarb } from './form/withJarb/withJarb';
-export { default as Input, JarbInput } from './form/Input/Input';
+export {
+  default as withJarb,
+  JarbFieldCompatible
+} from './form/withJarb/withJarb';
+export { default as Input, JarbInput, InputMask } from './form/Input/Input';
 export { default as Textarea, JarbTextarea } from './form/Textarea/Textarea';
 export {
   default as TextEditor,
@@ -43,12 +53,16 @@ export {
 } from './form/TextEditor/TextEditor';
 export {
   default as DateTimeInput,
-  JarbDateTimeInput
+  JarbDateTimeInput,
+  DateTimeInputIsDateAllowed,
+  DateTimeInputMode
 } from './form/DateTimeInput/DateTimeInput';
+export { DateFormat, TimeFormat } from './form/DateTimeInput/types';
 export {
   isDateAfter,
   isDateBefore,
-  isDateBetween
+  isDateBetween,
+  DateChecker
 } from './form/DateTimeInput/checkers';
 export {
   isDateAfterValidator,
@@ -58,12 +72,21 @@ export {
 export { default as Select, JarbSelect } from './form/Select/Select';
 export {
   default as ModalPickerSingle,
-  JarbModalPickerSingle
+  JarbModalPickerSingle,
+  ModalPickerSingleRenderValue
 } from './form/ModalPicker/single/ModalPickerSingle';
 export {
   default as ModalPickerMultiple,
-  JarbModalPickerMultiple
+  JarbModalPickerMultiple,
+  ModalPickerMultipleRenderValues
 } from './form/ModalPicker/multiple/ModalPickerMultiple';
+export {
+  ModalPickerAddButtonCallback,
+  ModalPickerAddButtonOptions,
+  ModalPickerRenderOptions,
+  ModalPickerRenderOptionsOption,
+  ModalPickerButtonAlignment
+} from './form/ModalPicker/types';
 export {
   default as TypeaheadSingle,
   JarbTypeaheadSingle
@@ -72,20 +95,28 @@ export {
   default as TypeaheadMultiple,
   JarbTypeaheadMultiple
 } from './form/Typeahead/multiple/TypeaheadMultiple';
+export { TypeaheadOption } from './form/Typeahead/types';
 export {
   default as FileInput,
   JarbFileInput,
   requireFile,
-  limitFileSize
+  limitFileSize,
+  FileValidator
 } from './form/FileInput/FileInput';
 export {
   default as ImageUpload,
   JarbImageUpload,
   requireImage,
-  limitImageSize
+  limitImageSize,
+  ImageUploadCrop,
+  ImageUploadCropCircle,
+  ImageUploadCropRect,
+  ImageValidator
 } from './form/ImageUpload/ImageUpload';
 export { default as Toggle } from './core/Toggle/Toggle';
 export { default as FormError } from './form/FormError/FormError';
+export { errorMessage } from './form/FormError/utils';
+export { FormErrorOnChange } from './form/FormError/types';
 export {
   default as CheckboxMultipleSelect,
   JarbCheckboxMultipleSelect
@@ -112,8 +143,9 @@ export {
   JarbNewPasswordInput,
   isStrongPassword
 } from './form/NewPasswordInput/NewPasswordInput';
+export { NewPasswordInputRule } from './form/NewPasswordInput/types';
 export { FormButton } from './form/FormButton/FormButton';
-export { Addon } from './form/addons/Addon/Addon';
+export { Addon, AddonPosition } from './form/addons/Addon/Addon';
 export { AddonButton } from './form/addons/AddonButton/AddonButton';
 export { AddonIcon } from './form/addons/AddonIcon/AddonIcon';
 
@@ -135,14 +167,29 @@ export { EpicExpander } from './table/EpicTable/widgets/EpicExpander/EpicExpande
 export { EpicSelection } from './table/EpicTable/widgets/EpicSelection/EpicSelection';
 export { EpicSort } from './table/EpicTable/widgets/EpicSort/EpicSort';
 
-export { Direction } from './table/EpicTable/types';
+export { EpicTableSortDirection } from './table/EpicTable/types';
 
 // Utilities
 export { t } from './utilities/translation/translation';
-export { setTranslator } from './utilities/translation/translator';
+export {
+  setTranslator,
+  Translation,
+  Translator
+} from './utilities/translation/translator';
 export { pageOf } from './utilities/page/page';
 export { useBodyFixOnModalClose } from './core/useBodyFixOnModalClose/useBodyFixOnModalClose';
-export { configure } from './config/config';
+export { configure, Config } from './config/config';
 
 // Types
 export { Color } from './core/types';
+export { FieldCompatible, MetaError, Meta } from './form/types';
+export {
+  Options,
+  FieldCompatibleWithPredeterminedOptions,
+  LabelForOption,
+  KeyForOption,
+  IsOptionEnabled,
+  IsOptionEqual,
+  FetchOptionsCallback,
+  FetchOptionsCallbackConfig
+} from './form/option';

--- a/src/table/EpicTable/EpicTable.stories.tsx
+++ b/src/table/EpicTable/EpicTable.stories.tsx
@@ -17,7 +17,7 @@ import { EpicDetail } from './widgets/EpicDetail/EpicDetail';
 import { EpicSelection } from './widgets/EpicSelection/EpicSelection';
 import { EpicSort } from './widgets/EpicSort/EpicSort';
 
-import { Direction } from './types';
+import { EpicTableSortDirection } from './types';
 import {
   Button,
   ContentState,
@@ -83,11 +83,14 @@ storiesOf('table/EpicTable', module)
     });
 
     const [sort, setSort] = useState<{
-      direction: Direction;
+      direction: EpicTableSortDirection;
       column: string;
     }>({ direction: 'NONE', column: 'firstName' });
 
-    function changeSort(column: keyof Person, direction: Direction) {
+    function changeSort(
+      column: keyof Person,
+      direction: EpicTableSortDirection
+    ) {
       setPage(1);
       setSort({ direction, column });
     }
@@ -1097,7 +1100,7 @@ storiesOf('table/EpicTable', module)
     );
   })
   .add('with sort', () => {
-    const [direction, setDirection] = useState<Direction>('NONE');
+    const [direction, setDirection] = useState<EpicTableSortDirection>('NONE');
 
     const sortFn =
       direction === 'ASC'

--- a/src/table/EpicTable/types.ts
+++ b/src/table/EpicTable/types.ts
@@ -1,4 +1,4 @@
-export type Direction = 'ASC' | 'DESC' | 'NONE';
+export type EpicTableSortDirection = 'ASC' | 'DESC' | 'NONE';
 
 export type HeaderRef = {
   ref: HTMLDivElement;

--- a/src/table/EpicTable/widgets/EpicSort/EpicSort.test.tsx
+++ b/src/table/EpicTable/widgets/EpicSort/EpicSort.test.tsx
@@ -4,12 +4,12 @@ import toJson from 'enzyme-to-json';
 
 import { EpicSort } from './EpicSort';
 import { Icon } from '../../../../core/Icon';
-import { Direction } from '../../types';
+import { EpicTableSortDirection } from '../../types';
 
 import * as utils from './utils';
 
 describe('Component: EpicSort', () => {
-  function setup({ direction }: { direction: Direction }) {
+  function setup({ direction }: { direction: EpicTableSortDirection }) {
     jest.spyOn(utils, 'nextDirection').mockReturnValue('ASC');
 
     const onChangeSpy = jest.fn();

--- a/src/table/EpicTable/widgets/EpicSort/EpicSort.tsx
+++ b/src/table/EpicTable/widgets/EpicSort/EpicSort.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 
 import { Icon, IconType } from '../../../../core/Icon';
-import { Direction } from '../../types';
+import { EpicTableSortDirection } from '../../types';
 import { nextDirection } from './utils';
 
 export type Props = {
   /**
    * The current direction of the sort.
    */
-  direction: Direction;
+  direction: EpicTableSortDirection;
 
   /**
    * The callback which is called when the direction changes.
    */
-  onChange: (direction: Direction) => void;
+  onChange: (direction: EpicTableSortDirection) => void;
 };
 
 /**
@@ -36,7 +36,7 @@ export function EpicSort({ direction, onChange }: Props) {
   );
 }
 
-function iconForDirection(direction: Direction): IconType {
+function iconForDirection(direction: EpicTableSortDirection): IconType {
   if (direction === 'ASC') {
     return 'arrow_drop_up';
   } else if (direction === 'DESC') {

--- a/src/table/EpicTable/widgets/EpicSort/utils.ts
+++ b/src/table/EpicTable/widgets/EpicSort/utils.ts
@@ -1,6 +1,8 @@
-import { Direction } from "../../types";
+import { EpicTableSortDirection } from '../../types';
 
-export function nextDirection(direction: Direction): Direction {
+export function nextDirection(
+  direction: EpicTableSortDirection
+): EpicTableSortDirection {
   if (direction === 'ASC') {
     return 'DESC';
   } else if (direction === 'DESC') {


### PR DESCRIPTION
The changing of the type names is a breaking change for people which
imported these types.

Before this commit the "inner" types of the components would be for
example: `IconPosition` for the `Button` component. This had the side
effect of names not being very "importable" because this would cause
collisions.

Now the inner types are all prefixed with the name of the component.
This means that `IconPosition` is now `ButtonIconPosition`.

Removed `UnionKeys` and `DistributiveOmit` types as they are not used
in the 42 ui itself, and were not exposed.

Also made the `validators` of `DateTimeInput` of type
`FieldValidator<Date>` instead of `FieldValidator<MomentInput>` as
that is the true type.