### PR TITLE
fix: EpicTable detail overlay padding

### DIFF
--- a/src/table/EpicTable/widgets/EpicDetail/EpicDetail.tsx
+++ b/src/table/EpicTable/widgets/EpicDetail/EpicDetail.tsx
@@ -36,7 +36,7 @@ type Props = {
 export function EpicDetail({ children, onClose, text = {} }: Props) {
   return (
     <div className="bg-white h-100 border-top border-right border-bottom py-1 shadow">
-      <div className="d-flex align-items-center border-bottom mb-2">
+      <div className="d-flex align-items-center border-bottom">
         <Icon className="text-muted py-2 px-1" onClick={onClose} icon="close" />
         <span className="text-muted">
           {t({
@@ -47,7 +47,7 @@ export function EpicDetail({ children, onClose, text = {} }: Props) {
         </span>
       </div>
 
-      <div className="px-2">{children}</div>
+      <div className="p-2">{children}</div>
     </div>
   );
 }

--- a/src/table/EpicTable/widgets/EpicDetail/__snapshots__/EpicDetail.test.tsx.snap
+++ b/src/table/EpicTable/widgets/EpicDetail/__snapshots__/EpicDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Component: EpicDetail ui 1`] = `
   className="bg-white h-100 border-top border-right border-bottom py-1 shadow"
 >
   <div
-    className="d-flex align-items-center border-bottom mb-2"
+    className="d-flex align-items-center border-bottom"
   >
     <Icon
       className="text-muted py-2 px-1"
@@ -19,7 +19,7 @@ exports[`Component: EpicDetail ui 1`] = `
     </span>
   </div>
   <div
-    className="px-2"
+    className="p-2"
   >
     <Component />
   </div>


### PR DESCRIPTION
When using for instance a button as last element in the detail overlay
of the EpicTable, the button sticks to the bottom of the table, even
when a margin is used.

Added padding to the bottom of the detail overlay to prevent elements to
stick to the bottom of the detail overlay and allow for margins to add
extra spacing.

Closes #514