### PR TITLE
improvement: typeahead invert highlight styling

### DIFF
--- a/src/form/Typeahead/Typeahead.scss
+++ b/src/form/Typeahead/Typeahead.scss
@@ -40,4 +40,13 @@
       border-color: $danger;
     }
   }
+
+  .rbt-menu {
+    .dropdown-item {
+      font-weight: bold;
+      .rbt-highlight-text {
+        font-weight: normal;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Users are aware of the text they just typed, so only emphasise the
predictive aspect of the query suggestion (and not what the users has
typed already, as is currently the case).

Inverted the font weight of the options to display the matching text in
normal font and the rest of the text in bold.

#517