### PR TITLE
feature: EpicTable resize trigger

### DIFF
--- a/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
+++ b/src/table/EpicTable/helpers/GooeyCenter/GooeyCenter.tsx
@@ -98,12 +98,14 @@ export function GooeyCenter({
       }, 200);
 
       window.addEventListener('resize', calculateCenterWidth);
+      window.addEventListener('resizeEpicTables', calculateCenterWidth);
 
       // Calculate at least once on startup
       calculateCenterWidth();
 
       return () => {
         window.removeEventListener('resize', calculateCenterWidth);
+        window.removeEventListener('resizeEpicTables', calculateCenterWidth);
       };
     },
     [setCenterWidth, onCenterWidthChanged, left, center, right]


### PR DESCRIPTION
We have a case where the space the table has is not enough to fit all
columns, but when the sidebar is minified, there is enough space to fit
all columns. When the sidebar is opened again, the table is not resized
until the user moves the mouse over the EpicTable. We would like to have
a custom trigger we can call to force the table to resize.

Added event listener to listen to custom resizeEpicTables event as well
as window resize.

Closes #608