### PR TITLE
improvement: replace React Async with React Query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9366,6 +9366,12 @@
         "open": "^7.0.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -9568,6 +9574,33 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "brorand": {
@@ -11596,6 +11629,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
     "detect-port-alt": {
@@ -20630,6 +20669,12 @@
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -21665,6 +21710,16 @@
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
       "dev": true
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
@@ -21880,6 +21935,12 @@
           "dev": true
         }
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==",
+      "dev": true
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -22161,6 +22222,15 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanocolors": {
       "version": "0.1.12",
@@ -23509,6 +23579,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
       "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
+      "dev": true
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
       "dev": true
     },
     "on-finished": {
@@ -25537,6 +25613,17 @@
         }
       }
     },
+    "react-query": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.25.1.tgz",
+      "integrity": "sha512-tGZkap921d9dJD2F8+NpEu3djLRP+tpZKHKhQvqUMYMfWT5R18iRtGAG5ZeUMlRKuhzNaZx3cHiYj3DsyZ1SWw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-quill": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-1.3.5.tgz",
@@ -26079,6 +26166,12 @@
       "requires": {
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=",
+      "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -29549,6 +29642,16 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -30559,7 +30662,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-async": "10.0.1",
     "react-docgen-typescript-plugin": "1.0.0",
     "react-dom": "17.0.2",
+    "react-query": "3.25.1",
     "react-router-dom": "5.3.0",
     "react-test-renderer": "17.0.2",
     "reactstrap": "8.10.0",

--- a/src/core/AsyncContent/AsyncContent.stories.tsx
+++ b/src/core/AsyncContent/AsyncContent.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import AsyncContent from './AsyncContent';
-import { useAsync } from 'react-async';
+import { useQuery } from 'react-query';
 import { action } from '@storybook/addon-actions';
 import { ContentState, Button } from '../..';
 
@@ -29,7 +29,7 @@ function loadingData() {
 storiesOf('core/async/AsyncContent', module)
   .addParameters({ component: AsyncContent })
   .add('when loaded', () => {
-    const state = useAsync(loadData);
+    const state = useQuery('data', loadData);
 
     return (
       <div className="text-center">
@@ -41,7 +41,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when error', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <div className="text-center">
@@ -53,7 +53,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when error with custom text', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <div className="text-center">
@@ -68,7 +68,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when error with no retry button', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <div className="text-center">
@@ -80,7 +80,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when loading', () => {
-    const state = useAsync(loadingData);
+    const state = useQuery('data', loadingData);
 
     return (
       <div className="text-center">
@@ -92,7 +92,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when loading with custom title', () => {
-    const state = useAsync(loadingData);
+    const state = useQuery('data', loadingData);
 
     return (
       <div className="text-center">
@@ -104,7 +104,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when empty', () => {
-    const state = useAsync(loadData);
+    const state = useQuery('data', loadData);
 
     return (
       <div className="text-center">
@@ -119,7 +119,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when empty with title', () => {
-    const state = useAsync(loadData);
+    const state = useQuery('data', loadData);
 
     return (
       <div className="text-center">
@@ -135,7 +135,7 @@ storiesOf('core/async/AsyncContent', module)
   })
 
   .add('when empty with custom empty', () => {
-    const state = useAsync(loadData);
+    const state = useQuery('data', loadData);
 
     return (
       <div className="text-center">

--- a/src/core/AsyncContent/AsyncContent.test.tsx
+++ b/src/core/AsyncContent/AsyncContent.test.tsx
@@ -7,9 +7,11 @@ import AsyncContent from './AsyncContent';
 type State = {
   isLoading: boolean;
   isFulfilled?: boolean;
+  isError?: boolean;
   data?: string;
   error?: string;
-  reload: () => void;
+  reload?: () => void;
+  refetch?: () => void;
 };
 
 describe('Component: AsyncContent', () => {
@@ -44,7 +46,7 @@ describe('Component: AsyncContent', () => {
   test('when loading', () => {
     const state = {
       isLoading: true,
-      reload: () => undefined
+      refetch: () => undefined
     };
 
     const { asyncContent } = setup({ state });
@@ -56,9 +58,9 @@ describe('Component: AsyncContent', () => {
     test('when not empty', () => {
       const state = {
         isLoading: false,
-        isFulfilled: true,
+        isError: false,
         data: 'importantos data',
-        reload: () => undefined
+        refetch: () => undefined
       };
 
       const { asyncContent } = setup({ state });
@@ -70,9 +72,9 @@ describe('Component: AsyncContent', () => {
     test('when empty', () => {
       const state = {
         isLoading: false,
-        isFulfilled: true,
+        isError: false,
         data: 'importantos data',
-        reload: () => undefined
+        refetch: () => undefined
       };
 
       const { asyncContent } = setup({ state, isEmpty: () => true });
@@ -84,9 +86,9 @@ describe('Component: AsyncContent', () => {
     test('when empty with custom empty ', () => {
       const state = {
         isLoading: false,
-        isFulfilled: true,
+        isError: false,
         data: 'importantos data',
-        reload: () => undefined
+        refetch: () => undefined
       };
 
       const { asyncContent } = setup({
@@ -107,14 +109,14 @@ describe('Component: AsyncContent', () => {
 
   describe('when rejected', () => {
     test('with retry button', () => {
-      const reloadSpy = jest.fn();
+      const refetchSpy = jest.fn();
 
       jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const state = {
         isLoading: false,
-        isFulfilled: false,
+        isError: true,
         error: 'something error',
-        reload: reloadSpy
+        refetch: refetchSpy
       };
 
       const { asyncContent } = setup({ state, showRetryButton: true });
@@ -125,16 +127,16 @@ describe('Component: AsyncContent', () => {
 
       asyncContent.find('Button').simulate('click');
 
-      expect(reloadSpy).toHaveBeenCalledTimes(1);
+      expect(refetchSpy).toHaveBeenCalledTimes(1);
     });
 
     test('without retry button', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const state = {
         isLoading: false,
-        isFulfilled: false,
+        isError: true,
         error: 'something error',
-        reload: () => undefined
+        refetch: () => undefined
       };
 
       const { asyncContent } = setup({ state, showRetryButton: false });
@@ -145,14 +147,14 @@ describe('Component: AsyncContent', () => {
     });
 
     test('should not render when showRetryButton is undefined', () => {
-      const reloadSpy = jest.fn();
+      const refetchSpy = jest.fn();
 
       jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const state = {
         isLoading: false,
-        isFulfilled: false,
+        isError: true,
         error: 'something error',
-        reload: reloadSpy
+        refetch: refetchSpy
       };
 
       const { asyncContent } = setup({ state });
@@ -160,6 +162,119 @@ describe('Component: AsyncContent', () => {
       expect(toJson(asyncContent)).toMatchSnapshot();
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(console.error).toHaveBeenCalledWith('something error');
+    });
+  });
+
+  describe('deprecated React Async', () => {
+    describe('when fulfilled', () => {
+      test('when not empty', () => {
+        const state = {
+          isLoading: false,
+          isFulfilled: true,
+          data: 'importantos data',
+          reload: () => undefined
+        };
+
+        const { asyncContent } = setup({ state });
+
+        expect(toJson(asyncContent)).toMatchSnapshot();
+        expect(console.error).toHaveBeenCalledTimes(0);
+      });
+
+      test('when empty', () => {
+        const state = {
+          isLoading: false,
+          isFulfilled: true,
+          data: 'importantos data',
+          reload: () => undefined
+        };
+
+        const { asyncContent } = setup({ state, isEmpty: () => true });
+
+        expect(toJson(asyncContent)).toMatchSnapshot();
+        expect(console.error).toHaveBeenCalledTimes(0);
+      });
+
+      test('when empty with custom empty ', () => {
+        const state = {
+          isLoading: false,
+          isFulfilled: true,
+          data: 'importantos data',
+          reload: () => undefined
+        };
+
+        const { asyncContent } = setup({
+          state,
+          isEmpty: () => true,
+          // eslint-disable-next-line react/display-name
+          emptyContent: (data) => {
+            expect(data).toBe('importantos data');
+
+            return <h1>Custom renderer</h1>;
+          }
+        });
+
+        expect(toJson(asyncContent)).toMatchSnapshot();
+        expect(console.error).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('when rejected', () => {
+      test('with retry button', () => {
+        const reloadSpy = jest.fn();
+
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const state = {
+          isLoading: false,
+          isFulfilled: false,
+          error: 'something error',
+          reload: reloadSpy
+        };
+
+        const { asyncContent } = setup({ state, showRetryButton: true });
+
+        expect(toJson(asyncContent)).toMatchSnapshot();
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('something error');
+
+        asyncContent.find('Button').simulate('click');
+
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+      });
+
+      test('without retry button', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const state = {
+          isLoading: false,
+          isFulfilled: false,
+          error: 'something error',
+          reload: () => undefined
+        };
+
+        const { asyncContent } = setup({ state, showRetryButton: false });
+
+        expect(toJson(asyncContent)).toMatchSnapshot();
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('something error');
+      });
+
+      test('should not render when showRetryButton is undefined', () => {
+        const reloadSpy = jest.fn();
+
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const state = {
+          isLoading: false,
+          isFulfilled: false,
+          error: 'something error',
+          reload: reloadSpy
+        };
+
+        const { asyncContent } = setup({ state });
+
+        expect(toJson(asyncContent)).toMatchSnapshot();
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('something error');
+      });
     });
   });
 });

--- a/src/core/AsyncContent/__snapshots__/AsyncContent.test.tsx.snap
+++ b/src/core/AsyncContent/__snapshots__/AsyncContent.test.tsx.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: AsyncContent deprecated React Async when fulfilled when empty 1`] = `
+<ContentState
+  mode="empty"
+  title="No results found"
+/>
+`;
+
+exports[`Component: AsyncContent deprecated React Async when fulfilled when empty with custom empty  1`] = `
+<Fragment>
+  <h1>
+    Custom renderer
+  </h1>
+</Fragment>
+`;
+
+exports[`Component: AsyncContent deprecated React Async when fulfilled when not empty 1`] = `
+<Fragment>
+  <h2>
+    importantos data
+  </h2>
+</Fragment>
+`;
+
+exports[`Component: AsyncContent deprecated React Async when rejected should not render when showRetryButton is undefined 1`] = `
+<ContentState
+  mode="error"
+  title="Oops something went wrong!"
+>
+  <Button
+    icon="refresh"
+    onClick={[Function]}
+  >
+    Retry
+  </Button>
+</ContentState>
+`;
+
+exports[`Component: AsyncContent deprecated React Async when rejected with retry button 1`] = `
+<ContentState
+  mode="error"
+  title="Oops something went wrong!"
+>
+  <Button
+    icon="refresh"
+    onClick={[Function]}
+  >
+    Retry
+  </Button>
+</ContentState>
+`;
+
+exports[`Component: AsyncContent deprecated React Async when rejected without retry button 1`] = `
+<ContentState
+  mode="error"
+  title="Oops something went wrong!"
+/>
+`;
+
 exports[`Component: AsyncContent when fulfilled when empty 1`] = `
 <ContentState
   mode="empty"

--- a/src/core/AsyncList/AsyncList.stories.tsx
+++ b/src/core/AsyncList/AsyncList.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { useAsync } from 'react-async';
+import { useQuery } from 'react-query';
 import { Button, Card, ListGroup, ListGroupItem } from 'reactstrap';
 
 import AsyncList from './AsyncList';
@@ -41,7 +41,7 @@ function loadingData(): Promise<User[]> {
 storiesOf('core/Async/AsyncList', module)
   .addParameters({ component: AsyncList })
   .add('when loaded', () => {
-    const state = useAsync(loadData);
+    const state = useQuery('data', loadData);
 
     return (
       <Card body>
@@ -59,7 +59,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when error', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <Card body>
@@ -77,7 +77,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when error with custom text', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <Card body>
@@ -98,7 +98,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when error with no retry button', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <Card body>
@@ -116,7 +116,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when loading', () => {
-    const state = useAsync(loadingData);
+    const state = useQuery('data', loadingData);
 
     return (
       <Card body>
@@ -134,7 +134,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when loading with custom title', () => {
-    const state = useAsync(loadingData);
+    const state = useQuery('data', loadingData);
 
     return (
       <Card body>
@@ -152,7 +152,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when empty', () => {
-    const state = useAsync(emptyData);
+    const state = useQuery('data', emptyData);
 
     return (
       <Card body>
@@ -170,7 +170,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when empty with custom title', () => {
-    const state = useAsync(emptyData);
+    const state = useQuery('data', emptyData);
 
     return (
       <Card body>
@@ -191,7 +191,7 @@ storiesOf('core/Async/AsyncList', module)
   })
 
   .add('when empty with custom empty', () => {
-    const state = useAsync(emptyData);
+    const state = useQuery('data', emptyData);
 
     return (
       <Card body>

--- a/src/core/AsyncList/AsyncList.test.tsx
+++ b/src/core/AsyncList/AsyncList.test.tsx
@@ -9,7 +9,7 @@ import { pageOfUsers } from '../../test/fixtures';
 
 type State = {
   isLoading: boolean;
-  isFulfilled: boolean;
+  isError: boolean;
   data: User[];
 };
 
@@ -38,7 +38,7 @@ describe('Component: Async|AsyncList', () => {
   test('ui', () => {
     const state = {
       isLoading: false,
-      isFulfilled: true,
+      isError: false,
       data: pageOfUsers().content
     };
 

--- a/src/core/AsyncList/AsyncList.tsx
+++ b/src/core/AsyncList/AsyncList.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import AsyncContent, {
-  Props as AsyncContentProps
+  Props as AsyncContentProps, ReactAsyncState, ReactQueryState
 } from '../AsyncContent/AsyncContent';
 
-type Props<T> = Omit<AsyncContentProps<T>, 'isEmpty'>;
+type Props<T> = Omit<AsyncContentProps<T>, 'isEmpty'> & (ReactAsyncState<T> | ReactQueryState<T>);
 
 export function isEmpty<T>(list: T[]): boolean {
   return list.length === 0;
@@ -12,8 +12,8 @@ export function isEmpty<T>(list: T[]): boolean {
 
 /**
  * The `AsyncList` is a variant of the `AsyncContent` which expects
- * the result of a call to `useAsync` from `react-async` to be an
- * array.
+ * the result of a call to `useQuery` from `react-query` or `useAsync`
+ * from `react-async` to be an array.
  *
  * It has all the behaviors of the `AsyncContent` but provides a
  * standard `isEmpty` function which checks if the array has the

--- a/src/core/AsyncList/__snapshots__/AsyncList.test.tsx.snap
+++ b/src/core/AsyncList/__snapshots__/AsyncList.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Component: Async|AsyncList ui 1`] = `
           ],
         },
       ],
-      "isFulfilled": true,
+      "isError": false,
       "isLoading": false,
     }
   }

--- a/src/core/AsyncPage/AsyncPage.stories.tsx
+++ b/src/core/AsyncPage/AsyncPage.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { useAsync } from 'react-async';
+import { useQuery } from 'react-query';
 import { Button, Card, ListGroup, ListGroupItem } from 'reactstrap';
 import { emptyPage, Page } from '@42.nl/spring-connect';
 
@@ -42,7 +42,7 @@ function loadingData(): Promise<Page<User>> {
 storiesOf('core/async/AsyncPage', module)
   .addParameters({ component: AsyncPage })
   .add('when loaded', () => {
-    const state = useAsync(loadData);
+    const state = useQuery('data', loadData);
 
     return (
       <Card body>
@@ -60,7 +60,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when error', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <Card body>
@@ -78,7 +78,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when error with custom text', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <Card body>
@@ -99,7 +99,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when error with no retry button', () => {
-    const state = useAsync(rejectData);
+    const state = useQuery('data', rejectData);
 
     return (
       <Card body>
@@ -117,7 +117,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when loading', () => {
-    const state = useAsync(loadingData);
+    const state = useQuery('data', loadingData);
 
     return (
       <Card body>
@@ -135,7 +135,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when loading with custom title', () => {
-    const state = useAsync(loadingData);
+    const state = useQuery('data', loadingData);
 
     return (
       <Card body>
@@ -153,7 +153,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when empty', () => {
-    const state = useAsync(emptyData);
+    const state = useQuery('data', emptyData);
 
     return (
       <Card body>
@@ -171,7 +171,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when empty with custom title', () => {
-    const state = useAsync(emptyData);
+    const state = useQuery('data', emptyData);
 
     return (
       <Card body>
@@ -192,7 +192,7 @@ storiesOf('core/async/AsyncPage', module)
   })
 
   .add('when empty with custom content', () => {
-    const state = useAsync(emptyData);
+    const state = useQuery('data', emptyData);
 
     return (
       <Card body>

--- a/src/core/AsyncPage/AsyncPage.test.tsx
+++ b/src/core/AsyncPage/AsyncPage.test.tsx
@@ -10,7 +10,7 @@ import { pageOfUsers } from '../../test/fixtures';
 
 type State = {
   isLoading: boolean;
-  isFulfilled: boolean;
+  isError: boolean;
   data: Page<User>;
 };
 
@@ -39,7 +39,7 @@ describe('Component: AsyncPage', () => {
   test('ui', () => {
     const state = {
       isLoading: false,
-      isFulfilled: true,
+      isError: false,
       data: pageOfUsers()
     };
 

--- a/src/core/AsyncPage/AsyncPage.tsx
+++ b/src/core/AsyncPage/AsyncPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import AsyncContent, {
-  Props as AsyncContentProps
+  Props as AsyncContentProps, ReactAsyncState, ReactQueryState
 } from '../AsyncContent/AsyncContent';
 import { Page } from '@42.nl/spring-connect';
 
-type Props<T> = Omit<AsyncContentProps<T>, 'isEmpty'>;
+type Props<T> = Omit<AsyncContentProps<T>, 'isEmpty'> & (ReactAsyncState<T> | ReactQueryState<T>);
 
 export function isEmpty<T>(page: Page<T>): boolean {
   return page.totalElements === 0;
@@ -13,8 +13,8 @@ export function isEmpty<T>(page: Page<T>): boolean {
 
 /**
  * The `AsyncPage` is a variant of `AsyncContent` which expects the
- * result of a call to `useAsync` from `react-async` to be a `Page`
- * from `@42.nl/spring-connect`.
+ * result of a call to `useQuery` from `react-query` or `useAsync`
+ * from `react-async` to be a `Page` from `@42.nl/spring-connect`.
  *
  * It has all the behaviors of the `AsyncContent` but provides a
  * standard `isEmpty` function which checks if the `totalElements`

--- a/src/core/AsyncPage/__snapshots__/AsyncPage.test.tsx.snap
+++ b/src/core/AsyncPage/__snapshots__/AsyncPage.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Component: AsyncPage ui 1`] = `
         "totalElements": 9,
         "totalPages": 3,
       },
-      "isFulfilled": true,
+      "isError": false,
       "isLoading": false,
     }
   }


### PR DESCRIPTION
There is a dependency to React Async, which is used in the AsyncContent,
AsyncList and AsyncPage components. That library has not been touched in
a year and is prone to security issues. There are a few other libraries
like React Query or SWR which provide the same functionality and more.

Added support for React Query in Async components.

Closes #601