### PR TITLE
improvement: Pagination static number of items

### DIFF
--- a/src/core/Pagination/Pagination.scss
+++ b/src/core/Pagination/Pagination.scss
@@ -2,6 +2,11 @@
   margin-bottom: 0;
 
   .page-item {
+    .page-link {
+      min-width: 38px;
+      padding: 0.5rem 0.5rem;
+    }
+
     button.disabled.page-link {
       border-radius: 0;
       background-color: $white;

--- a/src/core/Pagination/Pagination.test.tsx
+++ b/src/core/Pagination/Pagination.test.tsx
@@ -170,32 +170,37 @@ describe('pages', () => {
   });
 
   test('almost middle', () => {
-    expect(pagesFor(4, 10)).toEqual([1, '...', 3, 4, 5, '...', 10]);
+    expect(pagesFor(5, 10)).toEqual([1, '...', 4, 5, 6, '...', 10]);
     expect(pagesFor(6, 10)).toEqual([1, '...', 5, 6, 7, '...', 10]);
   });
 
   test('absolute left', () => {
-    expect(pagesFor(1, 10)).toEqual([1, 2, '...', 10]);
+    expect(pagesFor(1, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
   });
 
   test('almost left', () => {
-    expect(pagesFor(2, 10)).toEqual([1, 2, 3, '...', 10]);
-    expect(pagesFor(3, 10)).toEqual([1, 2, 3, 4, '...', 10]);
-    expect(pagesFor(4, 10)).toEqual([1, '...', 3, 4, 5, '...', 10]);
+    expect(pagesFor(2, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
+    expect(pagesFor(3, 10)).toEqual([1, 2, 3, 4, '...', 9, 10]);
+    expect(pagesFor(4, 10)).toEqual([1, 2, 3, 4, 5, '...', 10]);
   });
 
   test('almost right', () => {
-    expect(pagesFor(7, 10)).toEqual([1, '...', 6, 7, 8, '...', 10]);
-    expect(pagesFor(8, 10)).toEqual([1, '...', 7, 8, 9, 10]);
-    expect(pagesFor(9, 10)).toEqual([1, '...', 8, 9, 10]);
+    expect(pagesFor(7, 10)).toEqual([1, '...', 6, 7, 8, 9, 10]);
+    expect(pagesFor(8, 10)).toEqual([1, 2, '...', 7, 8, 9, 10]);
+    expect(pagesFor(9, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
   });
 
   test('absolute right', () => {
-    expect(pagesFor(10, 10)).toEqual([1, '...', 9, 10]);
+    expect(pagesFor(10, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
   });
 
   test('shortage', () => {
     expect(pagesFor(1, 3)).toEqual([1, 2, 3]);
     expect(pagesFor(3, 3)).toEqual([1, 2, 3]);
+    expect(pagesFor(1, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pagesFor(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pagesFor(7, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pagesFor(1, 8)).toEqual([1, 2, 3, '...', 6, 7, 8]);
+    expect(pagesFor(8, 8)).toEqual([1, 2, 3, '...', 6, 7, 8]);
   });
 });

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -8,6 +8,7 @@ import {
 } from 'reactstrap';
 
 import { Icon } from '../Icon';
+import { range } from 'lodash';
 
 type Props<T> = {
   /**
@@ -92,46 +93,40 @@ export default function Pagination<T>({
   );
 }
 
-type Dots = '...';
+type Ellipsis = '...';
 
 // Calculates which pages surround the current page.
 export function pagesFor(
   currentPage: number,
   totalPages: number
-): (number | Dots)[] {
-  const content: (number | Dots)[] = [];
+): (number | Ellipsis)[] {
+  const ellipsis: Ellipsis = '...';
 
-  if (currentPage > 1) {
-    content.push(1);
+  if (totalPages < 8) {
+    return range(1, totalPages + 1);
   }
 
-  const prev = currentPage - 1;
-  if (prev > 1) {
-    content.push(prev);
+  if (currentPage < 5) {
+    // {1} 2 3 ... 29 30 31
+    // till
+    // 1 2 3 {4} 5 ... 31
+
+    const tillEllipsis = range(1, Math.max(4, currentPage + 2));
+    const fromEllipsis = range(totalPages - (5 - tillEllipsis.length), totalPages + 1)
+
+    return [ ...tillEllipsis, ellipsis, ...fromEllipsis ];
   }
 
-  content.push(currentPage);
+  if (currentPage > totalPages - 4) {
+    // 1 ... 27 {28} 29 30 31
+    // till
+    // 1 2 3 ... 29 30 {31}
 
-  const next = currentPage + 1;
-  if (next <= totalPages) {
-    content.push(next);
+    const fromEllipsis = range(Math.min(totalPages - 2, currentPage - 1), totalPages + 1);
+    const tillEllipsis = range(1, 7 - fromEllipsis.length);
+
+    return [ ...tillEllipsis, ellipsis, ...fromEllipsis ];
   }
 
-  if (next + 1 <= totalPages) {
-    content.push(totalPages);
-  }
-
-  if (content[0] === 1 && content[1] !== 2) {
-    content.splice(1, 0, '...');
-  }
-
-  const lastIndex = content.length - 1;
-  if (
-    content[lastIndex] === totalPages &&
-    content[lastIndex - 1] !== totalPages - 1
-  ) {
-    content.splice(lastIndex, 0, '...');
-  }
-
-  return content;
+  return [1, ellipsis, ...range(currentPage - 1, currentPage + 2), ellipsis, totalPages];
 }

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -119,11 +119,10 @@ exports[`Component: Pagination ui no next: Component: Pagination => ui => no nex
     tag="li"
   >
     <PaginationLink
-      className="disabled"
-      disabled={true}
+      onClick={[Function]}
       tag="a"
     >
-      ...
+      2
     </PaginationLink>
   </PaginationItem>
   <PaginationItem
@@ -135,12 +134,49 @@ exports[`Component: Pagination ui no next: Component: Pagination => ui => no nex
       onClick={[Function]}
       tag="a"
     >
+      3
+    </PaginationLink>
+  </PaginationItem>
+  <PaginationItem
+    active={false}
+    key="3"
+    tag="li"
+  >
+    <PaginationLink
+      className="disabled"
+      disabled={true}
+      tag="a"
+    >
+      ...
+    </PaginationLink>
+  </PaginationItem>
+  <PaginationItem
+    active={false}
+    key="4"
+    tag="li"
+  >
+    <PaginationLink
+      onClick={[Function]}
+      tag="a"
+    >
+      8
+    </PaginationLink>
+  </PaginationItem>
+  <PaginationItem
+    active={false}
+    key="5"
+    tag="li"
+  >
+    <PaginationLink
+      onClick={[Function]}
+      tag="a"
+    >
       9
     </PaginationLink>
   </PaginationItem>
   <PaginationItem
     active={true}
-    key="3"
+    key="6"
     tag="li"
   >
     <PaginationLink
@@ -189,6 +225,18 @@ exports[`Component: Pagination ui no previous: Component: Pagination => ui => no
     tag="li"
   >
     <PaginationLink
+      onClick={[Function]}
+      tag="a"
+    >
+      3
+    </PaginationLink>
+  </PaginationItem>
+  <PaginationItem
+    active={false}
+    key="3"
+    tag="li"
+  >
+    <PaginationLink
       className="disabled"
       disabled={true}
       tag="a"
@@ -198,7 +246,31 @@ exports[`Component: Pagination ui no previous: Component: Pagination => ui => no
   </PaginationItem>
   <PaginationItem
     active={false}
-    key="3"
+    key="4"
+    tag="li"
+  >
+    <PaginationLink
+      onClick={[Function]}
+      tag="a"
+    >
+      8
+    </PaginationLink>
+  </PaginationItem>
+  <PaginationItem
+    active={false}
+    key="5"
+    tag="li"
+  >
+    <PaginationLink
+      onClick={[Function]}
+      tag="a"
+    >
+      9
+    </PaginationLink>
+  </PaginationItem>
+  <PaginationItem
+    active={false}
+    key="6"
     tag="li"
   >
     <PaginationLink


### PR DESCRIPTION
Currently, the pagination component could change position when it is
centered on a page depending on what page you are on. This should be
changed to always display a static amount of buttons, so the position of
the pagination component does not change when navigating between pages.

Changed pagination to always display the same amount of buttons.

Closes #604