### PR TITLE
fix: CheckboxMultipleSelect columns have static width

### DIFF
--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -426,6 +426,42 @@ storiesOf('Form/CheckboxMultipleSelect', module)
       </div>
     );
   })
+  .add('less columns', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <p>
+          If you want to regulate the amount of checkboxes that are displayed
+          next to eachother, you should wrap the component in an element with a
+          maximum width. The checkboxes are displayed in columns of 300 pixels,
+          so any multiple of 300 will work. Anything in between works as well,
+          though keep in mind you then will always have whitespace.
+        </p>
+
+        <div style={{ maxWidth: 600 }}>
+          <CheckboxMultipleSelect
+            id="provinces"
+            label="Provinces"
+            placeholder="Please select your provinces"
+            options={provinces()}
+            labelForOption={(province) => province.label}
+            value={value}
+            onChange={setValue}
+          />
+        </div>
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+      </Form>
+    );
+  })
   .add('jarb', () => {
     return (
       <FinalForm>

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -1,4 +1,4 @@
-import { chunk, isArray } from 'lodash';
+import { isArray } from 'lodash';
 import React from 'react';
 import { Col, FormGroup, Input as RSInput, Label, Row } from 'reactstrap';
 import { Loading } from '../..';
@@ -168,18 +168,8 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
     if (horizontal) {
       return renderOptions({ options: page.content, horizontal: true });
     } else {
-      const chunks = chunk(page.content, 10);
-
       return (
-        <Row>
-          {chunks.map((options, index) => {
-            return (
-              <Col xs="auto" key={index} style={{ width: '300px' }}>
-                {renderOptions({ options, horizontal: false })}
-              </Col>
-            );
-          })}
-        </Row>
+        <Row>{renderOptions({ options: page.content, horizontal: false })}</Row>
       );
     }
   }
@@ -191,7 +181,7 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
     options: T[];
     horizontal: boolean;
   }) {
-    return options.map((option, index) => {
+    return options.map((option) => {
       const label = labelForOption(option);
       const key = getKeyForOption({ option, keyForOption, labelForOption });
 
@@ -203,19 +193,26 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
         value
       });
 
-      return (
+      const checkbox = (
+        <Label check>
+          <RSInput
+            type="checkbox"
+            checked={isSelected}
+            disabled={!isOptionEnabled(option)}
+            onChange={() => optionClicked(option, isSelected)}
+          />{' '}
+          {label}
+        </Label>
+      );
+
+      return horizontal ? (
         <FormGroup check key={key} inline={horizontal}>
-          <Label check>
-            <RSInput
-              type="checkbox"
-              checked={isSelected}
-              value={index}
-              disabled={!isOptionEnabled(option)}
-              onChange={() => optionClicked(option, isSelected)}
-            />{' '}
-            {label}
-          </Label>
+          {checkbox}
         </FormGroup>
+      ) : (
+        <Col xs="auto" key={key} style={{ width: '300px', maxWidth: '100%' }}>
+          <FormGroup check>{checkbox}</FormGroup>
+        </Col>
       );
     });
   }

--- a/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
+++ b/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
         disabled={false}
         onChange={[Function]}
         type="checkbox"
-        value={0}
       />
        
       admin@42.nl
@@ -81,7 +80,6 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
         disabled={false}
         onChange={[Function]}
         type="checkbox"
-        value={1}
       />
        
       coordinator@42.nl
@@ -111,7 +109,6 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
         disabled={false}
         onChange={[Function]}
         type="checkbox"
-        value={2}
       />
        
       user@42.nl
@@ -195,9 +192,10 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
     }
   >
     <Col
-      key="0"
+      key="42"
       style={
         Object {
+          "maxWidth": "100%",
           "width": "300px",
         }
       }
@@ -215,8 +213,6 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
     >
       <FormGroup
         check={true}
-        inline={false}
-        key="42"
         tag="div"
       >
         <Label
@@ -237,16 +233,34 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={0}
           />
            
           admin@42.nl
         </Label>
       </FormGroup>
