### PR TITLE
feat(Typeahead): Allow customizing the reactstrap pagination text

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -192,6 +192,12 @@ Here is a JSON notation containing all keys and default translations:
   },
   "OrSeparator": {
     "OR": "OR"
+  },
+  "TypeaheadSingle": {
+    "PAGINATION_TEXT": "Display additional results..."
+  },
+  "TypeaheadMultiple": {
+    "PAGINATION_TEXT": "Display additional results..."
   }
 }
 ```

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.test.tsx
@@ -29,7 +29,8 @@ describe('Component: TypeaheadMultiple', () => {
     loading = false,
     isOptionEnabled,
     isAsync = false,
-    pageSize
+    pageSize,
+    text
   }: {
     value?: User[];
     hasPlaceholder?: boolean;
@@ -38,6 +39,9 @@ describe('Component: TypeaheadMultiple', () => {
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
     pageSize?: number;
+    text?: {
+      paginationText?: string;
+    };
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -67,6 +71,7 @@ describe('Component: TypeaheadMultiple', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       pageSize,
+      text,
       error: 'Some error'
     };
 
@@ -126,6 +131,40 @@ describe('Component: TypeaheadMultiple', () => {
       expect(toJson(typeaheadMultiple)).toMatchSnapshot(
         'Component: TypeaheadMultiple => ui => async with the default pageSize of 10 options in the dropdown'
       );
+    });
+
+    test('with the default pagination text', () => {
+      const { typeaheadMultiple } = setup({});
+
+      expect(toJson(typeaheadMultiple)).toMatchSnapshot(
+        'Component: TypeaheadMultiple => ui => with the default pagination text'
+      );
+
+      const reactstrapTypeahead = typeaheadMultiple
+        .find('div')
+        .children()
+        .first();
+      expect(reactstrapTypeahead.props().paginationText).toBe(
+        'Display additional results...'
+      );
+    });
+
+    test('with a custom pagination text', () => {
+      const { typeaheadMultiple } = setup({
+        text: {
+          paginationText: 'Show more'
+        }
+      });
+
+      expect(toJson(typeaheadMultiple)).toMatchSnapshot(
+        'Component: TypeaheadMultiple => ui => with a custom pagination text'
+      );
+
+      const reactstrapTypeahead = typeaheadMultiple
+        .find('div')
+        .children()
+        .first();
+      expect(reactstrapTypeahead.props().paginationText).toBe('Show more');
     });
 
     test('without label', () => {

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.tsx
@@ -19,6 +19,18 @@ import Tag from '../../../core/Tag/Tag';
 import { FieldCompatible } from '../../types';
 import { useId } from '../../../hooks/useId/useId';
 import { useOptions } from '../../useOptions';
+import { t } from '../../../utilities/translation/translation';
+
+type Text = {
+  /**
+   * Text to show when more than 100 items are available
+   * in the dropdown. This is used by the pagination built
+   * into the Typeahead of reactstrap.
+   *
+   * Defaults to `Display additional results...`
+   */
+  paginationText?: string;
+};
 
 type Props<T> = FieldCompatible<T[], T[] | undefined> &
   FieldCompatibleWithPredeterminedOptions<T> & {
@@ -41,6 +53,11 @@ type Props<T> = FieldCompatible<T[], T[] | undefined> &
      * Defaults to `10`.
      */
     pageSize?: number;
+    /**
+     * Optionally customized text within the component.
+     * This text should already be translated.
+     */
+    text?: Text;
   };
 
 /**
@@ -78,7 +95,8 @@ export default function TypeaheadMultiple<T>(props: Props<T>) {
     isOptionEqual,
     reloadOptions,
     isOptionEnabled = alwaysTrue,
-    pageSize = 10
+    pageSize = 10,
+    text = {}
   } = props;
 
   const [query, setQuery] = useState('');
@@ -155,6 +173,11 @@ export default function TypeaheadMultiple<T>(props: Props<T>) {
   const typeaheadProps: TypeaheadProps<TypeaheadOption<T>> = {
     id,
     filterBy: alwaysTrue,
+    paginationText: t({
+      key: 'TypeaheadMultiple.PAGINATION_TEXT',
+      fallback: 'Display additional results...',
+      overrideText: text.paginationText
+    }),
     multiple: true,
     placeholder,
     selected,

--- a/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
+++ b/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`Component: TypeaheadMultiple ui async with a custom pageSize of 2 optio
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       renderToken={[Function]}
@@ -172,12 +173,191 @@ exports[`Component: TypeaheadMultiple ui async with the default pageSize of 10 o
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       renderToken={[Function]}
       searchText="Searching..."
       selected={Array []}
       useCache={true}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TypeaheadMultiple ui with a custom pagination text: Component: TypeaheadMultiple => ui => with a custom pagination text 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <ForwardRef
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+          "value": undefined,
+        }
+      }
+      multiple={true}
+      onChange={[Function]}
+      onInputChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      paginationText="Show more"
+      placeholder="Please provide your best friend"
+      renderToken={[Function]}
+      selected={Array []}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TypeaheadMultiple ui with the default pagination text: Component: TypeaheadMultiple => ui => with the default pagination text 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <ForwardRef
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+          "value": undefined,
+        }
+      }
+      multiple={true}
+      onChange={[Function]}
+      onInputChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      paginationText="Display additional results..."
+      placeholder="Please provide your best friend"
+      renderToken={[Function]}
+      selected={Array []}
     />
   </div>
   Some error
@@ -261,6 +441,7 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       renderToken={[Function]}
       selected={
@@ -347,6 +528,7 @@ exports[`Component: TypeaheadMultiple ui without label: Component: TypeaheadMult
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       renderToken={[Function]}
       selected={
@@ -449,6 +631,7 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
           },
         ]
       }
