### PR TITLE
improvement: Typeahead should display all options

### DIFF
--- a/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
@@ -111,7 +111,8 @@ describe('Component: TypeaheadMultiple', () => {
 
     test('loading', () => {
       const { typeaheadMultiple } = setup({
-        loading: true
+        loading: true,
+        isAsync: true
       });
 
       const asyncTypeahead = typeaheadMultiple.find('div').children().first();
@@ -127,13 +128,15 @@ describe('Component: TypeaheadMultiple', () => {
       expect(asyncTypeahead.props().delay).toBe(200);
     });
 
-    test('sync delay', () => {
+    test('sync', () => {
       const { typeaheadMultiple } = setup({
         isAsync: false
       });
 
       const asyncTypeahead = typeaheadMultiple.find('div').children().first();
-      expect(asyncTypeahead.props().delay).toBe(0);
+      expect(asyncTypeahead.props().delay).toBeUndefined();
+      expect(asyncTypeahead.props().onSearch).toBeUndefined();
+      expect(asyncTypeahead.props().isLoading).toBeUndefined();
     });
   });
 
@@ -220,7 +223,8 @@ describe('Component: TypeaheadMultiple', () => {
 
     it('should set the query when the user starts typing in the input field', () => {
       const { typeaheadMultiple } = setup({
-        value: undefined
+        value: undefined,
+        isAsync: true
       });
 
       const asyncTypeahead = typeaheadMultiple.find('div').children().first();

--- a/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
+++ b/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
@@ -32,8 +32,7 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
   <div
     className=""
   >
-    <withAsync(Component)
-      delay={0}
+    <ForwardRef
       filterBy={[Function]}
       id="bestFriend"
       inputProps={
@@ -53,11 +52,9 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
           ],
         }
       }
-      isLoading={false}
-      minLength={2}
       multiple={true}
       onChange={[Function]}
-      onSearch={[Function]}
+      onInputChange={[Function]}
       options={
         Array [
           Object {
@@ -90,9 +87,7 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
         ]
       }
       placeholder="Please provide your best friend"
-      promptText="Type to search..."
       renderToken={[Function]}
-      searchText="Searching..."
       selected={
         Array [
           Object {
@@ -110,7 +105,6 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
           },
         ]
       }
-      useCache={true}
     />
   </div>
   Some error
@@ -125,8 +119,7 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
   <div
     className=""
   >
-    <withAsync(Component)
-      delay={0}
+    <ForwardRef
       filterBy={[Function]}
       inputProps={
         Object {
@@ -145,11 +138,9 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
           ],
         }
       }
-      isLoading={false}
-      minLength={2}
       multiple={true}
       onChange={[Function]}
-      onSearch={[Function]}
+      onInputChange={[Function]}
       options={
         Array [
           Object {
@@ -182,9 +173,7 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
         ]
       }
       placeholder="Please provide your best friend"
-      promptText="Type to search..."
       renderToken={[Function]}
-      searchText="Searching..."
       selected={
         Array [
           Object {
@@ -202,7 +191,6 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
           },
         ]
       }
-      useCache={true}
     />
   </div>
   Some error
@@ -232,8 +220,7 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
   <div
     className=""
   >
-    <withAsync(Component)
-      delay={0}
+    <ForwardRef
       filterBy={[Function]}
       id="bestFriend"
       inputProps={
@@ -253,11 +240,9 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
           ],
         }
       }
-      isLoading={false}
-      minLength={2}
       multiple={true}
       onChange={[Function]}
-      onSearch={[Function]}
+      onInputChange={[Function]}
       options={
         Array [
           Object {
@@ -289,9 +274,7 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
           },
         ]
       }
-      promptText="Type to search..."
       renderToken={[Function]}
-      searchText="Searching..."
       selected={
         Array [
           Object {
@@ -309,7 +292,6 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
           },
         ]
       }
-      useCache={true}
     />
   </div>
   Some error

--- a/src/form/Typeahead/single/TypeaheadSingle.test.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.test.tsx
@@ -114,6 +114,7 @@ describe('Component: TypeaheadSingle', () => {
 
     test('loading', () => {
       const { typeaheadSingle } = setup({
+        isAsync: true,
         loading: true
       });
 
@@ -130,13 +131,15 @@ describe('Component: TypeaheadSingle', () => {
       expect(asyncTypeahead.props().delay).toBe(200);
     });
 
-    test('sync delay', () => {
+    test('sync', () => {
       const { typeaheadSingle } = setup({
         isAsync: false
       });
 
       const asyncTypeahead = typeaheadSingle.find('div').children().first();
-      expect(asyncTypeahead.props().delay).toBe(0);
+      expect(asyncTypeahead.props().delay).toBeUndefined();
+      expect(asyncTypeahead.props().onSearch).toBeUndefined();
+      expect(asyncTypeahead.props().isLoading).toBeUndefined();
     });
   });
 
@@ -195,7 +198,8 @@ describe('Component: TypeaheadSingle', () => {
 
     it('should set the query when the user starts typing in the input field', () => {
       const { typeaheadSingle } = setup({
-        value: undefined
+        value: undefined,
+        isAsync: true
       });
 
       const asyncTypeahead = typeaheadSingle.find('div').children().first();

--- a/src/form/Typeahead/single/TypeaheadSingle.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.tsx
@@ -1,6 +1,10 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
-import { AsyncTypeahead } from 'react-bootstrap-typeahead';
+import {
+  AsyncTypeahead,
+  Typeahead,
+  TypeaheadProps
+} from 'react-bootstrap-typeahead';
 import { FormGroup, Label } from 'reactstrap';
 import { useId } from '../../../hooks/useId/useId';
 import {
@@ -119,28 +123,36 @@ export default function TypeaheadSingle<T>(props: Props<T>) {
 
   const innerId = useId({ id });
 
+  const typeaheadProps: TypeaheadProps<TypeaheadOption<T>> = {
+    id,
+    filterBy: alwaysTrue,
+    multiple: false,
+    placeholder,
+    selected,
+    options: typeaheadOptions,
+    onChange: doOnChange,
+    onFocus,
+    inputProps: {
+      className: classNames('form-control', {
+        'is-invalid': valid === false
+      })
+    }
+  };
+
   return (
     <FormGroup className={classes} color={color}>
       {label ? <Label for={innerId}>{label}</Label> : null}
       <div className={selected.length === 0 ? 'showing-placeholder' : ''}>
-        <AsyncTypeahead
-          id={id}
-          delay={Array.isArray(options) ? 0 : 200}
-          filterBy={alwaysTrue}
-          isLoading={loading}
-          multiple={false}
-          placeholder={placeholder}
-          selected={selected}
-          options={typeaheadOptions}
-          onSearch={setQuery}
-          onChange={doOnChange}
-          onFocus={onFocus}
-          inputProps={{
-            className: classNames('form-control', {
-              'is-invalid': valid === false
-            })
-          }}
-        />
+        {Array.isArray(options) ? (
+          <Typeahead {...typeaheadProps} onInputChange={setQuery} />
+        ) : (
+          <AsyncTypeahead
+            {...typeaheadProps}
+            isLoading={loading}
+            delay={200}
+            onSearch={setQuery}
+          />
+        )}
       </div>
       {error}
     </FormGroup>

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -23,8 +23,7 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
   <div
     className=""
   >
-    <withAsync(Component)
-      delay={0}
+    <ForwardRef
       filterBy={[Function]}
       id="bestFriend"
       inputProps={
@@ -32,11 +31,9 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
           "className": "form-control",
         }
       }
-      isLoading={false}
-      minLength={2}
       multiple={false}
       onChange={[Function]}
-      onSearch={[Function]}
+      onInputChange={[Function]}
       options={
         Array [
           Object {
@@ -69,8 +66,6 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
         ]
       }
       placeholder="Please provide your best friend"
-      promptText="Type to search..."
-      searchText="Searching..."
       selected={
         Array [
           Object {
@@ -88,7 +83,6 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
           },
         ]
       }
-      useCache={true}
     />
   </div>
   Some error
@@ -103,19 +97,16 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
   <div
     className=""
   >
-    <withAsync(Component)
-      delay={0}
+    <ForwardRef
       filterBy={[Function]}
       inputProps={
         Object {
           "className": "form-control",
         }
       }
-      isLoading={false}
-      minLength={2}
       multiple={false}
       onChange={[Function]}
-      onSearch={[Function]}
+      onInputChange={[Function]}
       options={
         Array [
           Object {
@@ -148,8 +139,6 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
         ]
       }
       placeholder="Please provide your best friend"
-      promptText="Type to search..."
-      searchText="Searching..."
       selected={
         Array [
           Object {
@@ -167,7 +156,6 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
           },
         ]
       }
-      useCache={true}
     />
   </div>
   Some error
@@ -197,8 +185,7 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
   <div
     className=""
   >
-    <withAsync(Component)
-      delay={0}
+    <ForwardRef
       filterBy={[Function]}
       id="bestFriend"
       inputProps={
@@ -206,11 +193,9 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
           "className": "form-control",
         }
       }
-      isLoading={false}
-      minLength={2}
       multiple={false}
       onChange={[Function]}
-      onSearch={[Function]}
+      onInputChange={[Function]}
       options={
         Array [
           Object {
@@ -242,8 +227,6 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
           },
         ]
       }
-      promptText="Type to search..."
-      searchText="Searching..."
       selected={
         Array [
           Object {
@@ -261,7 +244,6 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
           },
         ]
       }
-      useCache={true}
     />
   </div>
   Some error


### PR DESCRIPTION
When the options provided is an array, the options should be displayed
right away instead of waiting for user input to match any option. Not
displaying the available options right away is only useful when a
request to an API is used, to decrease the load on the API.

Changed the TypeaheadSingle and TypeaheadMultiple components to use the
Typeahead component from react-bootstrap-typeahead when the options
provided is an array to be able to display all options when the user did
not type anything in the input (yet).

Closes #544