### PR TITLE
improvement: select without placeholder

### DIFF
--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -124,12 +124,14 @@ export default function Select<T>(props: Props<T>) {
         </Loading>
       ) : (
         <RSInput value={indexOfValue} {...inputProps}>
-          <option ref={(option) => selectDefaultOption(option)}>
-            {placeholder}
-          </option>
+          {placeholder ? (
+            <option ref={(option) => selectDefaultOption(option)}>
+              {placeholder}
+            </option>
+          ) : null}
 
           {page.content.map((option, index) => {
-            const label = labelForOption(option);
+            const optionLabel = labelForOption(option);
             const key = getKeyForOption({
               option,
               keyForOption,
@@ -142,7 +144,7 @@ export default function Select<T>(props: Props<T>) {
                 value={index}
                 disabled={!isOptionEnabled(option)}
               >
-                {label}
+                {optionLabel}
               </option>
             );
           })}

--- a/src/form/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/form/Select/__snapshots__/Select.test.tsx.snap
@@ -159,7 +159,6 @@ exports[`Component: Select ui without placeholder: Component: Select => ui => wi
     type="select"
     value={0}
   >
-    <option />
     <option
       disabled={false}
       key="42"


### PR DESCRIPTION
The placeholder you define cannot be disabled. If you don't specify a
placeholder, you still have an empty value you can select even if you
don't want to. It would help if Select would not display an empty option
if the placeholder is empty.

Added check if placeholder is empty to prevent an empty option.

Closes #616