### PR TITLE
fix: password strength rule alignment

### DIFF
--- a/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
+++ b/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
@@ -58,14 +58,14 @@ export default function PasswordStrength(props: Props) {
         {rules.map((rule) => {
           const isCompliant = compliant[rule];
           return (
-            <div key={rule}>
+            <div key={rule} className="d-flex">
               <Icon
                 icon={isCompliant ? 'check_circle' : 'cancel'}
                 color={isCompliant ? 'success' : 'danger'}
                 size={16}
-                className="align-bottom mb-1 mr-3"
+                className="align-bottom mt-1 mb-1 mr-3"
               />
-              {t(labelForRule(rule, minimumLength))}
+              <div>{t(labelForRule(rule, minimumLength))}</div>
             </div>
           );
         })}

--- a/src/form/NewPasswordInput/PasswordStrength/__snapshots__/PasswordStrength.test.tsx.snap
+++ b/src/form/NewPasswordInput/PasswordStrength/__snapshots__/PasswordStrength.test.tsx.snap
@@ -19,26 +19,32 @@ exports[`Component: PasswordStrength ui default: Component: PasswordStrength => 
     className="mb-2"
   >
     <div
+      className="d-flex"
       key="lowercase"
     >
       <Icon
-        className="align-bottom mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 mr-3"
         color="danger"
         icon="cancel"
         size={16}
       />
-      Must contain at least one lowercase letter
+      <div>
+        Must contain at least one lowercase letter
+      </div>
     </div>
     <div
+      className="d-flex"
       key="minimumLength"
     >
       <Icon
-        className="align-bottom mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 mr-3"
         color="danger"
         icon="cancel"
         size={16}
       />
-      Must contain at least 10 characters
+      <div>
+        Must contain at least 10 characters
+      </div>
     </div>
   </div>
 </Fragment>
@@ -50,26 +56,32 @@ exports[`Component: PasswordStrength ui without meter: Component: PasswordStreng
     className="mb-2"
   >
     <div
+      className="d-flex"
       key="lowercase"
     >
       <Icon
-        className="align-bottom mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 mr-3"
         color="danger"
         icon="cancel"
         size={16}
       />
-      Must contain at least one lowercase letter
+      <div>
+        Must contain at least one lowercase letter
+      </div>
     </div>
     <div
+      className="d-flex"
       key="minimumLength"
     >
       <Icon
-        className="align-bottom mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 mr-3"
         color="danger"
         icon="cancel"
         size={16}
       />
-      Must contain at least 10 characters
+      <div>
+        Must contain at least 10 characters
+      </div>
     </div>
   </div>
 </Fragment>


### PR DESCRIPTION
The NewPasswordInput displays the rules next to a check, but if the text
is too long and breaks to a new line, the text starts underneath the
icon.

Fixed alignment of password strength rules.

Closes #549