### PR TITLE
improvement: option to hide clear button

### DIFF
--- a/src/form/ColorPicker/ColorPicker.stories.tsx
+++ b/src/form/ColorPicker/ColorPicker.stories.tsx
@@ -105,6 +105,24 @@ storiesOf('Form/ColorPicker', module)
       </div>
     );
   })
+  .add('without clear button', () => {
+    const [value, setValue] = useState<string | undefined>('#ff0000');
+
+    return (
+      <div>
+        <Form>
+          <ColorPicker
+            id="color"
+            label="Color"
+            placeholder="Please select your favorite color"
+            value={value}
+            onChange={setValue}
+            canClear={false}
+          />
+        </Form>
+      </div>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/ColorPicker/ColorPicker.test.tsx
+++ b/src/form/ColorPicker/ColorPicker.test.tsx
@@ -6,9 +6,10 @@ import { SketchPicker } from 'react-color';
 import Popover from '../../core/Popover/Popover';
 
 import ColorPicker from './ColorPicker';
+import TextButton from '../../core/TextButton/TextButton';
 
 describe('Component: ColorPicker', () => {
-  function setup({ value, hasIcon }: { value?: string; hasIcon?: boolean }) {
+  function setup({ value, hasIcon, canClear }: { value?: string; hasIcon?: boolean; canClear?: boolean }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
 
@@ -22,7 +23,8 @@ describe('Component: ColorPicker', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      color: 'success'
+      color: 'success',
+      canClear
     };
 
     // @ts-expect-error Test mock
@@ -56,6 +58,12 @@ describe('Component: ColorPicker', () => {
         colorPicker.find('Popover').props().target
       );
       expect(button.find('Icon').exists()).toBe(true);
+    });
+
+    test('without clear button', () => {
+      const { colorPicker } = setup({ value: '#cdcdcd', canClear: false });
+
+      expect(colorPicker.find(TextButton).exists()).toBe(false);
     });
   });
 

--- a/src/form/ColorPicker/ColorPicker.tsx
+++ b/src/form/ColorPicker/ColorPicker.tsx
@@ -90,6 +90,13 @@ type Props = {
    * This text should already be translated.
    */
   text?: Text;
+
+  /**
+   * Whether or not to show a "clear" button.
+   *
+   * Defaults to `true`
+   */
+  canClear?: boolean;
 };
 
 /**
@@ -108,6 +115,7 @@ export default function ColorPicker(props: Props) {
     error,
     onChange,
     onBlur,
+    canClear = true,
     text = {}
   } = props;
 
@@ -130,23 +138,25 @@ export default function ColorPicker(props: Props) {
       <div className="d-flex">
         {value ? (
           <div className="d-flex justify-content-between">
-            <div className="border p-1">
+            <div className="border p-1 mr-3">
               <div
                 id="color-picker-value"
                 className="h-100"
                 style={{ backgroundColor: value, width: 42 }}
               />
             </div>
-            <TextButton
-              onClick={() => onColorSelected(undefined)}
-              className="mx-3"
-            >
-              {t({
-                key: 'ColorPicker.CLEAR',
-                fallback: 'Clear',
-                overrideText: text.clear
-              })}
-            </TextButton>
+            {canClear ? (
+              <TextButton
+                onClick={() => onColorSelected(undefined)}
+                className="mr-3"
+              >
+                {t({
+                  key: 'ColorPicker.CLEAR',
+                  fallback: 'Clear',
+                  overrideText: text.clear
+                })}
+              </TextButton>
+            ) : null}
           </div>
         ) : null}
         <Popover

--- a/src/form/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/src/form/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Component: ColorPicker ui with selected value 1`] = `
       className="d-flex justify-content-between"
     >
       <div
-        className="border p-1"
+        className="border p-1 mr-3"
       >
         <div
           className="h-100"
@@ -42,7 +42,7 @@ exports[`Component: ColorPicker ui with selected value 1`] = `
         />
       </div>
       <TextButton
-        className="mx-3"
+        className="mr-3"
         onClick={[Function]}
       >
         Clear

--- a/src/form/IconPicker/IconPicker.stories.tsx
+++ b/src/form/IconPicker/IconPicker.stories.tsx
@@ -85,6 +85,23 @@ storiesOf('Form/IconPicker', module)
       </div>
     );
   })
+  .add('without clear button', () => {
+    const [value, setValue] = useState<IconType | undefined>(undefined);
+
+    return (
+      <div>
+        <Form>
+          <IconPicker
+            id="icon"
+            placeholder="Please select your icon"
+            value={value}
+            onChange={setValue}
+            canClear={false}
+          />
+        </Form>
+      </div>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/IconPicker/IconPicker.test.tsx
+++ b/src/form/IconPicker/IconPicker.test.tsx
@@ -6,16 +6,19 @@ import IconPicker from './IconPicker';
 import { SearchInput, Icon, IconType, Pager } from '../..';
 import { Button } from 'reactstrap';
 import Popover from '../../core/Popover/Popover';
+import TextButton from '../../core/TextButton/TextButton';
 
 describe('Component: IconPicker', () => {
   function setup({
     value,
     hasLabel = true,
-    hasIcon = false
+    hasIcon = false,
+    canClear
   }: {
     value?: IconType;
     hasLabel?: boolean;
     hasIcon?: boolean;
+    canClear?: boolean;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -31,7 +34,8 @@ describe('Component: IconPicker', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      color: 'success'
+      color: 'success',
+      canClear
     };
 
     // @ts-expect-error Test mock
@@ -98,6 +102,12 @@ describe('Component: IconPicker', () => {
         iconPicker.find('Popover').props().target
       );
       expect(button.find('Icon').exists()).toBe(true);
+    });
+
+    test('without clear button', () => {
+      const { iconPicker } = setup({ value: '3d_rotation', canClear: false });
+
+      expect(iconPicker.find(TextButton).exists()).toBe(false);
     });
   });
 

--- a/src/form/IconPicker/IconPicker.tsx
+++ b/src/form/IconPicker/IconPicker.tsx
@@ -52,6 +52,13 @@ type Props = FieldCompatible<IconType, IconType | undefined> & {
    * Optionally the icon to display on the button to open the icon picker.
    */
   icon?: IconType;
+
+  /**
+   * Whether or not to show a "clear" button.
+   *
+   * Defaults to `true`
+   */
+  canClear?: boolean;
 };
 
 /**
@@ -70,7 +77,8 @@ export default function IconPicker(props: Props) {
     error,
     onChange,
     onBlur,
-    text = {}
+    text = {},
+    canClear = true
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -107,17 +115,23 @@ export default function IconPicker(props: Props) {
           <div className="d-flex">
             {value ? (
               <div className="d-flex justify-content-between">
-                <Icon id="icon-picker-value" className="pt-2" icon={value} />
-                <TextButton
-                  onClick={() => onIconSelected(undefined)}
-                  className="mx-3"
-                >
-                  {t({
-                    key: 'IconPicker.CLEAR',
-                    fallback: 'Clear',
-                    overrideText: text.clear
-                  })}
-                </TextButton>
+                <Icon
+                  id="icon-picker-value"
+                  className="pt-2 mr-3"
+                  icon={value}
+                />
+                {canClear ? (
+                  <TextButton
+                    onClick={() => onIconSelected(undefined)}
+                    className="mr-3"
+                  >
+                    {t({
+                      key: 'IconPicker.CLEAR',
+                      fallback: 'Clear',
+                      overrideText: text.clear
+                    })}
+                  </TextButton>
+                ) : null}
               </div>
             ) : null}
             <Popover

--- a/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
+++ b/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
@@ -116,12 +116,12 @@ exports[`Component: IconPicker ui with selected value 1`] = `
       className="d-flex justify-content-between"
     >
       <Icon
-        className="pt-2"
+        className="pt-2 mr-3"
         icon="3d_rotation"
         id="icon-picker-value"
       />
       <TextButton
-        className="mx-3"
+        className="mr-3"
         onClick={[Function]}
       >
         Clear

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -82,8 +82,8 @@ export function ModalPickerOpener<T>(props: Props<T>) {
   });
 
   const buttonClassName = classNames('flex-grow-0', 'flex-shrink-0', {
-    'mr-1': hasValue && alignButton === 'left',
-    'ml-1': hasValue && alignButton !== 'left'
+    'mr-3': hasValue && alignButton === 'left',
+    'ml-3': hasValue && alignButton !== 'left'
   });
 
   // @ts-expect-error Accept that DisplayValues is sometimes an array and sometimes not
@@ -94,7 +94,7 @@ export function ModalPickerOpener<T>(props: Props<T>) {
       {displayValue}
 
       {hasValue && onClear ? (
-        <TextButton onClick={onClear} className="mx-3">
+        <TextButton onClick={onClear} className="ml-3">
           {t({
             overrideText: text.clear,
             key: 'ModalPickerOpener.CLEAR',

--- a/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
+++ b/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`Component: ModalPickerOpener ui button aligned left with values: Compon
     ADMIN@42.NL
   </span>
   <TextButton
-    className="mx-3"
+    className="ml-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 mr-1"
+    className="flex-grow-0 flex-shrink-0 mr-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -47,13 +47,13 @@ exports[`Component: ModalPickerOpener ui button aligned right with values: Compo
     ADMIN@42.NL
   </span>
   <TextButton
-    className="mx-3"
+    className="ml-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 ml-1"
+    className="flex-grow-0 flex-shrink-0 ml-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -86,13 +86,13 @@ exports[`Component: ModalPickerOpener ui tooltip: Component: ModalPickerOpener =
     ADMIN@42.NL
   </span>
   <TextButton
-    className="mx-3"
+    className="ml-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 ml-1"
+    className="flex-grow-0 flex-shrink-0 ml-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -110,13 +110,13 @@ exports[`Component: ModalPickerOpener ui with values: Component: ModalPickerOpen
     ADMIN@42.NL
   </span>
   <TextButton
-    className="mx-3"
+    className="ml-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 ml-1"
+    className="flex-grow-0 flex-shrink-0 ml-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -530,6 +530,25 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
       </Form>
     );
   })
+  .add('without clear button', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple
+          id="provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          canClear={false}
+        />
+      </Form>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -21,6 +21,8 @@ import { useOptions } from '../../useOptions';
 import { Color } from '../../../core/types';
 import { IsOptionEnabled } from '../../option';
 import { icons } from '../../../core/Icon';
+import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
+import TextButton from '../../../core/TextButton/TextButton';
 
 jest.mock('../../useOptions', () => {
   return { useOptions: jest.fn() };
@@ -39,7 +41,8 @@ describe('Component: ModalPickerMultiple', () => {
     empty = false,
     reUsePage = false,
     isOptionEnabled,
-    isAsync = false
+    isAsync = false,
+    canClear
   }: {
     value?: User[];
     showAddButton?: boolean;
@@ -54,6 +57,7 @@ describe('Component: ModalPickerMultiple', () => {
     reUsePage?: boolean;
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
+    canClear?: boolean;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -115,7 +119,8 @@ describe('Component: ModalPickerMultiple', () => {
       renderOptions: hasRenderOptions
         ? () => <span>RenderOptions</span>
         : undefined,
-      color: 'success' as Color
+      color: 'success' as Color,
+      canClear
     };
 
     const labelProps = hasLabel
@@ -307,6 +312,16 @@ describe('Component: ModalPickerMultiple', () => {
       expect(toJson(modalPickerMultiple)).toMatchSnapshot(
         'Component: ModalPickerMultiple => ui => should render button right with value'
       );
+    });
+
+    it('should render without clear button', () => {
+      const { modalPickerMultiple } = setup({
+        value: [adminUser()],
+        canClear: false
+      });
+      expect(
+        modalPickerMultiple.find(ModalPickerOpener).find(TextButton).exists()
+      ).toBe(false);
     });
 
     describe('renderValue', () => {

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -70,6 +70,13 @@ export type Props<T> = Omit<
      * Callback to customize display of options.
      */
     renderOptions?: ModalPickerRenderOptions<T>;
+
+    /**
+     * Whether or not to show a "clear" button.
+     *
+     * Defaults to `true`
+     */
+    canClear?: boolean;
   };
 
 /**
@@ -107,7 +114,8 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
     alignButton,
     renderOptions,
     error,
-    onBlur
+    onBlur,
+    canClear = true
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -208,7 +216,7 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
             labelForOption={labelForOption}
           />
         ),
-    onClear: () => onChange(undefined),
+    onClear: canClear ? () => onChange(undefined) : undefined,
     // Only render the clear button when it has a value
     value: value && value.length > 0 ? value : undefined
   };

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -425,6 +425,22 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
       </Form>
     );
   })
+  .add('without clear button', () => {
+    const [value, setValue] = useState<Province | undefined>(provinces()[0]);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          canClear={false}
+        />
+      </Form>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -21,6 +21,8 @@ import { useOptions } from '../../useOptions';
 import { Color } from '../../../core/types';
 import { IsOptionEnabled } from '../../option';
 import { icons } from '../../../core/Icon';
+import { ModalPickerOpener } from '../ModalPickerOpener/ModalPickerOpener';
+import TextButton from '../../../core/TextButton/TextButton';
 
 jest.mock('../../useOptions', () => {
   return { useOptions: jest.fn() };
@@ -39,7 +41,8 @@ describe('Component: ModalPickerSingle', () => {
     empty = false,
     reUsePage = false,
     isOptionEnabled,
-    isAsync = false
+    isAsync = false,
+    canClear
   }: {
     value?: User;
     showAddButton?: boolean;
@@ -53,6 +56,7 @@ describe('Component: ModalPickerSingle', () => {
     reUsePage?: boolean;
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
+    canClear?: boolean;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -108,7 +112,8 @@ describe('Component: ModalPickerSingle', () => {
       renderOptions: hasRenderOptions
         ? () => <span>RenderOptions</span>
         : undefined,
-      color: 'success' as Color
+      color: 'success' as Color,
+      canClear
     };
 
     const labelProps = hasLabel
@@ -248,6 +253,16 @@ describe('Component: ModalPickerSingle', () => {
       expect(toJson(modalPickerSingle)).toMatchSnapshot(
         'Component: ModalPickerSingle => ui => should render button right with value'
       );
+    });
+
+    it('should render without clear button', () => {
+      const { modalPickerSingle } = setup({
+        value: adminUser(),
+        canClear: false
+      });
+      expect(
+        modalPickerSingle.find(ModalPickerOpener).find(TextButton).exists()
+      ).toBe(false);
     });
 
     describe('renderValue', () => {

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -66,6 +66,13 @@ type Props<T> = Omit<
      * Callback to customize display of options.
      */
     renderOptions?: ModalPickerRenderOptions<T>;
+
+    /**
+     * Whether or not to show a "clear" button.
+     *
+     * Defaults to `true`
+     */
+    canClear?: boolean;
   };
 
 /**
@@ -102,7 +109,8 @@ export default function ModalPickerSingle<T>(props: Props<T>) {
     renderValue,
     alignButton,
     renderOptions,
-    error
+    error,
+    canClear = true
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -171,7 +179,7 @@ export default function ModalPickerSingle<T>(props: Props<T>) {
             labelForOption={labelForOption}
           />
         ),
-    onClear: () => onChange(undefined),
+    onClear: canClear ? () => onChange(undefined) : undefined,
     value
   };
 

--- a/src/form/ValuePicker/ValuePicker.stories.tsx
+++ b/src/form/ValuePicker/ValuePicker.stories.tsx
@@ -214,6 +214,32 @@ storiesOf('Form/ValuePicker/multiple', module)
       </Form>
     );
   })
+  .add('without clear button', () => {
+    const [value, setValue] = useState<User[] | undefined>([user]);
+
+    const promise = sizes['large'];
+
+    return (
+      <Form>
+        <ValuePicker<User>
+          multiple={true}
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
+          value={value}
+          onChange={setValue}
+          canClear={false}
+        />
+        <p className="mt-3">
+          <strong>Disclaimer:</strong> canClear has no effect on small option
+          sets (1-10 options) because checkboxes can be unselected.
+        </p>
+      </Form>
+    );
+  })
   .add('jarb', () => {
     const [size, setSize] = useState('small');
 
@@ -405,6 +431,41 @@ storiesOf('Form/ValuePicker/single', module)
         />
 
         <p>The icon only works when there are more than 10 options.</p>
+      </Form>
+    );
+  })
+  .add('without clear button', () => {
+    const [value, setValue] = useState<User | undefined>(user);
+
+    const [size, setSize] = useState('small');
+
+    const promise = sizes[size];
+
+    return (
+      <Form>
+        <ValuePicker<User>
+          multiple={false}
+          id="bestFriend"
+          label="Best friend"
+          placeholder="Select your best friend"
+          canSearch={true}
+          options={() => promise}
+          labelForOption={(user: User) => user.email}
+          value={value}
+          onChange={setValue}
+          canClear={false}
+        />
+
+        <p>Use these buttons to trigger a morph</p>
+        <Button className="mr-1" onClick={() => setSize('small')}>
+          Small
+        </Button>
+        <Button onClick={() => setSize('large')}>Large</Button>
+        <p className="mt-3">
+          <strong>Disclaimer:</strong> canClear has no effect on medium option
+          sets (4-10 options) because the select dropdown has a placeholder
+          option to clear the value.
+        </p>
       </Form>
     );
   })

--- a/src/form/ValuePicker/ValuePicker.test.tsx
+++ b/src/form/ValuePicker/ValuePicker.test.tsx
@@ -26,11 +26,13 @@ describe('Component: ValuePicker', () => {
 
   function setup({
     options,
-    multiple
+    multiple,
+    canClear
   }: {
     options: Options<User>;
     multiple: true | false;
     value?: User | User[];
+    canClear?: boolean;
   }) {
     onChangeSpy = jest.fn();
     onBlurSpy = jest.fn();
@@ -48,6 +50,7 @@ describe('Component: ValuePicker', () => {
         value={undefined}
         onChange={onChangeSpy}
         onBlur={onBlurSpy}
+        canClear={canClear}
       />
     );
   }
@@ -123,6 +126,20 @@ describe('Component: ValuePicker', () => {
         valuePicker.update();
 
         expect(valuePicker.find('RadioGroup').exists()).toBe(true);
+      });
+
+      it('should render a `RadioGroup` component without clear button', () => {
+        setup({
+          options: listOfUsers(),
+          multiple: false,
+          canClear: false
+        });
+
+        valuePicker.update();
+
+        expect(valuePicker.find('RadioGroup').find('TextButton').exists()).toBe(
+          false
+        );
       });
     });
 
@@ -256,6 +273,32 @@ describe('Component: ValuePicker', () => {
         valuePicker.update();
 
         expect(valuePicker.find('ModalPickerSingle').exists()).toBe(true);
+      });
+
+      it('should render a `ModalPickerSingle` component without clear button', () => {
+        setup({
+          options: [
+            adminUser(),
+            coordinatorUser(),
+            userUser(),
+            nobodyUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser()
+          ],
+          multiple: false,
+          canClear: false
+        });
+
+        valuePicker.update();
+
+        expect(
+          valuePicker.find('ModalPickerSingle').find('TextButton').exists()
+        ).toBe(false);
       });
     });
   });
@@ -403,6 +446,32 @@ describe('Component: ValuePicker', () => {
         valuePicker.update();
 
         expect(valuePicker.find('ModalPickerMultiple').exists()).toBe(true);
+      });
+
+      it('should render a `ModalPickerMultiple` component without clear button', () => {
+        setup({
+          options: [
+            adminUser(),
+            coordinatorUser(),
+            userUser(),
+            nobodyUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser(),
+            randomUser()
+          ],
+          multiple: true,
+          canClear: false
+        });
+
+        valuePicker.update();
+
+        expect(
+          valuePicker.find('ModalPickerMultiple').find('TextButton').exists()
+        ).toBe(false);
       });
     });
   });

--- a/src/form/ValuePicker/ValuePicker.tsx
+++ b/src/form/ValuePicker/ValuePicker.tsx
@@ -47,6 +47,15 @@ type BaseValuePickerProps<T> = Omit<FieldCompatible<T, T>, 'placeholder'> &
      * This text should already be translated.
      */
     text?: Text;
+
+    /**
+     * Whether or not to show a "clear" button.
+     * This property only has effect when there are more than 10 options
+     * or single value with 1-3 options.
+     *
+     * Defaults to `true`
+     */
+    canClear?: boolean;
   };
 
 type SingleValuePicker<T> = Omit<
