### PR TITLE
feature: CrudTable

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,6 +26,8 @@ describe('index', () => {
         "ConfirmButton": [Function],
         "ConfirmModal": [Function],
         "ContentState": [Function],
+        "CrudHeader": [Function],
+        "CrudTable": [Function],
         "DateTimeInput": [Function],
         "Debug": [Function],
         "EpicCell": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,9 @@ export { EpicSort } from './table/EpicTable/widgets/EpicSort/EpicSort';
 
 export { EpicTableSortDirection } from './table/EpicTable/types';
 
+export { CrudTable } from './table/CrudTable/CrudTable';
+export { CrudHeader } from './table/CrudTable/components/CrudHeader/CrudHeader';
+
 // Utilities
 export { t } from './utilities/translation/translation';
 export {

--- a/src/table/CrudTable/CrudTable.stories.tsx
+++ b/src/table/CrudTable/CrudTable.stories.tsx
@@ -1,0 +1,780 @@
+import React, { useEffect, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Card } from 'reactstrap';
+import { capitalize, every, lowerCase, startsWith } from 'lodash';
+import { Field, Form } from 'react-final-form';
+import moment from 'moment';
+import Button from '../../core/Button/Button';
+import Tag from '../../core/Tag/Tag';
+import Select from '../../form/Select/Select';
+import Input from '../../form/Input/Input';
+import ContentState from '../../core/ContentState/ContentState';
+import ConfirmButton from '../../core/ConfirmButton/ConfirmButton';
+import { pageOf } from '../../utilities/page/page';
+import DateTimeInput from '../../form/DateTimeInput/DateTimeInput';
+import { EpicRow } from '../EpicTable/rows/EpicRow/EpicRow';
+import { EpicHeader } from '../EpicTable/cells/EpicHeader/EpicHeader';
+import { EpicCell } from '../EpicTable/cells/EpicCell/EpicCell';
+import { EpicCellLayout } from '../EpicTable/cells/EpicCellLayout/EpicCellLayout';
+import { EpicSelection } from '../EpicTable/widgets/EpicSelection/EpicSelection';
+import { EpicSort } from '../EpicTable/widgets/EpicSort/EpicSort';
+
+import { EpicTableSortDirection } from '../EpicTable/types';
+import { CrudTable } from './CrudTable';
+import { CrudHeader } from './components/CrudHeader/CrudHeader';
+import { EpicDetailRow } from '../EpicTable/rows/EpicDetailRow/EpicDetailRow';
+import { EpicDetail } from '../EpicTable/widgets/EpicDetail/EpicDetail';
+import { AttributeList } from '../../core/lists/AttributeList/AttributeList';
+import { AttributeView } from '../../core/lists/AttributeView/AttributeView';
+
+type Person = {
+  id: number;
+  firstName: string;
+  lastName: string;
+  age: number;
+  eyeColor: string;
+  height: number;
+  weight: number;
+  jobTitle: string;
+  favoriteMovie: string;
+  favoriteFood: string;
+  sex: string;
+  dateOfBirth: string;
+};
+
+const persons: Person[] = [
+  {
+    id: Math.random(),
+    firstName: 'Fitzpatrick',
+    lastName: 'Lyons',
+    age: 20,
+    eyeColor: 'brown',
+    height: 10,
+    weight: 3,
+    jobTitle: 'Senior CodeMonkey',
+    favoriteMovie: 'The Matrix',
+    favoriteFood: 'Hamburgers',
+    sex: 'male',
+    dateOfBirth: '2014-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Berry',
+    lastName: 'McNab',
+    age: 41,
+    eyeColor: 'blue',
+    height: 13,
+    weight: 55,
+    jobTitle: 'Business Manager',
+    favoriteMovie: 'Fear and loathing in Las Vegas',
+    favoriteFood: 'Spaghetti',
+    sex: 'female',
+    dateOfBirth: '2000-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Neville',
+    lastName: 'Brooks',
+    age: 25,
+    eyeColor: 'green',
+    height: 12,
+    weight: 32,
+    jobTitle: 'Senior CodeMonkey',
+    favoriteMovie: 'Lord of the Rings',
+    favoriteFood: 'French Fries',
+    sex: 'male',
+    dateOfBirth: '2014-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Leonard',
+    lastName: 'Nemoy',
+    age: 50,
+    eyeColor: 'brown',
+    height: 10,
+    weight: 3,
+    jobTitle: 'Thespian',
+    favoriteMovie: 'Star Trek',
+    favoriteFood: 'Kosher',
+    sex: 'male',
+    dateOfBirth: '1900-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Levi',
+    lastName: 'Smith',
+    age: 30,
+    eyeColor: 'brown',
+    height: 10,
+    weight: 3,
+    jobTitle: 'Taxi driver',
+    favoriteMovie: 'Taxi',
+    favoriteFood:
+      'Lorem ipsum dolor sit amet consectetur adipisicing elit. Corporis, at nam alias ad culpa quae deleniti. Autem eveniet mollitia veritatis reprehenderit ea, tempora vero voluptatem. Dolore repudiandae voluptate quam quidem.,',
+    sex: 'male',
+    dateOfBirth: '2014-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Celine',
+    lastName: 'Ferdinand',
+    age: 80,
+    eyeColor: 'green',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Retired',
+    favoriteMovie: 'Driving miss Daisy',
+    favoriteFood: 'Prunes',
+    sex: 'female',
+    dateOfBirth: '1940-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Bonald',
+    lastName: 'Ferdinand',
+    age: 82,
+    eyeColor: 'blue',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Retired',
+    favoriteMovie: 'Driving miss Daisy',
+    favoriteFood: 'Prunes',
+    sex: 'male',
+    dateOfBirth: '1938-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Zechs',
+    lastName: 'Merquise',
+    age: 42,
+    eyeColor: 'blue',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Ace pilot',
+    favoriteMovie: 'Gundam wing',
+    favoriteFood: 'Apple pie',
+    sex: 'male',
+    dateOfBirth: '2010-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'David',
+    lastName: 'Hayter',
+    age: 55,
+    eyeColor: 'blue',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Voice actor',
+    favoriteMovie: 'Guyver',
+    favoriteFood: 'Snakes',
+    sex: 'male',
+    dateOfBirth: '1960-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'James',
+    lastName: 'Kirk',
+    age: 50,
+    eyeColor: 'brown',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Captain',
+    favoriteMovie: 'Star Trek',
+    favoriteFood: 'Replicated',
+    sex: 'male',
+    dateOfBirth: '2100-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Bert',
+    lastName: 'Kelly',
+    age: 30,
+    eyeColor: 'blue',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Blacksmith',
+    favoriteMovie: 'Not without my daughter',
+    favoriteFood: 'Pears',
+    sex: 'male',
+    dateOfBirth: '1989-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'John',
+    lastName: 'Goodall',
+    age: 68,
+    eyeColor: 'green',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Gardner',
+    favoriteMovie: 'The Gardner',
+    favoriteFood: 'Cauliflower',
+    sex: 'male',
+    dateOfBirth: '2019-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Rick',
+    lastName: 'Xander',
+    age: 14,
+    eyeColor: 'brown',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Baker',
+    favoriteMovie: 'Halloween',
+    favoriteFood: 'Cake',
+    sex: 'male',
+    dateOfBirth: '1980-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Jessica',
+    lastName: 'Bernard',
+    age: 36,
+    eyeColor: 'green',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Student',
+    favoriteMovie: 'Highlander',
+    favoriteFood: 'Ice cream',
+    sex: 'female',
+    dateOfBirth: '1980-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Benjamin',
+    lastName: 'Sisko',
+    age: 55,
+    eyeColor: 'brown',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Commander',
+    favoriteMovie: 'Search for Spock',
+    favoriteFood: 'Jamba',
+    sex: 'male',
+    dateOfBirth: '2200-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Kathyrn',
+    lastName: 'Janeway',
+    age: 55,
+    eyeColor: 'brown',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Captain',
+    favoriteMovie: 'Wrath of Khan',
+    favoriteFood: 'Coffee',
+    sex: 'female',
+    dateOfBirth: '2240-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Jean-Luc',
+    lastName: 'Picard',
+    age: 66,
+    eyeColor: 'blue',
+    height: 3,
+    weight: 5,
+    jobTitle: 'Captain',
+    favoriteMovie: 'Next generation',
+    favoriteFood: 'Tea Earl Grey Hot',
+    sex: 'male',
+    dateOfBirth: '2200-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Peter',
+    lastName: 'Parker',
+    age: 30,
+    eyeColor: 'blue',
+    height: 55,
+    weight: 14,
+    jobTitle: 'Spider-man',
+    favoriteMovie: 'Spider-man',
+    favoriteFood: 'Webs',
+    sex: 'male',
+    dateOfBirth: '1990-09-24'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Clark',
+    lastName: 'Kent',
+    age: 40,
+    eyeColor: 'blue',
+    height: 80,
+    weight: 33,
+    jobTitle: 'Journalist',
+    favoriteMovie: 'Superman returns',
+    favoriteFood: 'Kryptonite',
+    sex: 'male',
+    dateOfBirth: '1960-01-01'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Bruce',
+    lastName: 'Wayne',
+    age: 55,
+    eyeColor: 'blue',
+    height: 70,
+    weight: 33,
+    jobTitle: 'CEO',
+    favoriteMovie: 'Batman begins',
+    favoriteFood: 'Bats',
+    sex: 'male',
+    dateOfBirth: '1955-01-01'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Diana',
+    lastName: 'Prince',
+    age: 28,
+    eyeColor: 'green',
+    height: 90,
+    weight: 19,
+    jobTitle: 'Curator',
+    favoriteMovie: 'Wonderwoman',
+    favoriteFood: 'Greek',
+    sex: 'female',
+    dateOfBirth: '1990-01-01'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Tony',
+    lastName: 'Stark',
+    age: 40,
+    eyeColor: 'brown',
+    height: 70,
+    weight: 33,
+    jobTitle: 'CEO',
+    favoriteMovie: 'Ironman',
+    favoriteFood: 'Shoarma',
+    sex: 'male',
+    dateOfBirth: '1980-01-01'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Steve',
+    lastName: 'Rogers',
+    age: 100,
+    eyeColor: 'blue',
+    height: 44,
+    weight: 55,
+    jobTitle: 'Captain',
+    favoriteMovie: 'Winter soldier',
+    favoriteFood: 'Apple pie',
+    sex: 'male',
+    dateOfBirth: '1920-01-01'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Natasha',
+    lastName: 'Romanov',
+    age: 30,
+    eyeColor: 'green',
+    height: 77,
+    weight: 66,
+    jobTitle: 'Black widow',
+    favoriteMovie: 'Avengers',
+    favoriteFood: 'Stroganov',
+    sex: 'female',
+    dateOfBirth: '1995-01-01'
+  },
+  {
+    id: Math.random(),
+    firstName: 'Bruce',
+    lastName: 'Banner',
+    age: 42,
+    eyeColor: 'brown',
+    height: 89,
+    weight: 99,
+    jobTitle: 'Smasher',
+    favoriteMovie: 'The Incredible Hulk',
+    favoriteFood: 'Gammarays',
+    sex: 'male',
+    dateOfBirth: '1975-01-01'
+  }
+];
+
+storiesOf('table/CrudTable', module)
+  .addParameters({ component: CrudTable })
+  .add('simple example', () => {
+    const columns = {
+      firstName: 300,
+      lastName: 200,
+      age: 200
+    };
+
+    const [ page, setPage ] = useState(1);
+
+    const pageOfPersons = pageOf(persons, page, 20);
+
+    const [ detail, setDetail ] = useState(-1);
+
+    const [ loading, setLoading ] = useState(false);
+
+    useEffect(() => {
+      setLoading(true);
+
+      setTimeout(() => {
+        setLoading(false);
+      }, 1000);
+    }, []);
+
+    return (
+      <Card body>
+        <CrudTable
+          page={pageOfPersons}
+          pageChanged={setPage}
+        >
+          <EpicRow header>
+            <CrudHeader width={columns.firstName}>
+              First name
+            </CrudHeader>
+            <CrudHeader width={columns.firstName}>
+              Last name
+            </CrudHeader>
+            <CrudHeader width={columns.firstName}>
+              Age
+            </CrudHeader>
+          </EpicRow>
+
+          {loading ? (
+            <ContentState mode="loading" title="Loading..." />
+          ) : pageOfPersons.content.map((person) => (
+            <EpicRow key={person.id} onClick={() => setDetail(person.id)}>
+              <EpicCell width={columns.firstName}>
+                <span
+                  className="text-primary clickable w-100"
+                  onClick={() => setDetail(person.id)}
+                >
+                  {person.firstName}
+                </span>
+              </EpicCell>
+              <EpicCell width={columns.lastName}>
+                {person.lastName}
+              </EpicCell>
+              <EpicCell width={columns.age}>
+                {person.age}
+              </EpicCell>
+            </EpicRow>
+          ))}
+          <EpicDetailRow left={columns.firstName} active={detail > 0}>
+            {() => {
+              const person = pageOfPersons.content.find(p => p.id === detail);
+
+              if (!person) {
+                return <EpicDetail onClose={() => setDetail(-1)}>Person not found</EpicDetail>;
+              }
+
+              return (
+                <EpicDetail onClose={() => setDetail(-1)}>
+                  <AttributeList>
+                  {Object.keys(person).map((column) => (
+                    <AttributeView key={column} label={capitalize(column.replace(/([A-Z])/, ' $1'))}>
+                      {person[column]}
+                    </AttributeView>
+                    ))}
+                  </AttributeList>
+                </EpicDetail>
+              );
+            }}
+          </EpicDetailRow>
+        </CrudTable>
+      </Card>
+    );
+  })
+  .add('full example', () => {
+    const [ columns, setColumns ] = useState(() => ({
+      firstName: 300,
+      lastName: 200,
+      age: 200,
+      eyeColor: 200,
+      height: 150,
+      weight: 150,
+      jobTitle: 200,
+      favoriteMovie: 300,
+      favoriteFood: 200,
+      sex: 200,
+      dateOfBirth: 200
+    }));
+
+    function changeSize(name: keyof Person, width: number) {
+      setColumns((widths) => ({ ...widths, [name]: width }));
+    }
+
+    const [ filters, setFilters ] = useState(() => ({
+      firstName: '',
+      lastName: '',
+      age: '',
+      eyeColor: '',
+      height: '',
+      weight: '',
+      jobTitle: '',
+      favoriteMovie: '',
+      favoriteFood: '',
+      sex: '',
+      dateOfBirth: ''
+    }));
+
+    function filterChanged(name: keyof Person, value: string) {
+      setPage(1);
+      setFilters({ ...filters, [name]: value });
+    }
+
+    const filteredPersons = persons.filter((person) => {
+      return every(filters, (value, key) => {
+        const text = person[key];
+
+        if (!value || value === 'all') {
+          return true;
+        }
+
+        return startsWith(lowerCase(text), lowerCase(value));
+      });
+    });
+
+    const [ sort, setSort ] = useState<{
+      direction: EpicTableSortDirection;
+      column: string;
+    }>({ direction: 'NONE', column: 'firstName' });
+
+    function changeSort(
+      column: keyof Person,
+      direction: EpicTableSortDirection
+    ) {
+      setPage(1);
+      setSort({ direction, column });
+    }
+
+    const sortFn =
+      sort.direction === 'ASC'
+        ? (a, b) => `${a[sort.column]}`.localeCompare(`${b[sort.column]}`)
+        : (a, b) => `${b[sort.column]}`.localeCompare(`${a[sort.column]}`);
+
+    const sortedPersons = filteredPersons.sort(sortFn);
+
+    const [ page, setPage ] = useState(1);
+
+    const pageOfPersons = pageOf(sortedPersons, page, 20);
+
+    const [ selected, setSelected ] = useState<Person[]>([]);
+
+    function onSelect(person: Person, checked: boolean) {
+      if (checked) {
+        selected.push(person);
+        setSelected([ ...selected ]);
+      } else {
+        const nextSelected = selected.filter((p) => p.id !== person.id);
+
+        setSelected(nextSelected);
+      }
+    }
+
+    const [ detail, setDetail ] = useState(-1);
+
+    const [ editing, setEditing ] = useState(-1);
+
+    const [ creating, setCreating ] = useState(false);
+
+    const [ loading, setLoading ] = useState(false);
+
+    useEffect(() => {
+      setLoading(true);
+
+      setTimeout(() => {
+        setLoading(false);
+      }, 1000);
+    }, []);
+
+    return (
+      <Card body>
+        <CrudTable
+          buttons={() => (
+            <Button icon="add" onClick={() => setCreating(true)}>
+              Add person
+            </Button>
+          )}
+          renderSelection={selected.length > 0 ? () => (
+            <>
+              <h2>Selected</h2>
+              <div className="mb-3">
+                {selected.map((person) => (
+                  <Tag
+                    key={person.id}
+                    text={`${person.firstName} ${person.lastName}`}
+                    onRemove={() => onSelect(person, false)}
+                  />
+                ))}
+              </div>
+            </>
+          ) : undefined}
+          page={pageOfPersons}
+          pageChanged={setPage}
+        >
+          <EpicRow header>
+            {Object.keys(columns).filter(column => column !== 'dateOfBirth').map(((column: keyof Person) => (
+              <CrudHeader
+                key={column}
+                width={columns[column]}
+                onResize={(width) => changeSize(column, width)}
+                direction={sort.column === column ? sort.direction : 'NONE'}
+                onSort={(direction) => changeSort(column, direction)}
+                onSearch={(value) => filterChanged(column, value)}
+                searchValue={filters[column]}
+              >
+                {capitalize(column.replace(/([A-Z])/, ' $1'))}
+              </CrudHeader>
+            )))}
+            <EpicHeader
+              width={columns.dateOfBirth}
+              height={88}
+              onResize={(width) => changeSize('dateOfBirth', width)}
+            >
+              <EpicCellLayout mode="vertical">
+                <EpicCellLayout mode="horizontal">
+                  Birth date
+                  <EpicSort
+                    direction={
+                      sort.column === 'dateOfBirth' ? sort.direction : 'NONE'
+                    }
+                    onChange={(direction) =>
+                      changeSort('dateOfBirth', direction)
+                    }
+                  />
+                </EpicCellLayout>
+
+                <DateTimeInput
+                  id="dateOfBirth"
+                  dateFormat="YYYY-MM-DD"
+                  placeholder="YYYY-MM-DD"
+                  timeFormat={false}
+                  onChange={(date) =>
+                    filterChanged(
+                      'dateOfBirth',
+                      date ? moment(date).format('YYYY-MM-DD') : ''
+                    )
+                  }
+                />
+              </EpicCellLayout>
+            </EpicHeader>
+            <EpicHeader width={300} height={88}>
+              <div className="px-1 py-1 align-self-start">Actions</div>
+            </EpicHeader>
+          </EpicRow>
+
+          {loading ? (
+            <ContentState mode="loading" title="Loading..." />
+          ) : pageOfPersons.content.map((person) => (
+            <EpicRow key={person.id} onClick={() => setDetail(person.id)}>
+              <EpicCell width={columns.firstName}>
+                <EpicSelection
+                  checked={selected.some((p) => p.id === person.id)}
+                  onChange={(checked) => onSelect(person, checked)}
+                />
+
+                <span
+                  className="text-primary clickable w-100"
+                  onClick={() => setDetail(person.id)}
+                >
+                  {person.firstName}
+                </span>
+              </EpicCell>
+              {Object.keys(columns).filter(column => column !== 'firstName').map((column) => (
+                <EpicCell key={column} width={columns[column]}>
+                  {person[column]}
+                </EpicCell>
+              ))}
+              <EpicCell width={300}>
+                <ConfirmButton icon="delete" dialogText="Are you sure you want to delete this person?" onConfirm={action('delete')} />
+                <Button icon="edit" onClick={() => setEditing(person.id)} />
+              </EpicCell>
+            </EpicRow>
+          ))}
+
+          <EpicDetailRow left={columns.firstName} active={editing > 0}>
+            {() => (
+              <EpicDetail onClose={() => setEditing(-1)}>
+                <PersonForm person={pageOfPersons.content.find(person => person.id === editing)} />
+              </EpicDetail>
+            )}
+          </EpicDetailRow>
+          <EpicDetailRow left={columns.firstName} active={detail > 0}>
+            {() => {
+              const person = pageOfPersons.content.find(p => p.id === detail);
+
+              if (!person) {
+                return <EpicDetail onClose={() => setDetail(-1)}>Person not found</EpicDetail>;
+              }
+
+              return (
+                <EpicDetail onClose={() => setDetail(-1)}>
+                  <AttributeList>
+                  {Object.keys(columns).map((column) => (
+                    <AttributeView key={column} label={capitalize(column.replace(/([A-Z])/, ' $1'))}>
+                      {person[column]}
+                    </AttributeView>
+                    ))}
+                  </AttributeList>
+                </EpicDetail>
+              );
+            }}
+          </EpicDetailRow>
+          <EpicDetailRow left={columns.firstName} active={creating}>
+            {() => (
+              <EpicDetail onClose={() => setCreating(false)}>
+                <PersonForm />
+              </EpicDetail>
+            )}
+          </EpicDetailRow>
+        </CrudTable>
+      </Card>
+    );
+  });
+
+function PersonForm({ person }: { person?: Person }) {
+  return (
+    <Form initialValues={person} onSubmit={() => action('person edited')}>
+      {() => (
+        <>
+          <Field name="firstName">
+            {({ input }) => (
+              <Input {...input} type="text" label="First name" />
+            )}
+          </Field>
+          <Field name="lastName">
+            {({ input }) => (
+              <Input {...input} type="text" label="Last name" />
+            )}
+          </Field>
+          <Field name="age">
+            {({ input }) => (
+              <Input {...input} type="text" label="Age" />
+            )}
+          </Field>
+          <Field name="eyeColor">
+            {({ input }) => (
+              <Select
+                {...input}
+                label="Eye color"
+                options={[ 'all', 'brown', 'green', 'blue' ]}
+                labelForOption={(option) => option}
+              />
+            )}
+          </Field>
+          <Field name="sex">
+            {({ input }) => (
+              <Select
+                {...input}
+                label="Sex"
+                options={[ 'male', 'female' ]}
+                labelForOption={(option) => option}
+              />
+            )}
+          </Field>
+        </>
+      )}
+    </Form>
+  );
+}

--- a/src/table/CrudTable/CrudTable.test.tsx
+++ b/src/table/CrudTable/CrudTable.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { CrudTable } from './CrudTable';
+import { Page } from '@42.nl/spring-connect';
+import Tag from '../../core/Tag/Tag';
+import SearchInput from '../../core/SearchInput/SearchInput';
+import Button from '../../core/Button/Button';
+import { pageOfUsers } from '../../test/fixtures';
+import Pagination from '../../core/Pagination/Pagination';
+
+describe('Component: CrudTable', () => {
+  function setup({
+    buttons,
+    renderSelection,
+    canSearch,
+    searchValue,
+    page
+  } : {
+    buttons?: () => React.ReactNode;
+    renderSelection?: () => React.ReactNode;
+    canSearch?: () => boolean;
+    searchValue?: string;
+    page?: Page<any>;
+  }) {
+    const onSearchSpy = jest.fn();
+    const pageChangedSpy = jest.fn();
+
+    const crudTable = shallow(
+      <CrudTable
+        renderSelection={renderSelection}
+        buttons={buttons}
+        canSearch={canSearch}
+        onSearch={onSearchSpy}
+        searchValue={searchValue}
+        page={page}
+        pageChanged={pageChangedSpy}
+      >
+        crud table content
+      </CrudTable>
+    );
+
+    return { crudTable, onSearchSpy, pageChangedSpy };
+  }
+
+  describe('ui', () => {
+    test('default', () => {
+      const { crudTable } = setup({});
+
+      expect(toJson(crudTable)).toMatchSnapshot();
+    });
+
+    test('with buttons', () => {
+      const { crudTable } = setup({
+        buttons: () => <Button onClick={jest.fn()}>test</Button>
+      });
+
+      expect(toJson(crudTable)).toMatchSnapshot();
+    });
+
+    test('with selection', () => {
+      const { crudTable } = setup({
+        renderSelection: () => <Tag text="selected item" />
+      });
+
+      expect(toJson(crudTable)).toMatchSnapshot();
+    });
+
+    test('without search', () => {
+      const { crudTable } = setup({
+        canSearch: () => false
+      });
+
+      expect(toJson(crudTable)).toMatchSnapshot();
+    });
+
+    test('with search value', () => {
+      const { crudTable } = setup({
+        searchValue: 'test'
+      });
+
+      expect(toJson(crudTable)).toMatchSnapshot();
+    });
+
+    test('with pagination', () => {
+      const { crudTable } = setup({
+        page: pageOfUsers()
+      });
+
+      expect(toJson(crudTable)).toMatchSnapshot();
+    });
+  });
+
+  describe('events', () => {
+    it('should call onSearch when the user types in the search field', () => {
+      const { crudTable, onSearchSpy } = setup({});
+
+      crudTable
+        .find(SearchInput)
+        .props()
+        .onChange('test');
+
+      expect(onSearchSpy).toBeCalledTimes(1);
+      expect(onSearchSpy).toBeCalledWith('test');
+    });
+
+    it('should call pageChanged when the user clicks a page number', () => {
+      const { crudTable, pageChangedSpy } = setup({page: pageOfUsers()});
+
+      // @ts-expect-error Mock test
+      crudTable
+        .find(Pagination)
+        .props()
+        .onChange(2);
+
+      expect(pageChangedSpy).toBeCalledTimes(1);
+      expect(pageChangedSpy).toBeCalledWith(2);
+    });
+  });
+});

--- a/src/table/CrudTable/CrudTable.tsx
+++ b/src/table/CrudTable/CrudTable.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import SearchInput from '../../core/SearchInput/SearchInput';
+import { EpicTable } from '../EpicTable/EpicTable';
+import Pagination from '../../core/Pagination/Pagination';
+import { Page } from '@42.nl/spring-connect';
+
+type Props = {
+  /**
+   * Making it possible pass to on custom buttons.
+   */
+  buttons?: () => React.ReactNode;
+
+  /**
+   * Optional function which determines if the user can search the table.
+   * When `true` a single `SearchInput` is rendered.
+   * Defaults to a function which returns true.
+   */
+  canSearch?: () => boolean;
+
+  /**
+   * Provides a means of handling a search by the parent component itself.
+   */
+  onSearch?: (value: string) => void;
+
+  /**
+   * Optional search value.
+   */
+  searchValue?: string;
+
+  /**
+   * Optional callback function which you can use to render the current
+   * selected items.
+   */
+  renderSelection?: () => React.ReactNode;
+
+  /**
+   * The page passed to the Pagination component to determine what page you
+   * are on and how many page numbers should be displayed.
+   */
+  page?: Page<any>;
+
+  /**
+   * Optional callback that is triggered when one of the Pagination buttons
+   * is clicked.
+   */
+  pageChanged?: (page: number) => void;
+
+  /**
+   * The content of the table.
+   */
+  children: React.ReactNode;
+};
+
+/**
+ * CrudTable is an EpicTable wrapper to make it easier to display a table
+ * with CRUD options. If page is defined, it also includes pagination.
+ * It should be filled with `EpicRow`s, where the header row should be filled
+ * with `CrudHeader`s.
+ */
+export function CrudTable(props: Props) {
+  const {
+    buttons,
+    canSearch = () => true,
+    searchValue = '',
+    onSearch,
+    renderSelection,
+    page,
+    pageChanged,
+    children
+  } = props;
+
+  return (
+    <>
+      <div className="d-flex justify-content-end mb-2">
+        {buttons ? buttons() : null}
+      </div>
+
+      {canSearch() && onSearch ? (
+        <SearchInput
+          className="mb-4"
+          defaultValue={searchValue}
+          onChange={onSearch}
+        />
+      ) : null}
+
+      {renderSelection ? renderSelection() : null}
+
+      <EpicTable minHeight={400}>
+        {children}
+      </EpicTable>
+
+      {page && pageChanged ? (
+        <div className="d-flex justify-content-center">
+          <Pagination className="my-3" page={page} onChange={pageChanged} />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/table/CrudTable/__snapshots__/CrudTable.test.tsx.snap
+++ b/src/table/CrudTable/__snapshots__/CrudTable.test.tsx.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: CrudTable ui default 1`] = `
+<Fragment>
+  <div
+    className="d-flex justify-content-end mb-2"
+  />
+  <SearchInput
+    className="mb-4"
+    defaultValue=""
+    onChange={[MockFunction]}
+  />
+  <EpicTable
+    minHeight={400}
+  >
+    crud table content
+  </EpicTable>
+</Fragment>
+`;
+
+exports[`Component: CrudTable ui with buttons 1`] = `
+<Fragment>
+  <div
+    className="d-flex justify-content-end mb-2"
+  >
+    <Button
+      onClick={[MockFunction]}
+    >
+      test
+    </Button>
+  </div>
+  <SearchInput
+    className="mb-4"
+    defaultValue=""
+    onChange={[MockFunction]}
+  />
+  <EpicTable
+    minHeight={400}
+  >
+    crud table content
+  </EpicTable>
+</Fragment>
+`;
+
+exports[`Component: CrudTable ui with pagination 1`] = `
+<Fragment>
+  <div
+    className="d-flex justify-content-end mb-2"
+  />
+  <SearchInput
+    className="mb-4"
+    defaultValue=""
+    onChange={[MockFunction]}
+  />
+  <EpicTable
+    minHeight={400}
+  >
+    crud table content
+  </EpicTable>
+  <div
+    className="d-flex justify-content-center"
+  >
+    <Pagination
+      className="my-3"
+      onChange={[MockFunction]}
+      page={
+        Object {
+          "content": Array [
+            Object {
+              "active": true,
+              "email": "admin@42.nl",
+              "firstName": "Addie",
+              "id": 42,
+              "lastName": "Admin",
+              "roles": Array [
+                "ADMIN",
+              ],
+            },
+            Object {
+              "active": false,
+              "email": "coordinator@42.nl",
+              "firstName": "Cordelia",
+              "id": 777,
+              "lastName": "Coordinator",
+              "roles": Array [
+                "ADMIN",
+                "USER",
+              ],
+            },
+            Object {
+              "active": false,
+              "email": "user@42.nl",
+              "firstName": "Ulysses",
+              "id": 1337,
+              "lastName": "User",
+              "roles": Array [
+                "USER",
+              ],
+            },
+          ],
+          "first": false,
+          "last": false,
+          "number": 2,
+          "numberOfElements": 3,
+          "size": 3,
+          "totalElements": 9,
+          "totalPages": 3,
+        }
+      }
+    />
+  </div>
+</Fragment>
+`;
+
+exports[`Component: CrudTable ui with search value 1`] = `
+<Fragment>
+  <div
+    className="d-flex justify-content-end mb-2"
+  />
+  <SearchInput
+    className="mb-4"
+    defaultValue="test"
+    onChange={[MockFunction]}
+  />
+  <EpicTable
+    minHeight={400}
+  >
+    crud table content
+  </EpicTable>
+</Fragment>
+`;
+
+exports[`Component: CrudTable ui with selection 1`] = `
+<Fragment>
+  <div
+    className="d-flex justify-content-end mb-2"
+  />
+  <SearchInput
+    className="mb-4"
+    defaultValue=""
+    onChange={[MockFunction]}
+  />
+  <Tag
+    text="selected item"
+  />
+  <EpicTable
+    minHeight={400}
+  >
+    crud table content
+  </EpicTable>
+</Fragment>
+`;
+
+exports[`Component: CrudTable ui without search 1`] = `
+<Fragment>
+  <div
+    className="d-flex justify-content-end mb-2"
+  />
+  <EpicTable
+    minHeight={400}
+  >
+    crud table content
+  </EpicTable>
+</Fragment>
+`;

--- a/src/table/CrudTable/components/CrudHeader/CrudHeader.test.tsx
+++ b/src/table/CrudTable/components/CrudHeader/CrudHeader.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { CrudHeader } from './CrudHeader';
+import { EpicSort } from '../../../EpicTable/widgets/EpicSort/EpicSort';
+import Input from '../../../../form/Input/Input';
+
+describe('Component: CrudHeader', () => {
+  describe('ui', () => {
+    test('default', () => {
+      const crudHeader = shallow(
+        <CrudHeader width={300}>
+          crud header
+        </CrudHeader>
+      );
+
+      expect(toJson(crudHeader)).toMatchSnapshot();
+    });
+
+    test('with resize', () => {
+      const crudHeader = mount(
+        <CrudHeader width={300} onResize={jest.fn()}>
+          epic header
+        </CrudHeader>
+      );
+
+      expect(toJson(crudHeader)).toMatchSnapshot();
+    });
+
+    test('with sort', () => {
+      const crudHeader = shallow(
+        <CrudHeader width={300} onSort={jest.fn()}>
+          crud header
+        </CrudHeader>
+      );
+
+      expect(toJson(crudHeader)).toMatchSnapshot();
+    });
+
+    test('with search', () => {
+      const crudHeader = shallow(
+        <CrudHeader width={300} onSearch={jest.fn()}>
+          crud header
+        </CrudHeader>
+      );
+
+      expect(toJson(crudHeader)).toMatchSnapshot();
+    });
+
+    test('with sort and search', () => {
+      const crudHeader = shallow(
+        <CrudHeader width={300} onSort={jest.fn()} onSearch={jest.fn()}>
+          crud header
+        </CrudHeader>
+      );
+
+      expect(toJson(crudHeader)).toMatchSnapshot();
+    });
+
+    test('with search options', () => {
+      const crudHeader = shallow(
+        <CrudHeader width={300} onSearch={jest.fn()} options={['crud', 'header']} labelForOption={(option) => option}>
+          crud header
+        </CrudHeader>
+      );
+
+      expect(toJson(crudHeader)).toMatchSnapshot();
+    });
+  });
+
+  describe('events', () => {
+    it('should call onSort when the user clicks the sorting button', () => {
+      const onSortSpy = jest.fn();
+
+      const crudHeader = mount(
+        <CrudHeader width={300} height={44} onSort={onSortSpy}>
+          epic header
+        </CrudHeader>
+      );
+
+      crudHeader
+        .find(EpicSort)
+        .props()
+        .onChange('ASC');
+
+      expect(onSortSpy).toBeCalledTimes(1);
+      expect(onSortSpy).toBeCalledWith('ASC');
+    });
+
+    it('should call onSearch when the user types in the search field', () => {
+      const onSearchSpy = jest.fn();
+
+      const crudHeader = mount(
+        <CrudHeader width={300} height={44} onSearch={onSearchSpy}>
+          epic header
+        </CrudHeader>
+      );
+
+      crudHeader
+        .find(Input)
+        .props()
+        .onChange('test');
+
+      expect(onSearchSpy).toBeCalledTimes(1);
+      expect(onSearchSpy).toBeCalledWith('test');
+    });
+  });
+});

--- a/src/table/CrudTable/components/CrudHeader/CrudHeader.tsx
+++ b/src/table/CrudTable/components/CrudHeader/CrudHeader.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { EpicCellLayout } from '../../../EpicTable/cells/EpicCellLayout/EpicCellLayout';
+import { EpicSort } from '../../../EpicTable/widgets/EpicSort/EpicSort';
+import Input from '../../../../form/Input/Input';
+import { EpicTableSortDirection } from '../../../EpicTable/types';
+import { LabelForOption } from '../../../../form/option';
+import { EpicHeader } from '../../../EpicTable/cells/EpicHeader/EpicHeader';
+import Select from '../../../../form/Select/Select';
+
+type Props<T> = {
+  /**
+   * The width of the cell in pixels.
+   */
+  width: number;
+
+  /**
+   * The height of the cell in pixels.
+   * Defaults to 88 when onSearch is defined, or 44 otherwise.
+   */
+  height?: number;
+
+  /**
+   * Optionally a callback for when the width has changed. By setting
+   * this callback you enable the resizing of the EpicHeader.
+   *
+   * You can never resize the width to less than the original width to
+   * prevent columns from becoming too small.
+   *
+   * When this callback is called you should store the `width` and
+   * pass it back into the CrudHeader as the `width` property.
+   */
+  onResize?: (width: number) => void;
+
+  /**
+   * The content of the cell.
+   */
+  children: React.ReactNode;
+
+  /**
+   * Optionally the current sorting direction.
+   * Defaults to NONE.
+   */
+  direction?: EpicTableSortDirection;
+
+  /**
+   * Optional callback which is triggered when the direction changes.
+   */
+  onSort?: (direction: EpicTableSortDirection) => void;
+
+  /**
+   * Optional callback that is triggered when the search value changes.
+   * When `options` is defined, a dropdown is displayed, otherwise an open
+   * text input is displayed.
+   */
+  onSearch?: (value: T) => void;
+
+  /**
+   * Optionally the current search value.
+   */
+  searchValue?: T;
+
+  /**
+   * Optional search options used when you want to display a dropdown.
+   */
+  options?: T[];
+
+  /**
+   * Optional callback to convert a value of type T to an option to show
+   * to the user.
+   * Required when `options` is defined.
+   */
+  labelForOption?: LabelForOption<T>;
+}
+
+/**
+ * CrudHeader is used to display a header in the EpicTable or CrudTable.
+ * If onSort is defined, a sorting button is displayed next to the label.
+ * If onSearch is defined, a search field is displayed below the label.
+ */
+export function CrudHeader<T = string>({
+  direction = 'NONE',
+  onSort,
+  onSearch,
+  searchValue,
+  options,
+  labelForOption,
+  width,
+  height,
+  onResize,
+  children
+}: Props<T>) {
+  const header = onSort ? (
+    <EpicCellLayout mode="horizontal">
+      {children}
+      <EpicSort
+        direction={direction}
+        onChange={onSort}
+      />
+    </EpicCellLayout>
+  ) : (
+    <>{children}</>
+  );
+
+  if (onSearch) {
+    return (
+      <EpicHeader width={width} height={height ? height : 88} onResize={onResize}>
+        <EpicCellLayout mode="vertical">
+          {header}
+          {options && labelForOption ? (
+            <Select<T>
+              value={searchValue}
+              options={options}
+              labelForOption={labelForOption}
+              onChange={onSearch}
+            />
+          ) : (
+            <Input
+              // @ts-expect-error Default value type is a string
+              value={searchValue}
+              onChange={(value) => {
+                // @ts-expect-error Default value type is a string
+                onSearch(value);
+              }} />
+          )}
+        </EpicCellLayout>
+      </EpicHeader>
+    );
+  }
+
+  return (
+    <EpicHeader width={width} height={height} onResize={onResize}>{header}</EpicHeader>
+  );
+}

--- a/src/table/CrudTable/components/CrudHeader/__snapshots__/CrudHeader.test.tsx.snap
+++ b/src/table/CrudTable/components/CrudHeader/__snapshots__/CrudHeader.test.tsx.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: CrudHeader ui default 1`] = `
+<EpicHeader
+  width={300}
+>
+  crud header
+</EpicHeader>
+`;
+
+exports[`Component: CrudHeader ui with resize 1`] = `
+<CrudHeader
+  onResize={[MockFunction]}
+  width={300}
+>
+  <EpicHeader
+    onResize={[MockFunction]}
+    width={300}
+  >
+    <div
+      className="epic-table-header d-flex align-items-center justify-content-between p-1"
+      style={
+        Object {
+          "height": 44,
+          "minWidth": 300,
+          "width": 300,
+        }
+      }
+    >
+      epic header
+      <EpicResize
+        onResize={[MockFunction]}
+        width={300}
+      >
+        <div
+          className="epic-table-header-resizeable"
+          onMouseDown={[Function]}
+        />
+      </EpicResize>
+    </div>
+  </EpicHeader>
+</CrudHeader>
+`;
+
+exports[`Component: CrudHeader ui with search 1`] = `
+<EpicHeader
+  height={88}
+  width={300}
+>
+  <EpicCellLayout
+    mode="vertical"
+  >
+    crud header
+    <Input
+      onChange={[Function]}
+    />
+  </EpicCellLayout>
+</EpicHeader>
+`;
+
+exports[`Component: CrudHeader ui with search options 1`] = `
+<EpicHeader
+  height={88}
+  width={300}
+>
+  <EpicCellLayout
+    mode="vertical"
+  >
+    crud header
+    <Select
+      labelForOption={[Function]}
+      onChange={[MockFunction]}
+      options={
+        Array [
+          "crud",
+          "header",
+        ]
+      }
+    />
+  </EpicCellLayout>
+</EpicHeader>
+`;
+
+exports[`Component: CrudHeader ui with sort 1`] = `
+<EpicHeader
+  width={300}
+>
+  <EpicCellLayout
+    mode="horizontal"
+  >
+    crud header
+    <EpicSort
+      direction="NONE"
+      onChange={[MockFunction]}
+    />
+  </EpicCellLayout>
+</EpicHeader>
+`;
+
+exports[`Component: CrudHeader ui with sort and search 1`] = `
+<EpicHeader
+  height={88}
+  width={300}
+>
+  <EpicCellLayout
+    mode="vertical"
+  >
+    <EpicCellLayout
+      mode="horizontal"
+    >
+      crud header
+      <EpicSort
+        direction="NONE"
+        onChange={[MockFunction]}
+      />
+    </EpicCellLayout>
+    <Input
+      onChange={[Function]}
+    />
+  </EpicCellLayout>
+</EpicHeader>
+`;

--- a/src/table/EpicTable/cells/EpicCell/EpicCell.test.tsx
+++ b/src/table/EpicTable/cells/EpicCell/EpicCell.test.tsx
@@ -5,14 +5,14 @@ import toJson from 'enzyme-to-json';
 import { EpicCell } from './EpicCell';
 
 describe('Component: EpicCell', () => {
-  function setup({ hasOnRowClick = true }: { hasOnRowClick?: boolean }) {
+  function setup({ hasOnRowClick = true, height }: { hasOnRowClick?: boolean; height?: number; }) {
     const onRowClickSpy = jest.fn();
     const onHoverChangedSpy = jest.fn();
 
     const epicCell = shallow(
       <EpicCell
         width={300}
-        height={44}
+        height={height}
         // @ts-expect-error Test mock
         onRowClick={hasOnRowClick ? onRowClickSpy : undefined}
         onHoverChanged={hasOnRowClick ? onHoverChangedSpy : undefined}
@@ -24,10 +24,18 @@ describe('Component: EpicCell', () => {
     return { epicCell, onRowClickSpy, onHoverChangedSpy };
   }
 
-  test('ui', () => {
-    const { epicCell } = setup({});
+  describe('ui', () => {
+    test('default', () => {
+      const { epicCell } = setup({});
 
-    expect(toJson(epicCell)).toMatchSnapshot();
+      expect(toJson(epicCell)).toMatchSnapshot();
+    });
+
+    test('with height', () => {
+      const { epicCell } = setup({ height: 50 });
+
+      expect(toJson(epicCell)).toMatchSnapshot();
+    });
   });
 
   describe('events', () => {

--- a/src/table/EpicTable/cells/EpicCell/EpicCell.tsx
+++ b/src/table/EpicTable/cells/EpicCell/EpicCell.tsx
@@ -8,14 +8,15 @@ type Props = {
   children: React.ReactNode;
 
   /**
-   * The width of the cell.
+   * The width of the cell in pixels.
    */
   width: number;
 
   /**
-   * The height of the cell.
+   * Optionally the height of the cell in pixels.
+   * Defaults to 44.
    */
-  height: number;
+  height?: number;
 };
 
 // Props that will be injected by the EpicTable.
@@ -53,7 +54,7 @@ type InjectedProps = {
  * The EpicCell is used inside of a EpicRow to render content in.
  * It can be seen as the EpicTable's variant of the `<td>` element.
  */
-export function EpicCell({ children, width, height, ...rest }: Props) {
+export function EpicCell({ children, width, height = 44, ...rest }: Props) {
   const ref = useRef(null);
 
   const { odd, onRowClick, hover, onHoverChanged } = rest as InjectedProps;

--- a/src/table/EpicTable/cells/EpicCell/__snapshots__/EpicCell.test.tsx.snap
+++ b/src/table/EpicTable/cells/EpicCell/__snapshots__/EpicCell.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: EpicCell ui 1`] = `
+exports[`Component: EpicCell ui default 1`] = `
 <div
   className="epic-table-cell border-bottom p-1"
   onClick={[Function]}
@@ -9,6 +9,24 @@ exports[`Component: EpicCell ui 1`] = `
   style={
     Object {
       "height": 44,
+      "minWidth": 300,
+      "width": 300,
+    }
+  }
+>
+  epic cell
+</div>
+`;
+
+exports[`Component: EpicCell ui with height 1`] = `
+<div
+  className="epic-table-cell border-bottom p-1"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    Object {
+      "height": 50,
       "minWidth": 300,
       "width": 300,
     }

--- a/src/table/EpicTable/cells/EpicHeader/EpicHeader.tsx
+++ b/src/table/EpicTable/cells/EpicHeader/EpicHeader.tsx
@@ -2,28 +2,29 @@ import React from 'react';
 
 import { EpicResize } from './EpicResize/EpicResize';
 
-type Props = {
+export type Props = {
   /**
    * The content of the cell.
    */
   children: React.ReactNode;
 
   /**
-   * The width of the cell.
+   * The width of the cell in pixels.
    */
   width: number;
 
   /**
-   * The height of the cell.
+   * Optionally the height of the cell in pixels.
+   * Defaults to 44.
    */
-  height: number;
+  height?: number;
 
   /**
    * Optionally a callback for when the width has changed. By setting
    * this callback you enable the resizing of the EpicHeader.
    *
-   * You can never resize the width to less of the original width to
-   * prevent columns from becoming to small.
+   * You can never resize the width to less than the original width to
+   * prevent columns from becoming too small.
    *
    * When this callback is called you should store the `width` and
    * pass it back into the EpicHeader as the `width` property.
@@ -37,7 +38,7 @@ type Props = {
  *
  * It is resizable whenever the `onResize` callback is defined.
  */
-export function EpicHeader({ children, width, height, onResize }: Props) {
+export function EpicHeader({ children, width, height = 44, onResize }: Props) {
   return (
     <div
       className="epic-table-header d-flex align-items-center justify-content-between p-1"


### PR DESCRIPTION
We are using the EpicTable a lot for our entity listings and it would be
a lot easier if there is a component that simplifies the EpicTable for
that purpose.

Added CrudTable component which wraps the EpicTable to make it easier to
display a table with create/edit/detail view and pagination.
Added CrudHeader component to simplify the display of a header with
sort and search functionality.

Closes #605