### PR TITLE
fix: CheckboxMultipleSelect columns have static width

### DIFF
--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -1,6 +1,6 @@
 import { chunk, isArray } from 'lodash';
 import React from 'react';
-import { Col, FormGroup, Input as RSInput, Label, Row } from 'reactstrap';
+import { FormGroup, Input as RSInput, Label } from 'reactstrap';
 import { Loading } from '../..';
 import { useId } from '../../hooks/useId/useId';
 import { t } from '../../utilities/translation/translation';
@@ -171,15 +171,15 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
       const chunks = chunk(page.content, 10);
 
       return (
-        <Row>
+        <div className="d-flex flex-wrap">
           {chunks.map((options, index) => {
             return (
-              <Col xs="auto" key={index} style={{ width: '300px' }}>
+              <div className="pr-3" key={index} style={{ flexBasis: '300px' }}>
                 {renderOptions({ options, horizontal: false })}
-              </Col>
+              </div>
             );
           })}
-        </Row>
+        </div>
       );
     }
   }

--- a/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
+++ b/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
@@ -182,36 +182,17 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
       Please select your provinces
     </em>
   </p>
-  <Row
-    tag="div"
-    widths={
-      Array [
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl",
-      ]
-    }
+  <div
+    className="d-flex flex-wrap"
   >
-    <Col
+    <div
+      className="pr-3"
       key="0"
       style={
         Object {
-          "width": "300px",
+          "flexBasis": "300px",
         }
       }
-      tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
-      xs="auto"
     >
       <FormGroup
         check={true}
@@ -303,8 +284,8 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
           user@42.nl
         </Label>
       </FormGroup>
-    </Col>
-  </Row>
+    </div>
+  </div>
   Some error
 </FormGroup>
 `;
@@ -321,36 +302,17 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
       Please select your provinces
     </em>
   </p>
-  <Row
-    tag="div"
-    widths={
-      Array [
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl",
-      ]
-    }
+  <div
+    className="d-flex flex-wrap"
   >
-    <Col
+    <div
+      className="pr-3"
       key="0"
       style={
         Object {
-          "width": "300px",
+          "flexBasis": "300px",
         }
       }
-      tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
-      xs="auto"
     >
       <FormGroup
         check={true}
@@ -442,8 +404,8 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
           user@42.nl
         </Label>
       </FormGroup>
-    </Col>
-  </Row>
+    </div>
+  </div>
   Some error
 </FormGroup>
 `;
@@ -468,36 +430,17 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
   >
     Subject
   </Label>
-  <Row
-    tag="div"
-    widths={
-      Array [
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl",
-      ]
-    }
+  <div
+    className="d-flex flex-wrap"
   >
-    <Col
+    <div
+      className="pr-3"
       key="0"
       style={
         Object {
-          "width": "300px",
+          "flexBasis": "300px",
         }
       }
-      tag="div"
-      widths={
-        Array [
-          "xs",
-          "sm",
-          "md",
-          "lg",
-          "xl",
-        ]
-      }
-      xs="auto"
     >
       <FormGroup
         check={true}
@@ -589,8 +532,8 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
           user@42.nl
         </Label>
       </FormGroup>
