### PR TITLE
feature: OpenClose

### DIFF
--- a/src/core/OpenClose/OpenClose.stories.tsx
+++ b/src/core/OpenClose/OpenClose.stories.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { Card } from 'reactstrap';
+
+import { OpenClose } from './OpenClose';
+import Button from '../Button/Button';
+
+storiesOf('core/OpenClose', module).add('basic', () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Card body>
+      <div className="d-flex align-items-center justify-content-start">
+        <Button onClick={() => setIsOpen(!isOpen)} className="mr-3">
+          Toggle
+        </Button>
+        <OpenClose open={isOpen} />
+      </div>
+      <p>The collapsable element should now be {isOpen ? 'open' : 'closed'}</p>
+    </Card>
+  );
+});

--- a/src/core/OpenClose/OpenClose.test.tsx
+++ b/src/core/OpenClose/OpenClose.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { OpenClose } from './OpenClose';
+
+describe('Component: OpenClose', () => {
+  function setup({ isOpen = false }: { isOpen?: boolean }) {
+    const openClose = shallow(<OpenClose open={isOpen} />);
+
+    return { openClose };
+  }
+
+  describe('ui', () => {
+    test('open', () => {
+      const { openClose } = setup({ isOpen: true });
+
+      expect(toJson(openClose)).toMatchSnapshot(
+        'Component: OpenClose => ui => open'
+      );
+    });
+
+    test('closed', () => {
+      const { openClose } = setup({ isOpen: false });
+
+      expect(toJson(openClose)).toMatchSnapshot(
+        'Component: OpenClose => ui => closed'
+      );
+    });
+  });
+});

--- a/src/core/OpenClose/OpenClose.tsx
+++ b/src/core/OpenClose/OpenClose.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Icon } from '../Icon';
+
+type Props = {
+  /**
+   * Whether or not the collapsable element is currently open.
+   */
+  open: boolean;
+};
+
+/**
+ * Open and close icon with a nice animation to display whether a collapsable
+ * element is open or closed. This is often used in the header of a card with
+ * a collapsable body.
+ */
+export function OpenClose({ open }: Props) {
+  const classes = classNames('open-close', open ? 'is-open' : 'is-closed');
+
+  return <Icon icon="expand_more" className={classes} />;
+}

--- a/src/core/OpenClose/_OpenClose.scss
+++ b/src/core/OpenClose/_OpenClose.scss
@@ -1,0 +1,9 @@
+.open-close.is-open {
+  transition-duration: 0.2s;
+  transform: rotate(180deg);
+}
+
+.open-close.is-closed {
+  transition-duration: 0.2s;
+  transform: rotate(0deg);
+}

--- a/src/core/OpenClose/__snapshots__/OpenClose.test.tsx.snap
+++ b/src/core/OpenClose/__snapshots__/OpenClose.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: OpenClose ui closed: Component: OpenClose => ui => closed 1`] = `
+<Icon
+  className="open-close is-closed"
+  icon="expand_more"
+/>
+`;
+
+exports[`Component: OpenClose ui open: Component: OpenClose => ui => open 1`] = `
+<Icon
+  className="open-close is-open"
+  icon="expand_more"
+/>
+`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -75,6 +75,7 @@ describe('index', () => {
         "MoreOrLess": [Function],
         "NavigationItem": [Function],
         "NewPasswordInput": [Function],
+        "OpenClose": [Function],
         "OpenCloseModal": [Function],
         "OrSeparator": [Function],
         "Pager": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export { SuccessIcon } from './core/SuccessIcon/SuccessIcon';
 export { OrSeparator } from './core/OrSeparator/OrSeparator';
 export { AttributeList } from './core/lists/AttributeList/AttributeList';
 export { AttributeView } from './core/lists/AttributeView/AttributeView';
+export { OpenClose } from './core/OpenClose/OpenClose';
 
 // Form
 export { AutoSave } from './form/AutoSave/AutoSave';

--- a/src/main.scss
+++ b/src/main.scss
@@ -32,6 +32,7 @@
 @import './core/Popover/Popover';
 @import './core/OpenCloseModal/OpenCloseModal';
 @import './core/Toggle/Toggle';
+@import './core/OpenClose/OpenClose';
 
 // Form components
 @import './form/ImageUpload/ImageUpload';


### PR DESCRIPTION
We often repeat an icon that displays whether a collapsable element is
open or closed. To prevent the usage of different icons or other
inconsistencies, we need a generic component that displays the state of
a collapsable element.

Added OpenClose component.

Closes #555