### PR TITLE
feat (Typeahead, ModalPicker): Configurable page size

### DIFF
--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -58,6 +58,38 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
       </Form>
     );
   })
+  .add('show 5 options per page', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <ModalPickerMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          pageSize={5}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <p>
+          Note: Beware of performance issues when setting the page size too
+          high, that will cause the UX to deteriorate on smaller screens!
+        </p>
+      </Form>
+    );
+  })
   .add('async options', () => {
     const [value, setValue] = useState<Province[] | undefined>([
       nonExistingProvince()

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.test.tsx
@@ -42,7 +42,8 @@ describe('Component: ModalPickerMultiple', () => {
     reUsePage = false,
     isOptionEnabled,
     isAsync = false,
-    canClear
+    canClear,
+    pageSize = 10
   }: {
     value?: User[];
     showAddButton?: boolean;
@@ -58,6 +59,7 @@ describe('Component: ModalPickerMultiple', () => {
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
     canClear?: boolean;
+    pageSize?: number;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -73,7 +75,7 @@ describe('Component: ModalPickerMultiple', () => {
         if (doInitialCheck) {
           expect(pageNumber).toBe(1);
           expect(query).toBe('');
-          expect(size).toBe(10);
+          expect(size).toBe(pageSize);
           expect(optionsShouldAlwaysContainValue).toBe(false);
           doInitialCheck = false;
         }
@@ -120,7 +122,8 @@ describe('Component: ModalPickerMultiple', () => {
         ? () => <span>RenderOptions</span>
         : undefined,
       color: 'success' as Color,
-      canClear
+      canClear,
+      pageSize
     };
 
     const labelProps = hasLabel
@@ -273,6 +276,7 @@ describe('Component: ModalPickerMultiple', () => {
         // @ts-expect-error Test mock
         .openModal();
 
+      expect(modalPickerMultiple.find('Input')).toHaveLength(3);
       const admin = modalPickerMultiple.find('Input').at(0);
       const coordinator = modalPickerMultiple.find('Input').at(1);
       const user = modalPickerMultiple.find('Input').at(2);
@@ -280,6 +284,27 @@ describe('Component: ModalPickerMultiple', () => {
       expect(admin.props().disabled).toBe(false);
       expect(coordinator.props().disabled).toBe(true);
       expect(user.props().disabled).toBe(true);
+    });
+
+    it('should only render 2 options when pageSize is set to 2', () => {
+      const { modalPickerMultiple } = setup({
+        pageSize: 2,
+        value: [adminUser(), coordinatorUser()]
+      });
+
+      // Open the modal
+      modalPickerMultiple
+        .find('ModalPickerOpener')
+        .props()
+        // @ts-expect-error Test mock
+        .openModal();
+
+      expect(modalPickerMultiple.find('Input')).toHaveLength(2);
+      const admin = modalPickerMultiple.find('Input').at(0);
+      const coordinator = modalPickerMultiple.find('Input').at(1);
+
+      expect(admin.props().checked).toBe(true);
+      expect(coordinator.props().checked).toBe(true);
     });
 
     it('should render button left', () => {

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.tsx
@@ -50,6 +50,26 @@ export type Props<T> = Omit<
     canSearch?: boolean;
 
     /**
+     * Optionally specify the number of options to show / fetch per
+     * page in the modal.
+     *
+     * When `options` is an array, it will determine how many options
+     * will be displayed per page.
+     *
+     * When `options` is a fetcher, it will determine how many options
+     * are requested through the fetcher as the `page` parameter.
+     * This means that when you set the pageSize to `100` that
+     * `100` items are fetched from the back-end. Beware of
+     * performance issues when setting the value too high.
+     *
+     * Beware that setting the page size too high will cause the UX
+     * to deteriorate on smaller screens!
+     *
+     * Defaults to `10`.
+     */
+    pageSize?: number;
+
+    /**
      * Optionally an add button to display in the Modal. Can
      * be used to dynamically add an option which was not there
      * before.
@@ -105,6 +125,7 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
     onChange,
     addButton,
     canSearch = true,
+    pageSize = 10,
     options,
     keyForOption,
     isOptionEqual,
@@ -133,7 +154,7 @@ export default function ModalPickerMultiple<T>(props: Props<T>) {
     reloadOptions,
     pageNumber,
     query,
-    size: 10,
+    size: pageSize,
     optionsShouldAlwaysContainValue: false
   });
 

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -41,6 +41,31 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
       </Form>
     );
   })
+  .add('show 5 options per page', () => {
+    const [value, setValue] = useState<Province | undefined>(undefined);
+
+    return (
+      <Form>
+        <ModalPickerSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinces()}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          pageSize={5}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <p>
+          Note: Beware of performance issues when setting the page size too
+          high, that will cause the UX to deteriorate on smaller screens!
+        </p>
+      </Form>
+    );
+  })
   .add('async options', () => {
     const [value, setValue] = useState<Province | undefined>(provinces()[0]);
 

--- a/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.test.tsx
@@ -42,7 +42,8 @@ describe('Component: ModalPickerSingle', () => {
     reUsePage = false,
     isOptionEnabled,
     isAsync = false,
-    canClear
+    canClear,
+    pageSize = 10
   }: {
     value?: User;
     showAddButton?: boolean;
@@ -57,6 +58,7 @@ describe('Component: ModalPickerSingle', () => {
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
     canClear?: boolean;
+    pageSize?: number;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -72,7 +74,7 @@ describe('Component: ModalPickerSingle', () => {
         if (doInitialCheck) {
           expect(pageNumber).toBe(1);
           expect(query).toBe('');
-          expect(size).toBe(10);
+          expect(size).toBe(pageSize);
           expect(optionsShouldAlwaysContainValue).toBe(false);
           doInitialCheck = false;
         }
@@ -113,7 +115,8 @@ describe('Component: ModalPickerSingle', () => {
         ? () => <span>RenderOptions</span>
         : undefined,
       color: 'success' as Color,
-      canClear
+      canClear,
+      pageSize
     };
 
     const labelProps = hasLabel
@@ -216,6 +219,7 @@ describe('Component: ModalPickerSingle', () => {
         // @ts-expect-error Test mock
         .openModal();
 
+      expect(modalPickerSingle.find('Input')).toHaveLength(3);
       const admin = modalPickerSingle.find('Input').at(0);
       const coordinator = modalPickerSingle.find('Input').at(1);
       const user = modalPickerSingle.find('Input').at(2);
@@ -223,6 +227,27 @@ describe('Component: ModalPickerSingle', () => {
       expect(admin.props().disabled).toBe(false);
       expect(coordinator.props().disabled).toBe(true);
       expect(user.props().disabled).toBe(true);
+    });
+
+    it('should only render 2 options when pageSize is set to 2', () => {
+      const { modalPickerSingle } = setup({
+        value: adminUser(),
+        pageSize: 2
+      });
+
+      // Open the modal
+      modalPickerSingle
+        .find('ModalPickerOpener')
+        .props()
+        // @ts-expect-error Test mock
+        .openModal();
+
+      expect(modalPickerSingle.find('Input')).toHaveLength(2);
+      const admin = modalPickerSingle.find('Input').at(0);
+      const coordinator = modalPickerSingle.find('Input').at(1);
+
+      expect(admin.props().checked).toBe(true);
+      expect(coordinator.props().checked).toBe(false);
     });
 
     it('should render button left', () => {

--- a/src/form/ModalPicker/single/ModalPickerSingle.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.tsx
@@ -45,6 +45,26 @@ type Props<T> = Omit<
     canSearch?: boolean;
 
     /**
+     * Optionally specify the number of options to show / fetch per
+     * page in the modal.
+     *
+     * When `options` is an array, it will determine how many options
+     * will be displayed per page.
+     *
+     * When `options` is a fetcher, it will determine how many options
+     * are requested through the fetcher as the `page` parameter.
+     * This means that when you set the pageSize to `100` that
+     * `100` items are fetched from the back-end. Beware of
+     * performance issues when setting the value too high.
+     *
+     * Beware that setting the page size too high will cause the UX
+     * to deteriorate on smaller screens!
+     *
+     * Defaults to `10`.
+     */
+    pageSize?: number;
+
+    /**
      * Optionally an add button to display in the Modal. Can
      * be used to dynamically add an option which was not there
      * before.
@@ -100,6 +120,7 @@ export default function ModalPickerSingle<T>(props: Props<T>) {
     onChange,
     addButton,
     canSearch = true,
+    pageSize = 10,
     options,
     keyForOption,
     isOptionEqual,
@@ -127,7 +148,7 @@ export default function ModalPickerSingle<T>(props: Props<T>) {
     reloadOptions,
     pageNumber,
     query,
-    size: 10,
+    size: pageSize,
     optionsShouldAlwaysContainValue: false
   });
 

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
@@ -69,6 +69,39 @@ storiesOf('Form/Typeahead/JarbTypeaheadMultiple', module)
       </Form>
     );
   })
+
+  .add('async options - limited pageSize', () => {
+    const [value, setValue] = useState<Province[] | undefined>([
+      nonExistingProvince()
+    ]);
+
+    return (
+      <Form>
+        <TypeaheadMultiple
+          id="provinces"
+          label="Provinces"
+          placeholder="Please select your provinces"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          pageSize={5}
+        />
+
+        {value ? (
+          <p>
+            Your chosen provinces are:{' '}
+            {value.map((province) => province.label).join(', ')}
+          </p>
+        ) : null}
+
+        <p>
+          Note: Beware of performance issues when setting the page size too
+          high, that will cause the UX to deteriorate on smaller screens!
+        </p>
+      </Form>
+    );
+  })
   .add('disabled options', () => {
     const [value, setValue] = useState<Province[] | undefined>([
       nonExistingProvince()

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
@@ -28,7 +28,8 @@ describe('Component: TypeaheadMultiple', () => {
     hasLabel = true,
     loading = false,
     isOptionEnabled,
-    isAsync = false
+    isAsync = false,
+    pageSize
   }: {
     value?: User[];
     hasPlaceholder?: boolean;
@@ -36,6 +37,7 @@ describe('Component: TypeaheadMultiple', () => {
     loading?: boolean;
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
+    pageSize?: number;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -44,7 +46,7 @@ describe('Component: TypeaheadMultiple', () => {
     useOptions.mockImplementation(
       ({ pageNumber, size, optionsShouldAlwaysContainValue }) => {
         expect(pageNumber).toBe(1);
-        expect(size).toBe(10);
+        expect(size).toBe(!isAsync ? listOfUsers().length : pageSize ?? 10);
         expect(optionsShouldAlwaysContainValue).toBe(false);
 
         return {
@@ -64,6 +66,7 @@ describe('Component: TypeaheadMultiple', () => {
       value,
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
+      pageSize,
       error: 'Some error'
     };
 
@@ -95,6 +98,33 @@ describe('Component: TypeaheadMultiple', () => {
 
       expect(toJson(typeaheadMultiple)).toMatchSnapshot(
         'Component: TypeaheadMultiple => ui => without placeholder'
+      );
+    });
+
+    test('async with a custom pageSize of 2 options in the dropdown', () => {
+      const { typeaheadMultiple } = setup({
+        isAsync: true,
+        pageSize: 2
+      });
+
+      expect(useOptions).toBeCalledTimes(1);
+      expect(useOptions).toBeCalledWith(expect.objectContaining({ size: 2 }));
+
+      expect(toJson(typeaheadMultiple)).toMatchSnapshot(
+        'Component: TypeaheadMultiple => ui => async with a custom pageSize of 2 options in the dropdown'
+      );
+    });
+
+    test('async with the default pageSize of 10 options in the dropdown', () => {
+      const { typeaheadMultiple } = setup({
+        isAsync: true
+      });
+
+      expect(useOptions).toBeCalledTimes(1);
+      expect(useOptions).toBeCalledWith(expect.objectContaining({ size: 10 }));
+
+      expect(toJson(typeaheadMultiple)).toMatchSnapshot(
+        'Component: TypeaheadMultiple => ui => async with the default pageSize of 10 options in the dropdown'
       );
     });
 

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
@@ -21,7 +21,27 @@ import { useId } from '../../../hooks/useId/useId';
 import { useOptions } from '../../useOptions';
 
 type Props<T> = FieldCompatible<T[], T[] | undefined> &
-  FieldCompatibleWithPredeterminedOptions<T>;
+  FieldCompatibleWithPredeterminedOptions<T> & {
+    /**
+     * Optionally specify the number of suggestions to show / fetch
+     * in the dropdown.
+     *
+     * When `options` is an array, all options will always be shown
+     * and this prop has no effect.
+     *
+     * When `options` is a fetcher, it will determine how many options
+     * are requested through the fetcher as the `page` parameter.
+     * This means that when you set the pageSize to `100` that
+     * `100` items are fetched from the back-end. Beware of
+     * performance issues when setting the value too high.
+     *
+     * Beware that setting the page size too high will cause the UX
+     * to deteriorate on smaller screens!
+     *
+     * Defaults to `10`.
+     */
+    pageSize?: number;
+  };
 
 /**
  * The TypeaheadMultiple is a form element which allows the user
@@ -57,7 +77,8 @@ export default function TypeaheadMultiple<T>(props: Props<T>) {
     keyForOption,
     isOptionEqual,
     reloadOptions,
-    isOptionEnabled = alwaysTrue
+    isOptionEnabled = alwaysTrue,
+    pageSize = 10
   } = props;
 
   const [query, setQuery] = useState('');
@@ -71,7 +92,7 @@ export default function TypeaheadMultiple<T>(props: Props<T>) {
     reloadOptions,
     query,
     pageNumber: 1,
-    size: 10,
+    size: Array.isArray(options) ? options.length : pageSize,
     optionsShouldAlwaysContainValue: false
   });
 

--- a/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
+++ b/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
@@ -9,6 +9,181 @@ exports[`Component: TypeaheadMultiple renderToken ui: Component: TypeaheadMultip
 />
 `;
 
+exports[`Component: TypeaheadMultiple ui async with a custom pageSize of 2 options in the dropdown: Component: TypeaheadMultiple => ui => async with a custom pageSize of 2 options in the dropdown 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <withAsync(Component)
+      delay={200}
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+          "value": undefined,
+        }
+      }
+      isLoading={false}
+      minLength={2}
+      multiple={true}
+      onChange={[Function]}
+      onSearch={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      placeholder="Please provide your best friend"
+      promptText="Type to search..."
+      renderToken={[Function]}
+      searchText="Searching..."
+      selected={Array []}
+      useCache={true}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TypeaheadMultiple ui async with the default pageSize of 10 options in the dropdown: Component: TypeaheadMultiple => ui => async with the default pageSize of 10 options in the dropdown 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <withAsync(Component)
+      delay={200}
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+          "value": undefined,
+        }
+      }
+      isLoading={false}
+      minLength={2}
+      multiple={true}
+      onChange={[Function]}
+      onSearch={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      placeholder="Please provide your best friend"
+      promptText="Type to search..."
+      renderToken={[Function]}
+      searchText="Searching..."
+      selected={Array []}
+      useCache={true}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultiple => ui => with value 1`] = `
 <FormGroup
   className=""

--- a/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
@@ -55,6 +55,33 @@ storiesOf('Form/Typeahead/JarbTypeaheadSingle', module)
       </Form>
     );
   })
+  .add('async options - limited pageSize', () => {
+    const [value, setValue] = useState<Province | undefined>(
+      nonExistingProvince()
+    );
+
+    return (
+      <Form>
+        <TypeaheadSingle<Province>
+          id="province"
+          label="Province"
+          placeholder="Please select your province"
+          options={provinceFetcher}
+          labelForOption={(province) => province.label}
+          value={value}
+          onChange={setValue}
+          pageSize={5}
+        />
+
+        {value ? <p>Your chosen province is: {value.label}</p> : null}
+
+        <p>
+          Note: Beware of performance issues when setting the page size too
+          high, that will cause the UX to deteriorate on smaller screens!
+        </p>
+      </Form>
+    );
+  })
   .add('disabled options', () => {
     const [value, setValue] = useState<Province | undefined>(
       nonExistingProvince()

--- a/src/form/Typeahead/single/TypeaheadSingle.test.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.test.tsx
@@ -31,7 +31,8 @@ describe('Component: TypeaheadSingle', () => {
     hasLabel = true,
     loading = false,
     isOptionEnabled,
-    isAsync = false
+    isAsync = false,
+    pageSize
   }: {
     value?: User;
     hasPlaceholder?: boolean;
@@ -39,6 +40,7 @@ describe('Component: TypeaheadSingle', () => {
     loading?: boolean;
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
+    pageSize?: number;
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -47,7 +49,7 @@ describe('Component: TypeaheadSingle', () => {
     useOptions.mockImplementation(
       ({ pageNumber, size, optionsShouldAlwaysContainValue }) => {
         expect(pageNumber).toBe(1);
-        expect(size).toBe(10);
+        expect(size).toBe(!isAsync ? listOfUsers().length : pageSize ?? 10);
         expect(optionsShouldAlwaysContainValue).toBe(false);
 
         return {
@@ -67,7 +69,8 @@ describe('Component: TypeaheadSingle', () => {
       value,
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
-      error: 'Some error'
+      error: 'Some error',
+      pageSize
     };
 
     const labelProps = hasLabel
@@ -87,6 +90,33 @@ describe('Component: TypeaheadSingle', () => {
 
       expect(toJson(typeaheadSingle)).toMatchSnapshot(
         'Component: TypeaheadSingle => ui => with value'
+      );
+    });
+
+    test('async with a custom pageSize of 2 options in the dropdown', () => {
+      const { typeaheadSingle } = setup({
+        isAsync: true,
+        pageSize: 2
+      });
+
+      expect(useOptions).toBeCalledTimes(1);
+      expect(useOptions).toBeCalledWith(expect.objectContaining({ size: 2 }));
+
+      expect(toJson(typeaheadSingle)).toMatchSnapshot(
+        'Component: TypeaheadSingle => ui => async with a custom pageSize of 2 options in the dropdown'
+      );
+    });
+
+    test('async with the default pageSize of 10 options in the dropdown', () => {
+      const { typeaheadSingle } = setup({
+        isAsync: true
+      });
+
+      expect(useOptions).toBeCalledTimes(1);
+      expect(useOptions).toBeCalledWith(expect.objectContaining({ size: 10 }));
+
+      expect(toJson(typeaheadSingle)).toMatchSnapshot(
+        'Component: TypeaheadSingle => ui => async with the default pageSize of 10 options in the dropdown'
       );
     });
 

--- a/src/form/Typeahead/single/TypeaheadSingle.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.tsx
@@ -17,7 +17,27 @@ import { optionToTypeaheadOption } from '../utils';
 import { useAutoSelectOptionWhenQueryMatchesExactly } from './useAutoSelectOptionWhenQueryMatchesExactly';
 
 type Props<T> = FieldCompatible<T, T | undefined> &
-  FieldCompatibleWithPredeterminedOptions<T>;
+  FieldCompatibleWithPredeterminedOptions<T> & {
+    /**
+     * Optionally specify the number of suggestions to show / fetch
+     * in the dropdown.
+     *
+     * When `options` is an array, all options will always be shown
+     * and this prop has no effect.
+     *
+     * When `options` is a fetcher, it will determine how many options
+     * are requested through the fetcher as the `page` parameter.
+     * This means that when you set the pageSize to `100` that
+     * `100` items are fetched from the back-end. Beware of
+     * performance issues when setting the value too high.
+     *
+     * Beware that setting the page size too high will cause the UX
+     * to deteriorate on smaller screens!
+     *
+     * Defaults to `10`.
+     */
+    pageSize?: number;
+  };
 
 /**
  * The TypeaheadSingle is a form element which allows the user
@@ -53,7 +73,8 @@ export default function TypeaheadSingle<T>(props: Props<T>) {
     keyForOption,
     isOptionEqual,
     reloadOptions,
-    isOptionEnabled = alwaysTrue
+    isOptionEnabled = alwaysTrue,
+    pageSize = 10
   } = props;
 
   const [query, setQuery] = useState('');
@@ -67,7 +88,7 @@ export default function TypeaheadSingle<T>(props: Props<T>) {
     reloadOptions,
     query,
     pageNumber: 1,
-    size: 10,
+    size: Array.isArray(options) ? options.length : pageSize,
     optionsShouldAlwaysContainValue: false
   });
 

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -1,5 +1,176 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: TypeaheadSingle ui async with a custom pageSize of 2 options in the dropdown: Component: TypeaheadSingle => ui => async with a custom pageSize of 2 options in the dropdown 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <withAsync(Component)
+      delay={200}
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+        }
+      }
+      isLoading={false}
+      minLength={2}
+      multiple={false}
+      onChange={[Function]}
+      onSearch={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      placeholder="Please provide your best friend"
+      promptText="Type to search..."
+      searchText="Searching..."
+      selected={Array []}
+      useCache={true}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TypeaheadSingle ui async with the default pageSize of 10 options in the dropdown: Component: TypeaheadSingle => ui => async with the default pageSize of 10 options in the dropdown 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <withAsync(Component)
+      delay={200}
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+        }
+      }
+      isLoading={false}
+      minLength={2}
+      multiple={false}
+      onChange={[Function]}
+      onSearch={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      placeholder="Please provide your best friend"
+      promptText="Type to search..."
+      searchText="Searching..."
+      selected={Array []}
+      useCache={true}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
 exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle => ui => with value 1`] = `
 <FormGroup
   className=""


### PR DESCRIPTION
Added the ability to specify the number of suggestions for
`TypeaheadSingle` and `TypeaheadMultiple`. Also added the ability to
show all predefined options matching the input. One of our applications
needs to show as much suggestions as possible, as users need to know
which values are supported.

Added the ability to change the page size of `ModalPickerMultiple` and
`ModalPickerSingle`, for some applications it is desired to have more
than 10 items per page on screen.