### PR TITLE
improvement: clarify use of isDateAllowed

### DIFF
--- a/src/form/DateTimeInput/DateTimeInput.stories.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.stories.tsx
@@ -190,6 +190,13 @@ storiesOf('Form/DateTimeInput', module)
           End time:
           <pre>{end?.toISOString()}</pre>
         </div>
+
+        <p>
+          Note: isDateAllowed is not a validator, it only disables selectable
+          dates to prevent users from selecting invalid dates. Manually typing a
+          date that is out of range should be validated using validators,
+          preferably using the JarbDateTimeInput.
+        </p>
       </Form>
     );
   })


### PR DESCRIPTION
In the DateTimeInput, the isDateAllowed does not validate the input, it
only disables clickable elements. This should be clarified as some
developers thought manually typing a date that is out of range would not
be allowed.

Added a note in the range story for the DateTimeInput component.

#561