### PR TITLE
fix: select options array not displaying all options

### DIFF
--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -67,6 +67,12 @@ storiesOf('Form/CheckboxMultipleSelect', module)
             {value.map((province) => province.label).join(', ')}
           </p>
         ) : null}
+
+        <p className="mt-3">
+          <strong>Disclaimer:</strong> when using async, a maximum of 100
+          options will be displayed. If you want to display more than 100
+          options, you should use the ModalPickerMultiple.
+        </p>
       </Form>
     );
   })

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.test.tsx
@@ -48,7 +48,7 @@ describe('Component: CheckboxMultipleSelect', () => {
     useOptions.mockImplementation(
       ({ options, pageNumber, size, optionsShouldAlwaysContainValue }) => {
         expect(pageNumber).toBe(1);
-        expect(size).toBe(100);
+        expect(size).toBe(3);
         expect(optionsShouldAlwaysContainValue).toBe(
           optionsShouldAlwaysContainValueConfig ?? true
         );

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -72,6 +72,11 @@ export type Props<T> = Omit<FieldCompatible<T[], T[]>, 'valid'> &
  * CheckboxMultipleSelect is a form element for which the values can
  * be selected from a limited range. Is shown a grid of options as
  * checkboxes from which the user can select multiple values.
+ *
+ * If you pass a callback to the options property, be aware
+ * that only 100 options will be displayed without pagination.
+ * If you want to display more than 100 options,
+ * you should use the ModalPickerMultiple instead.
  */
 export default function CheckboxMultipleSelect<T>(props: Props<T>) {
   const {
@@ -104,7 +109,7 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
     reloadOptions,
     pageNumber: 1,
     query: '',
-    size: 100,
+    size: Array.isArray(props.options) ? props.options.length : 100,
     optionsShouldAlwaysContainValue
   });
 

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -54,6 +54,12 @@ storiesOf('Form/RadioGroup', module)
         />
 
         {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <p className="mt-3">
+          <strong>Disclaimer:</strong> when using async, a maximum of 100
+          options will be displayed. If you want to display more than 100
+          options, you should use the ModalPickerSingle.
+        </p>
       </Form>
     );
   })

--- a/src/form/RadioGroup/RadioGroup.test.tsx
+++ b/src/form/RadioGroup/RadioGroup.test.tsx
@@ -53,7 +53,7 @@ describe('Component: RadioGroup', () => {
       }) => {
         expect(pageNumber).toBe(1);
         expect(query).toBe('');
-        expect(size).toBe(10);
+        expect(size).toBe(3);
         expect(optionsShouldAlwaysContainValue).toBe(true);
 
         return {

--- a/src/form/RadioGroup/RadioGroup.tsx
+++ b/src/form/RadioGroup/RadioGroup.tsx
@@ -53,6 +53,11 @@ export type Props<T> = FieldCompatible<T, T | undefined> &
 /**
  * RadioGroup is a form element for which the value can be selected
  * from a limited range.
+ *
+ * If you pass a callback to the options property, be aware
+ * that only 100 options will be displayed without pagination.
+ * If you want to display more than 100 options,
+ * you should use the ModalPickerSingle instead.
  */
 export default function RadioGroup<T>(props: Props<T>) {
   const {
@@ -83,7 +88,7 @@ export default function RadioGroup<T>(props: Props<T>) {
     reloadOptions,
     pageNumber: 1,
     query: '',
-    size: 10,
+    size: Array.isArray(options) ? options.length : 100,
     optionsShouldAlwaysContainValue: true
   });
 

--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -54,6 +54,12 @@ storiesOf('Form/Select', module)
         />
 
         {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <p className="mt-3">
+          <strong>Disclaimer:</strong> when using async, a maximum of 100
+          options will be displayed. If you want to display more than 100
+          options, you should use the ModalPickerSingle.
+        </p>
       </Form>
     );
   })

--- a/src/form/Select/Select.test.tsx
+++ b/src/form/Select/Select.test.tsx
@@ -51,7 +51,7 @@ describe('Component: Select', () => {
       }) => {
         expect(pageNumber).toBe(1);
         expect(query).toBe('');
-        expect(size).toBe(10);
+        expect(size).toBe(3);
         expect(optionsShouldAlwaysContainValue).toBe(true);
 
         return {

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -35,6 +35,11 @@ export type Props<T> = FieldCompatible<T, T> &
 /**
  * Select is a form element for which the value can be selected
  * from a limited range.
+ *
+ * If you pass a callback to the options property, be aware
+ * that only 100 options will be displayed without pagination.
+ * If you want to display more than 100 options,
+ * you should use the ModalPickerSingle instead.
  */
 export default function Select<T>(props: Props<T>) {
   const {
@@ -66,7 +71,7 @@ export default function Select<T>(props: Props<T>) {
     reloadOptions,
     pageNumber: 1,
     query: '',
-    size: 10,
+    size: Array.isArray(options) ? options.length : 100,
     optionsShouldAlwaysContainValue: true
   });
 

--- a/src/form/ValuePicker/ValuePicker.test.tsx
+++ b/src/form/ValuePicker/ValuePicker.test.tsx
@@ -107,7 +107,7 @@ describe('Component: ValuePicker', () => {
           expect(fetchOptionsSpy).toHaveBeenLastCalledWith({
             query: '',
             page: 1,
-            size: 10
+            size: 100
           });
 
           done();
@@ -182,7 +182,7 @@ describe('Component: ValuePicker', () => {
           expect(fetchOptionsSpy).toHaveBeenLastCalledWith({
             query: '',
             page: 1,
-            size: 10
+            size: 100
           });
 
           done();

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -880,7 +880,7 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
           Object {
             "page": 1,
             "query": "",
-            "size": 10,
+            "size": 100,
           },
         ],
       ],
@@ -920,7 +920,7 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
             Object {
               "page": 1,
               "query": "",
-              "size": 10,
+              "size": 100,
             },
           ],
         ],
@@ -1126,7 +1126,7 @@ exports[`Component: ValuePicker single when Select should render a \`Select\` co
           Object {
             "page": 1,
             "query": "",
-            "size": 10,
+            "size": 100,
           },
         ],
       ],
@@ -1166,7 +1166,7 @@ exports[`Component: ValuePicker single when Select should render a \`Select\` co
             Object {
               "page": 1,
               "query": "",
-              "size": 10,
+              "size": 100,
             },
           ],
         ],


### PR DESCRIPTION
When the options given to the Select component is an array with more
than 10 options, not all options are displayed.

Changed form elements that provide a selection without pagination to
display all options when an array was given as options, and a maximum of
100 options when a callback was given to fetch options.

Closes #522