### PR TITLE
feature: error boundary in card

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -198,6 +198,11 @@ Here is a JSON notation containing all keys and default translations:
   },
   "TypeaheadMultiple": {
     "PAGINATION_TEXT": "Display additional results..."
+  },
+  "ErrorBoundary": {
+    "ERROR": {
+      "TITLE": "Oops something went wrong!"
+    }
   }
 }
 ```

--- a/src/core/Card/Card.tsx
+++ b/src/core/Card/Card.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import { Card as ReactstrapCard, CardBody, CardFooter, CardHeader } from 'reactstrap';
 import Loading from '../Loading/Loading';
+import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 
 export type Props = {
   /**
@@ -99,7 +100,11 @@ export function Card({
         </CardHeader>
       ) : null}
       <CardBody className={cardBodyClassName ? cardBodyClassName : modalBodyClassName}>
-        <Suspense fallback={<Loading />}>{children}</Suspense>
+        <Suspense fallback={<Loading />}>
+          <ErrorBoundary>
+            {children}
+          </ErrorBoundary>
+        </Suspense>
       </CardBody>
       {footer ? (
         <CardFooter className={cardFooterClassName ? cardFooterClassName : modalFooterClassName}>

--- a/src/core/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/core/Card/__snapshots__/Card.test.tsx.snap
@@ -11,7 +11,9 @@ exports[`Component: Card deprecated: modalBodyClassName: Component: Card => depr
     <Suspense
       fallback={<Loading />}
     >
-      This is the content
+      <ErrorBoundary>
+        This is the content
+      </ErrorBoundary>
     </Suspense>
   </CardBody>
 </Card>
