### PR TITLE
fix: Typeahead is now case insensitive

### DIFF
--- a/src/form/useOptions.test.ts
+++ b/src/form/useOptions.test.ts
@@ -55,6 +55,46 @@ describe('useOptions', () => {
       });
     });
 
+    it('should filter case insensitive', () => {
+      const { result } = renderHook(() => {
+        const options: Option[] = [
+          {
+            id: 1,
+            label: 'Nederland'
+          },
+          {
+            id: 2,
+            label: 'Duitsland'
+          }
+        ];
+
+        return useOptions({
+          options,
+          labelForOption: (option: Option) => option.label,
+          isOptionEqual: (a, b) => a.id === b.id,
+          query: 'neder',
+          pageNumber: 1,
+          size: 2,
+          optionsShouldAlwaysContainValue: false
+        });
+      });
+
+      // should return the country by searching case insensitive
+      expect(result.current).toEqual({
+        page: {
+          first: true,
+          last: true,
+          number: 1,
+          numberOfElements: 1,
+          size: 1,
+          totalElements: 1,
+          totalPages: 1,
+          content: [{ id: 1, label: 'Nederland' }]
+        },
+        loading: false
+      });
+    });
+
     it('should when the reloadOptions changes update the options', () => {
       const { result, rerender } = renderHook(
         ({ reloadOptions }) => {

--- a/src/form/useOptions.ts
+++ b/src/form/useOptions.ts
@@ -51,7 +51,9 @@ export function useOptions<T>(config: UseOptionConfig<T>): UseOptionResult<T> {
   function pageFromOptionsArray(options: T[]): Page<T> {
     // Filter based on the label for the option
     const content = options.filter((option) =>
-      labelForOption(option).includes(query)
+      labelForOption(option)
+        .toLocaleLowerCase()
+        .includes(query.toLocaleLowerCase())
     );
 
     // We expect that the caller will change the pageNumber to 1


### PR DESCRIPTION
The default behavior for AsyncTypeahead of react-bootstrap-typeahead is
that the filter is case insensitive. I have extended this bevavior to
our own Typeaheads.

See also https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Filtering.md#casesensitive-boolean-default-false

<img width="405" alt="Screenshot 2021-02-23 at 14 08 56" src="https://user-images.githubusercontent.com/2385144/108848365-327bd600-75e1-11eb-868b-5bb0112e0037.png">
