### PR TITLE
improvement: CheckboxMultiple custom optionsShouldAlwaysContainValue

### DIFF
--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -197,6 +197,133 @@ storiesOf('Form/CheckboxMultipleSelect', module)
       </Form>
     );
   })
+  .add('optionsShouldAlwaysContainValue', () => {
+    const permissions = [
+      'CREATE_CAR',
+      'UPDATE_CAR',
+      'READ_CAR',
+      'DELETE_CAR',
+
+      'CREATE_BIKE',
+      'UPDATE_BIKE',
+      'READ_BIKE',
+      'DELETE_BIKE',
+
+      'CREATE_BOAT',
+      'UPDATE_BOAT',
+      'READ_BOAT',
+      'DELETE_BOAT'
+    ] as const;
+
+    type Permission = typeof permissions[number];
+
+    function carPermissions(): Permission[] {
+      return ['CREATE_CAR', 'UPDATE_CAR', 'READ_CAR', 'DELETE_CAR'];
+    }
+
+    function bikePermissions(): Permission[] {
+      return ['CREATE_BIKE', 'UPDATE_BIKE', 'READ_BIKE', 'DELETE_BIKE'];
+    }
+
+    function boatPermissions(): Permission[] {
+      return ['CREATE_BOAT', 'UPDATE_BOAT', 'READ_BOAT', 'DELETE_BOAT'];
+    }
+
+    const [value, setValue] = useState<Permission[] | undefined>([
+      'CREATE_CAR',
+      'CREATE_BIKE',
+      'CREATE_BOAT'
+    ]);
+
+    return (
+      <Form>
+        <CheckboxMultipleSelect
+          key="car"
+          id="carPermission"
+          label="Car permissions"
+          placeholder="Please select your car permissions"
+          options={carPermissions()}
+          labelForOption={(permission) => permission}
+          optionsShouldAlwaysContainValue={false}
+          value={value}
+          onChange={setValue}
+        />
+
+        <CheckboxMultipleSelect
+          key="bike"
+          id="bikePermission"
+          label="Bike permissions"
+          placeholder="Please select your bike permissions"
+          options={bikePermissions()}
+          labelForOption={(permission) => permission}
+          optionsShouldAlwaysContainValue={false}
+          value={value}
+          onChange={setValue}
+        />
+
+        <CheckboxMultipleSelect
+          key="boat"
+          id="boatPermission"
+          label="Boat permissions"
+          placeholder="Please select your boat permissions"
+          options={boatPermissions()}
+          labelForOption={(permission) => permission}
+          optionsShouldAlwaysContainValue={false}
+          value={value}
+          onChange={setValue}
+        />
+
+        {value ? (
+          <p>
+            Your permissions are:{' '}
+            {value.map((permissions) => permissions).join(', ')}
+          </p>
+        ) : null}
+
+        <p>
+          <strong>optionsShouldAlwaysContainValue</strong> determines whether or
+          not the form element should always contain the value which is
+          selected.
+        </p>
+
+        <p>
+          It should be <strong>true</strong> when using it in the following
+          situation: The form element receives a value which is no longer part
+          of the options. In that case it is handy to have the value
+          automatically added to the options, so the user still sees the select
+          value.
+        </p>
+
+        <p>
+          It should be <strong>false</strong> when using it in the following
+          situations:
+          <ol>
+            <li>
+              The selected `value` is displayed separately from the selection of
+              values. In this case it does not make sense to add the `value` to
+              the options because it is already displayed.
+            </li>
+
+            <li>
+              The form element represents a sub selection of a larger value. For
+              example you have an array of permissions of what the user can do
+              in the system, visually you display grouped by parts of the
+              domain. This means giving the same `value` to various form element
+              components to represent parts of the same array of permissions. If
+              `optionsShouldAlwaysContainValue` were `true` it would add all
+              permissions to each permission group.
+            </li>
+          </ol>
+        </p>
+
+        <p>
+          In the above example it is <strong>false</strong> because otherwise
+          the selected CREATE options would appear in each form element, and not
+          just the one for the group.
+        </p>
+      </Form>
+    );
+  })
   .add('label & placeholder', () => {
     const [value, setValue] = useState<Province[] | undefined>([
       nonExistingProvince()

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
@@ -27,7 +27,8 @@ describe('Component: CheckboxMultipleSelect', () => {
     hasPlaceholder = true,
     hasLabel = true,
     horizontal,
-    loading = false
+    loading = false,
+    optionsShouldAlwaysContainValueConfig
   }: {
     value?: User[];
     isOptionEnabled?: IsOptionEnabled<User>;
@@ -38,6 +39,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     horizontal?: boolean;
     hasIsOptionEqual?: boolean;
     loading?: boolean;
+    optionsShouldAlwaysContainValueConfig?: boolean;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -47,7 +49,9 @@ describe('Component: CheckboxMultipleSelect', () => {
       ({ options, pageNumber, size, optionsShouldAlwaysContainValue }) => {
         expect(pageNumber).toBe(1);
         expect(size).toBe(100);
-        expect(optionsShouldAlwaysContainValue).toBe(true);
+        expect(optionsShouldAlwaysContainValue).toBe(
+          optionsShouldAlwaysContainValueConfig ?? true
+        );
 
         return {
           page: pageOf(options, pageNumber, size),
@@ -66,7 +70,8 @@ describe('Component: CheckboxMultipleSelect', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      horizontal
+      horizontal,
+      optionsShouldAlwaysContainValue: optionsShouldAlwaysContainValueConfig
     };
 
     const labelProps = hasLabel ? { id: 'subject', label: 'Subject' } : {};
@@ -268,6 +273,36 @@ describe('Component: CheckboxMultipleSelect', () => {
 
       checkbox = checkboxMultipleSelect.find('Input').at(1);
       expect(checkbox.props().checked).toBe(true);
+    });
+  });
+
+  describe('optionsShouldAlwaysContainValue behavior', () => {
+    test('when false is provided it should be false', () => {
+      setup({
+        optionsShouldAlwaysContainValueConfig: false
+      });
+
+      expect(useOptions).toBeCalledWith(
+        expect.objectContaining({ optionsShouldAlwaysContainValue: false })
+      );
+    });
+
+    test('when true is provided it should be true', () => {
+      setup({
+        optionsShouldAlwaysContainValueConfig: true
+      });
+
+      expect(useOptions).toBeCalledWith(
+        expect.objectContaining({ optionsShouldAlwaysContainValue: true })
+      );
+    });
+
+    test('when nothing is provided it should be true', () => {
+      setup({});
+
+      expect(useOptions).toBeCalledWith(
+        expect.objectContaining({ optionsShouldAlwaysContainValue: true })
+      );
     });
   });
 });

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -36,6 +36,36 @@ export type Props<T> = Omit<FieldCompatible<T[], T[]>, 'valid'> &
      * Defaults to `false`
      */
     horizontal?: boolean;
+
+    /**
+     * Whether or not the form element should always contain the value
+     * which is selected.
+     *
+     * It should be `true` when using it in the following situation:
+     * The form element receives a value which is no longer part
+     * of the options. In that case it is handy to have the value
+     * automatically added to the options, so the user still sees
+     * the select value.
+     *
+     * It should be `false` when using it in the following situations:
+     *
+     * 1. The selected `value` is displayed separately from the
+     *    selection of values. In this case it does not make sense
+     *    to add the `value` to the options because it is already
+     *    displayed.
+     *
+     * 2. The form element represents a sub selection of a larger
+     *    value. For example you have an array of permissions of what
+     *    the user can do in the system, visually you display grouped
+     *    by parts of the domain. This means giving the same `value`
+     *    to various form element components to represent parts of the
+     *    same array of permissions. If `optionsShouldAlwaysContainValue`
+     *    were `true` it would add all permissions to each permission
+     *    group.
+     *
+     * This value is `true` by default.
+     */
+    optionsShouldAlwaysContainValue?: boolean;
   };
 
 /**
@@ -59,6 +89,7 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
     keyForOption,
     horizontal = false,
     isOptionEnabled = alwaysTrue,
+    optionsShouldAlwaysContainValue = true,
     onChange,
     onBlur
   } = props;
@@ -74,7 +105,7 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
     pageNumber: 1,
     query: '',
     size: 100,
-    optionsShouldAlwaysContainValue: true
+    optionsShouldAlwaysContainValue
   });
 
   function optionClicked(option: T, isSelected: boolean) {


### PR DESCRIPTION
Allow the developer to manually specify the
`optionsShouldAlwaysContainValue` value which is passed to the
`useOptions` hook.

Closes: #518