### PR TITLE
Typeahead: keep the selected result in the search results

### DIFF
--- a/src/form/Typeahead/single/TypeaheadSingle.test.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.test.tsx
@@ -212,9 +212,9 @@ describe('Component: TypeaheadSingle', () => {
       );
     });
 
-    it('should filter out already selected values and disabled options from the typeahead options', () => {
+    it('should filter out disabled options from the typeahead options', () => {
       const { typeaheadSingle } = setup({
-        value: adminUser(), // The admin user is select so it should be filtered out
+        value: adminUser(),
         isOptionEnabled: (user) => user.id !== userUser().id // Also disable the userUser
       });
 
@@ -223,6 +223,7 @@ describe('Component: TypeaheadSingle', () => {
       const options = asyncTypeahead.props().options;
 
       expect(options).toEqual([
+        { label: 'admin@42.nl', value: adminUser() },
         { label: 'coordinator@42.nl', value: coordinatorUser() }
       ]);
     });

--- a/src/form/Typeahead/single/TypeaheadSingle.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.tsx
@@ -7,10 +7,7 @@ import {
 } from 'react-bootstrap-typeahead';
 import { FormGroup, Label } from 'reactstrap';
 import { useId } from '../../../hooks/useId/useId';
-import {
-  FieldCompatibleWithPredeterminedOptions,
-  isOptionSelected
-} from '../../option';
+import { FieldCompatibleWithPredeterminedOptions } from '../../option';
 import { FieldCompatible } from '../../types';
 import { useOptions } from '../../useOptions';
 import { doBlur, alwaysTrue } from '../../utils';
@@ -76,16 +73,6 @@ export default function TypeaheadSingle<T>(props: Props<T>) {
 
   const typeaheadOptions = page.content
     .filter((option) => isOptionEnabled(option))
-    .filter(
-      (option) =>
-        !isOptionSelected({
-          option,
-          keyForOption,
-          labelForOption,
-          isOptionEqual,
-          value
-        })
-    )
     .map((option) => optionToTypeaheadOption(option, labelForOption));
 
   function doOnChange(values: TypeaheadOption<T>[]) {

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -37,6 +37,19 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
       options={
         Array [
           Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
             "label": "coordinator@42.nl",
             "value": Object {
               "active": false,
@@ -109,6 +122,19 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
       onInputChange={[Function]}
       options={
         Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
           Object {
             "label": "coordinator@42.nl",
             "value": Object {
@@ -198,6 +224,19 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
       onInputChange={[Function]}
       options={
         Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
           Object {
             "label": "coordinator@42.nl",
             "value": Object {


### PR DESCRIPTION
Normal users find it confusing when their exact search doesn't return any result, that is because the typeahead will automatically select it and filter it out. It now only automatically selects and keeps the selected result in the search lists.