-    </Col>
-  </Row>
+    </div>
+  </div>
   Some error
 </FormGroup>
 `;

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -116,193 +116,161 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
             Select your best friend
           </em>
         </p>
-        <Row
-          tag="div"
-          widths={
-            Array [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-            ]
-          }
+        <div
+          className="d-flex flex-wrap"
         >
           <div
-            className="row"
+            className="pr-3"
+            key="0"
+            style={
+              Object {
+                "flexBasis": "300px",
+              }
+            }
           >
-            <Col
-              key="0"
-              style={
-                Object {
-                  "width": "300px",
-                }
-              }
+            <FormGroup
+              check={true}
+              inline={false}
+              key="42"
               tag="div"
-              widths={
-                Array [
-                  "xs",
-                  "sm",
-                  "md",
-                  "lg",
-                  "xl",
-                ]
-              }
-              xs="auto"
             >
               <div
-                className="col-auto"
-                style={
-                  Object {
-                    "width": "300px",
-                  }
-                }
+                className="form-check"
               >
-                <FormGroup
+                <Label
                   check={true}
-                  inline={false}
-                  key="42"
-                  tag="div"
+                  tag="label"
+                  widths={
+                    Array [
+                      "xs",
+                      "sm",
+                      "md",
+                      "lg",
+                      "xl",
+                    ]
+                  }
                 >
-                  <div
-                    className="form-check"
+                  <label
+                    className="form-check-label"
                   >
-                    <Label
-                      check={true}
-                      tag="label"
-                      widths={
-                        Array [
-                          "xs",
-                          "sm",
-                          "md",
-                          "lg",
-                          "xl",
-                        ]
-                      }
+                    <Input
+                      checked={false}
+                      disabled={false}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value={0}
                     >
-                      <label
-                        className="form-check-label"
-                      >
-                        <Input
-                          checked={false}
-                          disabled={false}
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={0}
-                        >
-                          <input
-                            checked={false}
-                            className="form-check-input"
-                            disabled={false}
-                            onChange={[Function]}
-                            type="checkbox"
-                            value={0}
-                          />
-                        </Input>
-                         
-                        admin@42.nl
-                      </label>
-                    </Label>
-                  </div>
-                </FormGroup>
-                <FormGroup
-                  check={true}
-                  inline={false}
-                  key="777"
-                  tag="div"
-                >
-                  <div
-                    className="form-check"
-                  >
-                    <Label
-                      check={true}
-                      tag="label"
-                      widths={
-                        Array [
-                          "xs",
-                          "sm",
-                          "md",
-                          "lg",
-                          "xl",
-                        ]
-                      }
-                    >
-                      <label
-                        className="form-check-label"
-                      >
-                        <Input
-                          checked={false}
-                          disabled={false}
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={1}
-                        >
-                          <input
-                            checked={false}
-                            className="form-check-input"
-                            disabled={false}
-                            onChange={[Function]}
-                            type="checkbox"
-                            value={1}
-                          />
-                        </Input>
-                         
-                        coordinator@42.nl
-                      </label>
-                    </Label>
-                  </div>
-                </FormGroup>
-                <FormGroup
-                  check={true}
-                  inline={false}
-                  key="1337"
-                  tag="div"
-                >
-                  <div
-                    className="form-check"
-                  >
-                    <Label
-                      check={true}
-                      tag="label"
-                      widths={
-                        Array [
-                          "xs",
-                          "sm",
-                          "md",
-                          "lg",
-                          "xl",
-                        ]
-                      }
-                    >
-                      <label
-                        className="form-check-label"
-                      >
-                        <Input
-                          checked={false}
-                          disabled={false}
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={2}
-                        >
-                          <input
-                            checked={false}
-                            className="form-check-input"
-                            disabled={false}
-                            onChange={[Function]}
-                            type="checkbox"
-                            value={2}
-                          />
-                        </Input>
-                         
-                        user@42.nl
-                      </label>
-                    </Label>
-                  </div>
-                </FormGroup>
+                      <input
+                        checked={false}
+                        className="form-check-input"
+                        disabled={false}
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={0}
+                      />
+                    </Input>
+                     
+                    admin@42.nl
+                  </label>
+                </Label>
               </div>
-            </Col>
+            </FormGroup>
+            <FormGroup
+              check={true}
+              inline={false}
+              key="777"
+              tag="div"
+            >
+              <div
+                className="form-check"
+              >
+                <Label
+                  check={true}
+                  tag="label"
+                  widths={
+                    Array [
+                      "xs",
+                      "sm",
+                      "md",
+                      "lg",
+                      "xl",
+                    ]
+                  }
+                >
+                  <label
+                    className="form-check-label"
+                  >
+                    <Input
+                      checked={false}
+                      disabled={false}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value={1}
+                    >
+                      <input
+                        checked={false}
+                        className="form-check-input"
+                        disabled={false}
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={1}
+                      />
+                    </Input>
+                     
+                    coordinator@42.nl
+                  </label>
+                </Label>
+              </div>
+            </FormGroup>
+            <FormGroup
+              check={true}
+              inline={false}
+              key="1337"
+              tag="div"
+            >
+              <div
+                className="form-check"
+              >
+                <Label
+                  check={true}
+                  tag="label"
+                  widths={
+                    Array [
+                      "xs",
+                      "sm",
+                      "md",
+                      "lg",
+                      "xl",
+                    ]
+                  }
+                >
+                  <label
+                    className="form-check-label"
+                  >
+                    <Input
+                      checked={false}
+                      disabled={false}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value={2}
+                    >
+                      <input
+                        checked={false}
+                        className="form-check-input"
+                        disabled={false}
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={2}
+                      />
+                    </Input>
+                     
+                    user@42.nl
+                  </label>
+                </Label>
+              </div>
+            </FormGroup>
           </div>
-        </Row>
+        </div>
       </div>
     </FormGroup>
   </CheckboxMultipleSelect>


### PR DESCRIPTION
In the CheckboxMultipleSelect, the columns have a static width. When the
component is used in smaller layouts, the component overlays the
elements next to it due to the static width.

Changed static width to flex-basis to prevent overflow issues.

Closes #552