+    </Col>
+    <Col
+      key="777"
+      style={
+        Object {
+          "maxWidth": "100%",
+          "width": "300px",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+      xs="auto"
+    >
       <FormGroup
         check={true}
-        inline={false}
-        key="777"
         tag="div"
       >
         <Label
@@ -267,16 +281,34 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={1}
           />
            
           coordinator@42.nl
         </Label>
       </FormGroup>
+    </Col>
+    <Col
+      key="1337"
+      style={
+        Object {
+          "maxWidth": "100%",
+          "width": "300px",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+      xs="auto"
+    >
       <FormGroup
         check={true}
-        inline={false}
-        key="1337"
         tag="div"
       >
         <Label
@@ -297,7 +329,6 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={2}
           />
            
           user@42.nl
@@ -334,9 +365,10 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
     }
   >
     <Col
-      key="0"
+      key="42"
       style={
         Object {
+          "maxWidth": "100%",
           "width": "300px",
         }
       }
@@ -354,8 +386,6 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
     >
       <FormGroup
         check={true}
-        inline={false}
-        key="42"
         tag="div"
       >
         <Label
@@ -376,16 +406,34 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={0}
           />
            
           admin@42.nl
         </Label>
       </FormGroup>
+    </Col>
+    <Col
+      key="777"
+      style={
+        Object {
+          "maxWidth": "100%",
+          "width": "300px",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+      xs="auto"
+    >
       <FormGroup
         check={true}
-        inline={false}
-        key="777"
         tag="div"
       >
         <Label
@@ -406,16 +454,34 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={1}
           />
            
           coordinator@42.nl
         </Label>
       </FormGroup>
+    </Col>
+    <Col
+      key="1337"
+      style={
+        Object {
+          "maxWidth": "100%",
+          "width": "300px",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+      xs="auto"
+    >
       <FormGroup
         check={true}
-        inline={false}
-        key="1337"
         tag="div"
       >
         <Label
@@ -436,7 +502,6 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={2}
           />
            
           user@42.nl
@@ -481,9 +546,10 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
     }
   >
     <Col
-      key="0"
+      key="42"
       style={
         Object {
+          "maxWidth": "100%",
           "width": "300px",
         }
       }
@@ -501,8 +567,6 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
     >
       <FormGroup
         check={true}
-        inline={false}
-        key="42"
         tag="div"
       >
         <Label
@@ -523,16 +587,34 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={0}
           />
            
           admin@42.nl
         </Label>
       </FormGroup>
+    </Col>
+    <Col
+      key="777"
+      style={
+        Object {
+          "maxWidth": "100%",
+          "width": "300px",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+      xs="auto"
+    >
       <FormGroup
         check={true}
-        inline={false}
-        key="777"
         tag="div"
       >
         <Label
@@ -553,16 +635,34 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={1}
           />
            
           coordinator@42.nl
         </Label>
       </FormGroup>
+    </Col>
+    <Col
+      key="1337"
+      style={
+        Object {
+          "maxWidth": "100%",
+          "width": "300px",
+        }
+      }
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+      xs="auto"
+    >
       <FormGroup
         check={true}
-        inline={false}
-        key="1337"
         tag="div"
       >
         <Label
@@ -583,7 +683,6 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
             disabled={false}
             onChange={[Function]}
             type="checkbox"
-            value={2}
           />
            
           user@42.nl

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -132,9 +132,10 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
             className="row"
           >
             <Col
-              key="0"
+              key="42"
               style={
                 Object {
+                  "maxWidth": "100%",
                   "width": "300px",
                 }
               }
@@ -154,14 +155,13 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                 className="col-auto"
                 style={
                   Object {
+                    "maxWidth": "100%",
                     "width": "300px",
                   }
                 }
               >
                 <FormGroup
                   check={true}
-                  inline={false}
-                  key="42"
                   tag="div"
                 >
                   <div
@@ -188,7 +188,6 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                           disabled={false}
                           onChange={[Function]}
                           type="checkbox"
-                          value={0}
                         >
                           <input
                             checked={false}
@@ -196,7 +195,6 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                             disabled={false}
                             onChange={[Function]}
                             type="checkbox"
-                            value={0}
                           />
                         </Input>
                          
@@ -205,10 +203,39 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                     </Label>
                   </div>
                 </FormGroup>
+              </div>
+            </Col>
+            <Col
+              key="777"
+              style={
+                Object {
+                  "maxWidth": "100%",
+                  "width": "300px",
+                }
+              }
+              tag="div"
+              widths={
+                Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ]
+              }
+              xs="auto"
+            >
+              <div
+                className="col-auto"
+                style={
+                  Object {
+                    "maxWidth": "100%",
+                    "width": "300px",
+                  }
+                }
+              >
                 <FormGroup
                   check={true}
-                  inline={false}
-                  key="777"
                   tag="div"
                 >
                   <div
@@ -235,7 +262,6 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                           disabled={false}
                           onChange={[Function]}
                           type="checkbox"
-                          value={1}
                         >
                           <input
                             checked={false}
@@ -243,7 +269,6 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                             disabled={false}
                             onChange={[Function]}
                             type="checkbox"
-                            value={1}
                           />
                         </Input>
                          
@@ -252,10 +277,39 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                     </Label>
                   </div>
                 </FormGroup>
+              </div>
+            </Col>
+            <Col
+              key="1337"
+              style={
+                Object {
+                  "maxWidth": "100%",
+                  "width": "300px",
+                }
+              }
+              tag="div"
+              widths={
+                Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ]
+              }
+              xs="auto"
+            >
+              <div
+                className="col-auto"
+                style={
+                  Object {
+                    "maxWidth": "100%",
+                    "width": "300px",
+                  }
+                }
+              >
                 <FormGroup
                   check={true}
-                  inline={false}
-                  key="1337"
                   tag="div"
                 >
                   <div
@@ -282,7 +336,6 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                           disabled={false}
                           onChange={[Function]}
                           type="checkbox"
-                          value={2}
                         >
                           <input
                             checked={false}
@@ -290,7 +343,6 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                             disabled={false}
                             onChange={[Function]}
                             type="checkbox"
-                            value={2}
                           />
                         </Input>
                          


### PR DESCRIPTION
In the CheckboxMultipleSelect, the columns have a static width. When the
component is used in smaller layouts, the component overlays the
elements next to it due to the static width.

Added max-width 100% to prevent out-of-bounds display.
Removed chunking to prevent loads of whitespace when the number of
options is just over 10. The developer implementing this component is 
now responsible for the grid.

Closes #552