### PR TITLE
improvement: ModalPickerMultiple without selection

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -186,6 +186,9 @@ Here is a JSON notation containing all keys and default translations:
   },
   "withJarb": {
     "REQUIRED_MARK": " *"
+  },
+  "ModalPickerMultiple": {
+    "NO_OPTION_SELECTED": "No option selected"
   }
 }
 ```

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -22,6 +22,7 @@ import { FieldCompatible } from '../../types';
 import { useId } from '../../../hooks/useId/useId';
 import { useOptions } from '../../useOptions';
 import { IconType } from '../../../core/Icon';
+import { t } from '../../../utilities/translation/translation';
 
 export type ModalPickerMultipleRenderValues<T> = (
   value?: T[]
@@ -314,10 +315,6 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
   }
 
   function renderModalCurrentSelection() {
-    if (!selected || selected.length === 0) {
-      return null;
-    }
-
     return (
       <Row
         className="mb-3 p-2"
@@ -326,17 +323,26 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
         }}
       >
         <Col>
-          {selected.map((value) => {
-            const label = labelForOption(value);
+          {selected && selected.length > 0 ? (
+            selected.map((value) => {
+              const label = labelForOption(value);
 
-            return (
-              <Tag
-                key={label}
-                onRemove={() => optionClicked(value, true)}
-                text={label}
-              />
-            );
-          })}
+              return (
+                <Tag
+                  key={label}
+                  onRemove={() => optionClicked(value, true)}
+                  text={label}
+                />
+              );
+            })
+          ) : (
+            <span className="text-muted">
+              {t({
+                key: 'ModalPickerMultiple.NO_OPTION_SELECTED',
+                fallback: 'No option selected'
+              })}
+            </span>
+          )}
         </Col>
       </Row>
     );

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -100,6 +100,43 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
     selected={Array []}
     userHasSearched={false}
   >
+    <Row
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <span
+          className="text-muted"
+        >
+          No option selected
+        </span>
+      </Col>
+    </Row>
     <FormGroup
       check={true}
       key="42"
@@ -304,6 +341,43 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
     selected={Array []}
     userHasSearched={false}
   >
+    <Row
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <span
+          className="text-muted"
+        >
+          No option selected
+        </span>
+      </Col>
+    </Row>
     <FormGroup
       check={true}
       key="42"
@@ -490,6 +564,43 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
     selected={Array []}
     userHasSearched={false}
   >
+    <Row
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <span
+          className="text-muted"
+        >
+          No option selected
+        </span>
+      </Col>
+    </Row>
     <FormGroup
       check={true}
       key="42"
@@ -662,6 +773,43 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
     selected={Array []}
     userHasSearched={false}
   >
+    <Row
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <span
+          className="text-muted"
+        >
+          No option selected
+        </span>
+      </Col>
+    </Row>
     <FormGroup
       check={true}
       key="42"
@@ -842,6 +990,43 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
     selected={Array []}
     userHasSearched={false}
   >
+    <Row
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <span
+          className="text-muted"
+        >
+          No option selected
+        </span>
+      </Col>
+    </Row>
     <FormGroup
       check={true}
       key="42"
@@ -1299,6 +1484,43 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
     selected={Array []}
     userHasSearched={false}
   >
+    <Row
+      className="mb-3 p-2"
+      style={
+        Object {
+          "backgroundColor": "#edecf1",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <Col
+        tag="div"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        <span
+          className="text-muted"
+        >
+          No option selected
+        </span>
+      </Col>
+    </Row>
     <FormGroup
       check={true}
       key="42"


### PR DESCRIPTION
The selection ribbon is only displayed when there is a selection in the
modal, but that causes the options to shift down when an option is
selected. It would be better if the selection ribbon could stay with a
text telling no options is selected.

Removed check that prevents selection ribbon from being displayed.
Added text to be displayed in the selection ribbon when no option is
selected.

Closes #509