### PR TITLE
feature: plain text form control

### DIFF
--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -34,7 +34,9 @@ import {
   isDateBeforeValidator,
   isDateBetween,
   isDateBetweenValidator,
-  SubmitButton
+  SubmitButton,
+  PlainTextFormControl,
+  InfoTooltip
 } from '..';
 import { pageOfUsers } from '../test/fixtures';
 import { User } from '../test/types';
@@ -150,6 +152,21 @@ export function TotalForm({ hasSubmit }: { hasSubmit: boolean }) {
         <Fragment>
           <Row>
             <Col lg={6}>
+              <PlainTextFormControl
+                label={
+                  <>
+                    Key
+                    <InfoTooltip
+                      tooltip="The 'Key' represents a part of the entity which can only be
+                created once on create but not on edit."
+                      className="ml-2"
+                    />
+                  </>
+                }
+              >
+                83690c32-26af-467b-9105-cde36ef8e21c
+              </PlainTextFormControl>
+
               <JarbInput
                 name="firstName"
                 jarb={{ validator: 'User.email', label: 'First name' }}

--- a/src/form/PlainTextFormControl/PlainTextFormControl.stories.tsx
+++ b/src/form/PlainTextFormControl/PlainTextFormControl.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { PlainTextFormControl } from './PlainTextFormControl';
+import { Form } from 'reactstrap';
+
+storiesOf('Form/PlainTextFormControl', module).add('basic', () => {
+  return (
+    <Form>
+      <PlainTextFormControl label="Organisation">42 BV</PlainTextFormControl>
+    </Form>
+  );
+});

--- a/src/form/PlainTextFormControl/PlainTextFormControl.test.tsx
+++ b/src/form/PlainTextFormControl/PlainTextFormControl.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { PlainTextFormControl } from './PlainTextFormControl';
+
+describe('Component: PlainTextFormControl', () => {
+  function setup({
+    label = 'name',
+    labelClassName,
+    valueClassName
+  }: {
+    label?: string;
+    labelClassName?: string;
+    valueClassName?: string;
+  }) {
+    const props = {
+      label,
+      labelClassName,
+      valueClassName
+    };
+    const plainTextFormControl = shallow(
+      <PlainTextFormControl {...props}>This is your name</PlainTextFormControl>
+    );
+    return { plainTextFormControl };
+  }
+
+  describe('ui', () => {
+    test('default', () => {
+      const { plainTextFormControl } = setup({});
+      expect(toJson(plainTextFormControl)).toMatchSnapshot(
+        'Component: PlainTextFormControl => ui => default'
+      );
+    });
+
+    test('without label', () => {
+      const { plainTextFormControl } = setup({
+        label: ''
+      });
+      expect(toJson(plainTextFormControl)).toMatchSnapshot(
+        'Component: PlainTextFormControl => ui => without label'
+      );
+    });
+
+    test('with label class name', () => {
+      const { plainTextFormControl } = setup({
+        labelClassName: 'label-class-name'
+      });
+      expect(plainTextFormControl.find('Label').props().className).toBe(
+        'label-class-name'
+      );
+    });
+
+    test('with value class name', () => {
+      const { plainTextFormControl } = setup({
+        valueClassName: 'value-class-name'
+      });
+      expect(plainTextFormControl.find('div').props().className).toBe(
+        'form-control-plaintext value-class-name'
+      );
+    });
+  });
+});

--- a/src/form/PlainTextFormControl/PlainTextFormControl.tsx
+++ b/src/form/PlainTextFormControl/PlainTextFormControl.tsx
@@ -1,0 +1,57 @@
+import { FormGroup, Label } from 'reactstrap';
+import React from 'react';
+import classNames from 'classnames';
+
+type Props = {
+  /**
+   * Optionally the label of the form element.
+   */
+  label?: React.ReactNode;
+
+  /**
+   * The value that the form element currently has.
+   */
+  children: React.ReactNode;
+
+  /**
+   * Optional extra CSS class you want to add to the value.
+   * Useful for styling the value.
+   */
+  valueClassName?: string;
+
+  /**
+   * Optional extra CSS class you want to add to the label.
+   * Useful for styling the label.
+   */
+  labelClassName?: string;
+};
+
+/**
+ * Not all users know that an interaction design element can have
+ * a disabled state. Disabled elements have poor contrast and thus
+ * are not as readable as they should. Also, screen readers don't
+ * give users as much information about the state of the element
+ * and keyboard navigation gets a little weird, causing confusion to
+ * those using a screen reader. Users might also think the form
+ * element might be enabled by changing another form element or in
+ * a different use case. So to prevent users confusion or thinking
+ * the form is invalid, you should display the value without letting
+ * it look like a form element. To prevent alignment issues, the
+ * PlainTextFormControl uses spacing as if it were a form element,
+ * without the looks of a form element.
+ */
+export function PlainTextFormControl({
+  label,
+  children,
+  valueClassName,
+  labelClassName
+}: Props) {
+  const valueClasses = classNames('form-control-plaintext', valueClassName);
+
+  return (
+    <FormGroup>
+      {label ? <Label className={labelClassName}>{label}</Label> : null}
+      <div className={valueClasses}>{children}</div>
+    </FormGroup>
+  );
+}

--- a/src/form/PlainTextFormControl/__snapshots__/PlainTextFormControl.test.tsx.snap
+++ b/src/form/PlainTextFormControl/__snapshots__/PlainTextFormControl.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: PlainTextFormControl ui default: Component: PlainTextFormControl => ui => default 1`] = `
+<FormGroup
+  tag="div"
+>
+  <Label
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    name
+  </Label>
+  <div
+    className="form-control-plaintext"
+  >
+    This is your name
+  </div>
+</FormGroup>
+`;
+
+exports[`Component: PlainTextFormControl ui without label: Component: PlainTextFormControl => ui => without label 1`] = `
+<FormGroup
+  tag="div"
+>
+  <div
+    className="form-control-plaintext"
+  >
+    This is your name
+  </div>
+</FormGroup>
+`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -75,6 +75,7 @@ describe('index', () => {
         "OpenCloseModal": [Function],
         "Pager": [Function],
         "Pagination": [Function],
+        "PlainTextFormControl": [Function],
         "Popover": [Function],
         "ProgressStepper": [Function],
         "RadioGroup": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ export { FormButton } from './form/FormButton/FormButton';
 export { Addon, AddonPosition } from './form/addons/Addon/Addon';
 export { AddonButton } from './form/addons/AddonButton/AddonButton';
 export { AddonIcon } from './form/addons/AddonIcon/AddonIcon';
+export { PlainTextFormControl } from './form/PlainTextFormControl/PlainTextFormControl';
 
 // Table
 export { EpicTable } from './table/EpicTable/EpicTable';


### PR DESCRIPTION
In forms you sometimes want to display a value the user is not allowed
to edit. The value should have the same dimensions as an input in that
case, especially when the form is spread over multiple columns.

Added PlainTextFormControl component.

Closes #537