### PR TITLE
improvement: CardOpenClose rename content to children

### DIFF
--- a/src/core/CardOpenClose/CardOpenClose.stories.tsx
+++ b/src/core/CardOpenClose/CardOpenClose.stories.tsx
@@ -12,7 +12,8 @@ storiesOf('core/CardOpenClose', module)
         header="You should see this!"
         isOpen={isOpen}
         toggle={() => setIsOpen(!isOpen)}
-        content={() => (
+      >
+        {() => (
           <iframe
             width="560"
             height="315"
@@ -23,6 +24,6 @@ storiesOf('core/CardOpenClose', module)
             allowFullScreen
           ></iframe>
         )}
-      />
+      </CardOpenClose>
     );
   });

--- a/src/core/CardOpenClose/CardOpenClose.test.tsx
+++ b/src/core/CardOpenClose/CardOpenClose.test.tsx
@@ -9,17 +9,14 @@ describe('Component: CardOpenClose', () => {
     const toggleSpy = jest.fn();
 
     const cardOpenClose = shallow(
-      <CardOpenClose
-        header="click this"
-        isOpen={isOpen}
-        toggle={toggleSpy}
-        content={() => (
+      <CardOpenClose header="click this" isOpen={isOpen} toggle={toggleSpy}>
+        {() => (
           <p>
             This is collapsable content that should not be included in the HTML
             when isOpen is false
           </p>
         )}
-      />
+      </CardOpenClose>
     );
 
     return { cardOpenClose, toggleSpy };
@@ -55,6 +52,41 @@ describe('Component: CardOpenClose', () => {
         .onClick();
 
       expect(toggleSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deprecated: content', () => {
+    function setup({ isOpen }: { isOpen: boolean }) {
+      const cardOpenClose = shallow(
+        <CardOpenClose
+          header="click this"
+          isOpen={isOpen}
+          toggle={jest.fn()}
+          content={() => (
+            <p>
+              This is collapsable content that should not be included in the
+              HTML when isOpen is false
+            </p>
+          )}
+        />
+      );
+      return { cardOpenClose };
+    }
+
+    test('open', () => {
+      const { cardOpenClose } = setup({ isOpen: true });
+
+      expect(toJson(cardOpenClose)).toMatchSnapshot(
+        'Component: CardOpenClose => deprecated: content => open'
+      );
+    });
+
+    test('closed', () => {
+      const { cardOpenClose } = setup({ isOpen: false });
+
+      expect(toJson(cardOpenClose)).toMatchSnapshot(
+        'Component: CardOpenClose => deprecated: content => closed'
+      );
     });
   });
 });

--- a/src/core/CardOpenClose/CardOpenClose.tsx
+++ b/src/core/CardOpenClose/CardOpenClose.tsx
@@ -3,16 +3,11 @@ import { OpenClose } from '../OpenClose/OpenClose';
 import { Card, CardHeader } from 'reactstrap';
 import classNames from 'classnames';
 
-type Props = {
+type BaseProps = {
   /**
    * The important details you always want to be displayed.
    */
   header: React.ReactNode;
-
-  /**
-   * The content that might be hidden in the collapsable body.
-   */
-  content: () => React.ReactNode;
 
   /**
    * Whether or not the collapsable body is opened.
@@ -32,18 +27,34 @@ type Props = {
   className?: string;
 };
 
+type PropsWithChildren = BaseProps & {
+  /**
+   * The content that might be hidden in the collapsable body.
+   */
+  children: () => React.ReactNode;
+};
+
+type DeprecatedPropsWithContent = BaseProps & {
+  /**
+   * The content that might be hidden in the collapsable body.
+   *
+   * @deprecated Please do not use the content property anymore.
+   * Instead use the children property.
+   * In version 4.0.0 the content property will be removed.
+   */
+  content: () => React.ReactNode;
+};
+
+type Props = PropsWithChildren | DeprecatedPropsWithContent;
+
 /**
  * CardOpenClose is a collapsable bootstrap card that you can use to only display
  * important details and hide other details in a collapsable body to prevent extra
  * long pages that cause the user to scroll a lot.
  */
-export function CardOpenClose({
-  header,
-  content,
-  isOpen,
-  toggle,
-  className
-}: Props) {
+export function CardOpenClose(props: Props) {
+  const { header, isOpen, toggle, className } = props;
+
   return (
     <Card className={classNames('my-2', className)}>
       <CardHeader
@@ -55,7 +66,15 @@ export function CardOpenClose({
         <OpenClose open={isOpen} />
       </CardHeader>
 
-      {isOpen ? content() : null}
+      {!isOpen
+        ? null
+        : propsHasChildren(props)
+        ? props.children()
+        : props.content()}
     </Card>
   );
+}
+
+function propsHasChildren(props: Props): props is PropsWithChildren {
+  return (props as PropsWithChildren).children !== undefined;
 }

--- a/src/core/CardOpenClose/__snapshots__/CardOpenClose.test.tsx.snap
+++ b/src/core/CardOpenClose/__snapshots__/CardOpenClose.test.tsx.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: CardOpenClose deprecated: content closed: Component: CardOpenClose => deprecated: content => closed 1`] = `
+<Card
+  className="my-2"
+  tag="div"
+>
+  <CardHeader
+    className="d-flex justify-content-between align-content-center clickable"
+    onClick={[MockFunction]}
+    tag="div"
+  >
+    click this
+    <OpenClose
+      open={false}
+    />
+  </CardHeader>
+</Card>
+`;
+
+exports[`Component: CardOpenClose deprecated: content open: Component: CardOpenClose => deprecated: content => open 1`] = `
+<Card
+  className="my-2"
+  tag="div"
+>
+  <CardHeader
+    className="d-flex justify-content-between align-content-center clickable"
+    onClick={[MockFunction]}
+    tag="div"
+  >
+    click this
+    <OpenClose
+      open={true}
+    />
+  </CardHeader>
+  <p>
+    This is collapsable content that should not be included in the HTML when isOpen is false
+  </p>
+</Card>
+`;
+
 exports[`Component: CardOpenClose ui closed: Component: CardOpenClose => ui => closed 1`] = `
 <Card
   className="my-2"

--- a/src/core/Debug/Debug.test.tsx
+++ b/src/core/Debug/Debug.test.tsx
@@ -16,7 +16,7 @@ describe('Component: Debug', () => {
     const { debug } = setup({});
 
     expect(toJson(debug)).toMatchSnapshot();
-    expect(toJson(debug.props().content())).toMatchSnapshot();
+    expect(toJson(debug.props().children())).toMatchSnapshot();
   });
 
   it('should start closed when open is false', () => {

--- a/src/core/Debug/Debug.tsx
+++ b/src/core/Debug/Debug.tsx
@@ -44,7 +44,8 @@ export function Debug({ value, defaultOpen = true }: Props) {
       header="DEBUG"
       isOpen={isOpen}
       toggle={() => setIsOpen(!isOpen)}
-      content={() => <pre>{JSON.stringify(value, null, 2)}</pre>}
-    />
+    >
+      {() => <pre>{JSON.stringify(value, null, 2)}</pre>}
+    </CardOpenClose>
   );
 }

--- a/src/core/Debug/__snapshots__/Debug.test.tsx.snap
+++ b/src/core/Debug/__snapshots__/Debug.test.tsx.snap
@@ -2,11 +2,12 @@
 
 exports[`Component: Debug ui 1`] = `
 <CardOpenClose
-  content={[Function]}
   header="DEBUG"
   isOpen={true}
   toggle={[Function]}
-/>
+>
+  <Component />
+</CardOpenClose>
 `;
 
 exports[`Component: Debug ui 2`] = `undefined`;


### PR DESCRIPTION
The content property should have been called children instead. This
makes for a better API.
We should deprecate content but not remove it and wait until 4.0.0 to
remove it.

Added children prop to replace the content prop in the next major
version.

Closes #575