+      paginationText="Display additional results..."
       renderToken={[Function]}
       selected={
         Array [

--- a/src/form/Typeahead/single/TypeaheadSingle.test.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.test.tsx
@@ -32,7 +32,8 @@ describe('Component: TypeaheadSingle', () => {
     loading = false,
     isOptionEnabled,
     isAsync = false,
-    pageSize
+    pageSize,
+    text
   }: {
     value?: User;
     hasPlaceholder?: boolean;
@@ -41,6 +42,9 @@ describe('Component: TypeaheadSingle', () => {
     isOptionEnabled?: IsOptionEnabled<User>;
     isAsync?: boolean;
     pageSize?: number;
+    text?: {
+      paginationText?: string;
+    };
   }) {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
@@ -70,7 +74,8 @@ describe('Component: TypeaheadSingle', () => {
       onChange: onChangeSpy,
       onBlur: onBlurSpy,
       error: 'Some error',
-      pageSize
+      pageSize,
+      text
     };
 
     const labelProps = hasLabel
@@ -129,6 +134,40 @@ describe('Component: TypeaheadSingle', () => {
       expect(toJson(typeaheadSingle)).toMatchSnapshot(
         'Component: TypeaheadSingle => ui => without placeholder'
       );
+    });
+
+    test('with the default pagination text', () => {
+      const { typeaheadSingle } = setup({});
+
+      expect(toJson(typeaheadSingle)).toMatchSnapshot(
+        'Component: TypeaheadSingle => ui => with the default pagination text'
+      );
+
+      const reactstrapTypeahead = typeaheadSingle
+        .find('div')
+        .children()
+        .first();
+      expect(reactstrapTypeahead.props().paginationText).toBe(
+        'Display additional results...'
+      );
+    });
+
+    test('with a custom pagination text', () => {
+      const { typeaheadSingle } = setup({
+        text: {
+          paginationText: 'Show more'
+        }
+      });
+
+      expect(toJson(typeaheadSingle)).toMatchSnapshot(
+        'Component: TypeaheadSingle => ui => with a custom pagination text'
+      );
+
+      const reactstrapTypeahead = typeaheadSingle
+        .find('div')
+        .children()
+        .first();
+      expect(reactstrapTypeahead.props().paginationText).toBe('Show more');
     });
 
     test('without label', () => {

--- a/src/form/Typeahead/single/TypeaheadSingle.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.tsx
@@ -15,6 +15,18 @@ import withJarb from '../../withJarb/withJarb';
 import { TypeaheadOption } from '../types';
 import { optionToTypeaheadOption } from '../utils';
 import { useAutoSelectOptionWhenQueryMatchesExactly } from './useAutoSelectOptionWhenQueryMatchesExactly';
+import { t } from '../../../utilities/translation/translation';
+
+type Text = {
+  /**
+   * Text to show when more than 100 items are available
+   * in the dropdown. This is used by the pagination built
+   * into the Typeahead of reactstrap.
+   *
+   * Defaults to `Display additional results...`
+   */
+  paginationText?: string;
+};
 
 type Props<T> = FieldCompatible<T, T | undefined> &
   FieldCompatibleWithPredeterminedOptions<T> & {
@@ -37,6 +49,11 @@ type Props<T> = FieldCompatible<T, T | undefined> &
      * Defaults to `10`.
      */
     pageSize?: number;
+    /**
+     * Optionally customized text within the component.
+     * This text should already be translated.
+     */
+    text?: Text;
   };
 
 /**
@@ -74,7 +91,8 @@ export default function TypeaheadSingle<T>(props: Props<T>) {
     isOptionEqual,
     reloadOptions,
     isOptionEnabled = alwaysTrue,
-    pageSize = 10
+    pageSize = 10,
+    text = {}
   } = props;
 
   const [query, setQuery] = useState('');
@@ -140,6 +158,11 @@ export default function TypeaheadSingle<T>(props: Props<T>) {
     options: typeaheadOptions,
     onChange: doOnChange,
     onFocus,
+    paginationText: t({
+      key: 'TypeaheadSingle.PAGINATION_TEXT',
+      fallback: 'Display additional results...',
+      overrideText: text.paginationText
+    }),
     inputProps: {
       className: classNames('form-control', {
         'is-invalid': valid === false

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`Component: TypeaheadSingle ui async with a custom pageSize of 2 options
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       searchText="Searching..."
@@ -160,11 +161,186 @@ exports[`Component: TypeaheadSingle ui async with the default pageSize of 10 opt
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       promptText="Type to search..."
       searchText="Searching..."
       selected={Array []}
       useCache={true}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TypeaheadSingle ui with a custom pagination text: Component: TypeaheadSingle => ui => with a custom pagination text 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <ForwardRef
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+        }
+      }
+      multiple={false}
+      onChange={[Function]}
+      onInputChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      paginationText="Show more"
+      placeholder="Please provide your best friend"
+      selected={Array []}
+    />
+  </div>
+  Some error
+</FormGroup>
+`;
+
+exports[`Component: TypeaheadSingle ui with the default pagination text: Component: TypeaheadSingle => ui => with the default pagination text 1`] = `
+<FormGroup
+  className=""
+  tag="div"
+>
+  <Label
+    for="bestFriend"
+    tag="label"
+    widths={
+      Array [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+      ]
+    }
+  >
+    Best friend
+  </Label>
+  <div
+    className="showing-placeholder"
+  >
+    <ForwardRef
+      filterBy={[Function]}
+      id="bestFriend"
+      inputProps={
+        Object {
+          "className": "form-control",
+        }
+      }
+      multiple={false}
+      onChange={[Function]}
+      onInputChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "admin@42.nl",
+            "value": Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+          },
+          Object {
+            "label": "coordinator@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+          },
+          Object {
+            "label": "user@42.nl",
+            "value": Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          },
+        ]
+      }
+      paginationText="Display additional results..."
+      placeholder="Please provide your best friend"
+      selected={Array []}
     />
   </div>
   Some error
@@ -249,6 +425,7 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       selected={
         Array [
@@ -335,6 +512,7 @@ exports[`Component: TypeaheadSingle ui without label: Component: TypeaheadSingle
           },
         ]
       }
+      paginationText="Display additional results..."
       placeholder="Please provide your best friend"
       selected={
         Array [
@@ -437,6 +615,7 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
           },
         ]
       }
+      paginationText="Display additional results..."
       selected={
         Array [
           Object {


### PR DESCRIPTION
If a large set of items is passed (or `pageSize` is higher than 100),
ReactStrap will add a fallback pagination to the dropdown to ensure the
DOM performance stays optimal.

The text of this pagination button was not configurable. This has now
been resolved.

<img width="651" alt=" " src="https://user-images.githubusercontent.com/10106652/115260159-c88c3280-a132-11eb-9da3-e186eb508b36.png">