@@ -27,7 +29,9 @@ exports[`Component: Card deprecated: modalFooterClassName: Component: Card => de
     <Suspense
       fallback={<Loading />}
     >
-      This is the content
+      <ErrorBoundary>
+        This is the content
+      </ErrorBoundary>
     </Suspense>
   </CardBody>
   <CardFooter
@@ -63,7 +67,9 @@ exports[`Component: Card deprecated: modalHeaderClassName: Component: Card => de
     <Suspense
       fallback={<Loading />}
     >
-      This is the content
+      <ErrorBoundary>
+        This is the content
+      </ErrorBoundary>
     </Suspense>
   </CardBody>
 </Card>
@@ -90,19 +96,21 @@ exports[`Component: Card ui basic: Component: Card => ui => basic 1`] = `
     <Suspense
       fallback={<Loading />}
     >
-      <RadioGroup
-        labelForOption={[Function]}
-        onChange={[MockFunction]}
-        options={
-          Array [
-            "local",
-            "development",
-            "test",
-            "acceptation",
-            "production",
-          ]
-        }
-      />
+      <ErrorBoundary>
+        <RadioGroup
+          labelForOption={[Function]}
+          onChange={[MockFunction]}
+          options={
+            Array [
+              "local",
+              "development",
+              "test",
+              "acceptation",
+              "production",
+            ]
+          }
+        />
+      </ErrorBoundary>
     </Suspense>
   </CardBody>
   <CardFooter
@@ -139,19 +147,21 @@ exports[`Component: Card ui without footer: Component: Card => ui => without foo
     <Suspense
       fallback={<Loading />}
     >
-      <RadioGroup
-        labelForOption={[Function]}
-        onChange={[MockFunction]}
-        options={
-          Array [
-            "local",
-            "development",
-            "test",
-            "acceptation",
-            "production",
-          ]
-        }
-      />
+      <ErrorBoundary>
+        <RadioGroup
+          labelForOption={[Function]}
+          onChange={[MockFunction]}
+          options={
+            Array [
+              "local",
+              "development",
+              "test",
+              "acceptation",
+              "production",
+            ]
+          }
+        />
+      </ErrorBoundary>
     </Suspense>
   </CardBody>
 </Card>
@@ -168,19 +178,21 @@ exports[`Component: Card ui without header: Component: Card => ui => without hea
     <Suspense
       fallback={<Loading />}
     >
-      <RadioGroup
-        labelForOption={[Function]}
-        onChange={[MockFunction]}
-        options={
-          Array [
-            "local",
-            "development",
-            "test",
-            "acceptation",
-            "production",
-          ]
-        }
-      />
+      <ErrorBoundary>
+        <RadioGroup
+          labelForOption={[Function]}
+          onChange={[MockFunction]}
+          options={
+            Array [
+              "local",
+              "development",
+              "test",
+              "acceptation",
+              "production",
+            ]
+          }
+        />
+      </ErrorBoundary>
     </Suspense>
   </CardBody>
   <CardFooter

--- a/src/core/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/core/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { ErrorBoundary } from './ErrorBoundary';
+import RadioGroup from '../../form/RadioGroup/RadioGroup';
+
+describe('Component: ErrorBoundary', () => {
+  function setup({ text }: { text?: { error: string } }) {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {
+      // Do nothing, we only want to make sure the error is logged
+    });
+
+    const errorBoundary = shallow(
+      <ErrorBoundary text={text}>
+        <RadioGroup<string>
+          onChange={jest.fn().mockImplementation(() => {
+            throw new Error('test');
+          })}
+          options={[ 'local', 'development', 'test', 'acceptation', 'production' ]}
+          labelForOption={(v) => v}
+        />
+      </ErrorBoundary>
+    );
+
+    return { errorBoundary, consoleErrorSpy };
+  }
+
+  describe('ui', () => {
+    test('without error', () => {
+      const { errorBoundary, consoleErrorSpy } = setup({});
+
+      expect(toJson(errorBoundary)).toMatchSnapshot(
+        'Component: ErrorBoundary => ui => without error'
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test('with error', () => {
+      const { errorBoundary, consoleErrorSpy } = setup({});
+      const error = new Error('test');
+
+      errorBoundary.find('RadioGroup').simulateError(error);
+
+      expect(toJson(errorBoundary)).toMatchSnapshot(
+        'Component: ErrorBoundary => ui => with error'
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error, `
+    in RadioGroup (created by ErrorBoundary)
+    in ErrorBoundary (created by WrapperComponent)
+    in WrapperComponent`);
+    });
+
+    test('with custom text', () => {
+      const { errorBoundary } = setup({ text: { error: 'Failure!' } });
+      const error = new Error('test');
+
+      errorBoundary.find('RadioGroup').simulateError(error);
+
+      expect(toJson(errorBoundary)).toMatchSnapshot(
+        'Component: ErrorBoundary => ui => with custom text'
+      );
+    });
+  });
+});

--- a/src/core/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/core/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import ContentState from '../ContentState/ContentState';
+import { t } from '../../utilities/translation/translation';
+
+type ErrorState = {
+  hasError: boolean;
+};
+
+type Props = {
+  text?: {
+    error: string;
+  }
+}
+
+export class ErrorBoundary extends React.Component<Props, ErrorState> {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error(error, errorInfo.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ContentState
+          mode="error"
+          title={t({
+            key: 'ErrorBoundary.ERROR.TITLE',
+            fallback: 'Oops something went wrong!',
+            overrideText: this.props.text?.error
+          })}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/core/ErrorBoundary/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/src/core/ErrorBoundary/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: ErrorBoundary ui with custom text: Component: ErrorBoundary => ui => with custom text 1`] = `
+<ContentState
+  mode="error"
+  title="Failure!"
+/>
+`;
+
+exports[`Component: ErrorBoundary ui with error: Component: ErrorBoundary => ui => with error 1`] = `
+<ContentState
+  mode="error"
+  title="Oops something went wrong!"
+/>
+`;
+
+exports[`Component: ErrorBoundary ui without error: Component: ErrorBoundary => ui => without error 1`] = `
+<RadioGroup
+  labelForOption={[Function]}
+  onChange={[MockFunction]}
+  options={
+    Array [
+      "local",
+      "development",
+      "test",
+      "acceptation",
+      "production",
+    ]
+  }
+/>
+`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -44,6 +44,7 @@ describe('index', () => {
         "EpicSelection": [Function],
         "EpicSort": [Function],
         "EpicTable": [Function],
+        "ErrorBoundary": [Function],
         "FavoriteIcon": [Function],
         "FileInput": [Function],
         "FlashMessage": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { Tabs } from './core/Tabs/Tabs';
 export { Tab } from './core/Tabs/Tab/Tab';
 export { AsyncActionButton } from './core/AsyncActionButton/AsyncActionButton';
 export { Debug } from './core/Debug/Debug';
+export { ErrorBoundary } from './core/ErrorBoundary/ErrorBoundary';
 
 // Form
 export { AutoSave } from './form/AutoSave/AutoSave';


### PR DESCRIPTION
It would be nice if the card has an error boundary to allow rendering of
other parts of the application when an error occurs within the card.

Added ErrorBoundary component to allow developers to catch and display
errors without breaking the entire application.
Added ErrorBoundary to Card body to automatically catch and display
errors in cards.

Closes #596