### PR TITLE
feature: info tooltip

### DIFF
--- a/src/core/InfoTooltip/InfoTooltip.stories.tsx
+++ b/src/core/InfoTooltip/InfoTooltip.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { InfoTooltip } from './InfoTooltip';
+
+storiesOf('core/InfoTooltip', module)
+  .addParameters({ component: InfoTooltip })
+  .add('basic', () => {
+    return (
+      <div className="text-center">
+        <InfoTooltip tooltip="This is the content of the tooltip" />
+      </div>
+    );
+  })
+  .add('custom content', () => {
+    return (
+      <div className="text-center">
+        <InfoTooltip
+          tooltip={
+            <>
+              <p>
+                The tooltip can contain multiple paragraphs by using plain HTML.
+              </p>
+              <p>
+                But it is also allowed to use custom components inside the
+                tooltip. Just be careful with components with interactions as
+                they might conflict with the tooltip.
+              </p>
+            </>
+          }
+        />
+      </div>
+    );
+  })
+  .add('custom size', () => {
+    return (
+      <div className="text-center">
+        <InfoTooltip tooltip="This icon is quite small" size={10} />
+        <InfoTooltip tooltip="This is the default size of the icon" />
+        <InfoTooltip tooltip="This icon is quite big" size={20} />
+      </div>
+    );
+  });

--- a/src/core/InfoTooltip/InfoTooltip.test.tsx
+++ b/src/core/InfoTooltip/InfoTooltip.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { InfoTooltip } from './InfoTooltip';
+import Spinner from '../Spinner/Spinner';
+
+describe('Component: InfoTooltip', () => {
+  function setup({
+    tooltip = 'tooltip content',
+    size,
+    className
+  }: {
+    tooltip?: React.ReactNode;
+    size?: number;
+    className?: string;
+  }) {
+    const props = {
+      tooltip,
+      size,
+      className
+    };
+
+    const infoTooltip = shallow(<InfoTooltip {...props} />);
+
+    return { infoTooltip };
+  }
+
+  describe('ui', () => {
+    test('default', () => {
+      const { infoTooltip } = setup({});
+      expect(toJson(infoTooltip)).toMatchSnapshot(
+        'Component: InfoTooltip => ui => default'
+      );
+    });
+
+    test('custom content', () => {
+      const { infoTooltip } = setup({
+        tooltip: <Spinner size={10} color="primary" />
+      });
+      expect(toJson(infoTooltip)).toMatchSnapshot(
+        'Component: InfoTooltip => ui => custom content'
+      );
+    });
+
+    test('with size', () => {
+      const { infoTooltip } = setup({ size: 10 });
+      expect(infoTooltip.find('Icon').props().size).toBe(10);
+    });
+  });
+});

--- a/src/core/InfoTooltip/InfoTooltip.tsx
+++ b/src/core/InfoTooltip/InfoTooltip.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Icon } from '../../core/Icon';
+import Tooltip from '../../core/Tooltip/Tooltip';
+
+type Props = {
+  /**
+   * The content of the tooltip.
+   */
+  tooltip: React.ReactNode;
+
+  /**
+   * Optionally the size of the icon.
+   * Defaults to 16.
+   */
+  size?: number;
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
+};
+
+/**
+ * InfoTooltip is an info icon that displays a tooltip on mouseover.
+ */
+export function InfoTooltip(props: Props) {
+  const { tooltip, size = 16, className } = props;
+  return (
+    <Tooltip content={tooltip} className={className}>
+      <Icon icon="info" size={size} />
+    </Tooltip>
+  );
+}

--- a/src/core/InfoTooltip/__snapshots__/InfoTooltip.test.tsx.snap
+++ b/src/core/InfoTooltip/__snapshots__/InfoTooltip.test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: InfoTooltip ui custom content: Component: InfoTooltip => ui => custom content 1`] = `
+<Tooltip
+  content={
+    <Spinner
+      color="primary"
+      size={10}
+    />
+  }
+>
+  <Icon
+    icon="info"
+    size={16}
+  />
+</Tooltip>
+`;
+
+exports[`Component: InfoTooltip ui default: Component: InfoTooltip => ui => default 1`] = `
+<Tooltip
+  content="tooltip content"
+>
+  <Icon
+    icon="info"
+    size={16}
+  />
+</Tooltip>
+`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -45,6 +45,7 @@ describe('index', () => {
         "IconPicker": [Function],
         "ImageUpload": [Function],
         "InfoBadge": [Function],
+        "InfoTooltip": [Function],
         "Input": [Function],
         "JarbCheckbox": [Function],
         "JarbCheckboxMultipleSelect": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export { OpenCloseModal } from './core/OpenCloseModal/OpenCloseModal';
 export { default as Popover } from './core/Popover/Popover';
 export { default as TextButton } from './core/TextButton/TextButton';
 export { useShowAfter } from './core/useShowAfter/useShowAfter';
+export { InfoTooltip } from './core/InfoTooltip/InfoTooltip';
 
 // Form
 export { AutoSave } from './form/AutoSave/AutoSave';


### PR DESCRIPTION
You sometimes want to explain the use of a certain field for people that
use a form for the first time, but you don't want to display that
information all the time because it increases the size of the form and
therefore decreases its usability. A tooltip might be the perfect
solution in that case.

Added InfoTooltip compenent to display an info icon with a tooltip.

Closes #533