@@ -110,7 +119,7 @@ type Props<T> = SingleValuePicker<T> | MultipleValuePicker<T>;
  * for a `Page` of size `1` so it can get the `totalElements`.
  */
 export default function ValuePicker<T>(props: Props<T>) {
-  const { text = {}, options } = props;
+  const { text = {}, options, canClear = true } = props;
 
   const [booting, setBooting] = useState(true);
   const [totalElements, setTotalElements] = useState(0);
@@ -152,17 +161,17 @@ export default function ValuePicker<T>(props: Props<T>) {
     if (totalElements < 11) {
       return <CheckboxMultipleSelect {...rest} />;
     } else {
-      return <ModalPickerMultiple {...rest} />;
+      return <ModalPickerMultiple canClear={canClear} {...rest} />;
     }
   } else {
     const { multiple, ...rest } = props;
 
     if (totalElements < 4) {
-      return <RadioGroup canClear={true} {...rest} />;
+      return <RadioGroup canClear={canClear} {...rest} />;
     } else if (totalElements < 11) {
       return <Select {...rest} />;
     } else {
-      return <ModalPickerSingle {...rest} />;
+      return <ModalPickerSingle canClear={canClear} {...rest} />;
     }
   }
 }

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -899,7 +899,6 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
   placeholder="Select your best friend"
 >
   <RadioGroup
-    canClear={true}
     canSearch={true}
     icon="face"
     id="bestFriend"


### PR DESCRIPTION
Sometimes a field is required and should work like a radio button, where
it is not possible to clear the field, you have to select at least one
option. It would be nice to be able to use all form components that way,
but for that we need an option whether to display the clear button.

Added canClear option to form components to be able to prevent users
from clearing the form element.

Closes #502