### PR TITLE
improvement: upgrade to bootstrap 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.MD",
       "dependencies": {
         "@tippyjs/react": "4.2.6",
-        "bootstrap": "4.6.1",
+        "bootstrap": "5.1.3",
         "moment": "2.29.1",
         "overlayscrollbars": "1.13.1",
         "overlayscrollbars-react": "0.2.3",
@@ -79,7 +79,7 @@
         "react-query": "3.34.8",
         "react-router-dom": "6.2.1",
         "react-test-renderer": "17.0.2",
-        "reactstrap": "8.10.1",
+        "reactstrap": "9.0.1",
         "rollup": "2.64.0",
         "rollup-plugin-auto-external": "2.0.0",
         "rollup-plugin-copy": "3.4.0",
@@ -91,7 +91,7 @@
         "style-loader": "2.0.0",
         "ts-jest": "27.1.2",
         "ts-loader": "9.2.6",
-        "typescript": "4.5.4"
+        "typescript": "4.5.5"
       },
       "peerDependencies": {
         "@42.nl/jarb-final-form": "^2.0.4",
@@ -103,7 +103,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",
-        "reactstrap": "^8.10.1"
+        "reactstrap": "^9.0.1"
       }
     },
     "node_modules/@42.nl/jarb-final-form": {
@@ -304,9 +304,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
-      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
+      "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -4399,9 +4399,9 @@
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/@types/node": {
-      "version": "14.18.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-      "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+      "version": "14.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+      "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
       "dev": true
     },
     "node_modules/@storybook/builder-webpack4/node_modules/babel-plugin-polyfill-corejs3": {
@@ -4875,9 +4875,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "14.18.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-      "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+      "version": "14.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+      "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
       "dev": true
     },
     "node_modules/@storybook/core-common/node_modules/ansi-styles": {
@@ -5133,9 +5133,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "14.18.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-      "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+      "version": "14.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+      "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
       "dev": true
     },
     "node_modules/@storybook/core-server/node_modules/ansi-styles": {
@@ -5286,9 +5286,9 @@
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/@types/node": {
-      "version": "14.18.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-      "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+      "version": "14.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+      "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
       "dev": true
     },
     "node_modules/@storybook/manager-webpack4/node_modules/ansi-styles": {
@@ -6349,9 +6349,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.9.tgz",
+      "integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -8265,12 +8265,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
-      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
+      "integrity": "sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==",
       "dependencies": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "@babel/helper-define-polyfill-provider": "^0.3.1",
         "semver": "^6.1.1"
       },
       "peerDependencies": {
@@ -8278,11 +8278,11 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.0.tgz",
-      "integrity": "sha512-Hcrgnmkf+4JTj73GbK3bBhlVPiLL47owUAnoJIf69Hakl3q+KfodbDXiZWGMM7iqCZTxCG3Z2VRfPNYES4rXqQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.1.tgz",
+      "integrity": "sha512-TihqEe4sQcb/QcPJvxe94/9RZuLQuF1+To4WqQcRvc+3J3gLCPIPgDKzGLG6zmQLfH3nn25heRuDNkS2KR4I8A==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "@babel/helper-define-polyfill-provider": "^0.3.1",
         "core-js-compat": "^3.20.0"
       },
       "peerDependencies": {
@@ -8290,11 +8290,11 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
-      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz",
+      "integrity": "sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.3.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -8641,16 +8641,15 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.10.2"
       }
     },
     "node_modules/boxen": {
@@ -9192,9 +9191,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001299",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -9327,10 +9326,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -10142,9 +10147,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-      "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+      "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -10153,9 +10158,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.2.tgz",
-      "integrity": "sha512-qZEzVQ+5Qh6cROaTPFLNS4lkvQ6mBzE3R6A6EEpssj7Zr2egMHgsy4XapdifqJDGC9CBiNv7s+ejI96rLNQFdg==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.3.tgz",
+      "integrity": "sha512-c8M5h0IkNZ+I92QhIpuSijOxGAcj3lgpsWdkCqmUTZNwidujF4r3pi6x1DCN+Vcs5qTS2XWWMfWSuCqyupX8gw==",
       "dependencies": {
         "browserslist": "^4.19.1",
         "semver": "7.0.0"
@@ -10174,9 +10179,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.2.tgz",
-      "integrity": "sha512-CmWHvSKn2vNL6p6StNp1EmMIfVY/pqn3JLAjfZQ8WZGPOlGoO92EkX9/Mk81i6GxvoPXjUqEQnpM3rJ5QxxIOg==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.3.tgz",
+      "integrity": "sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -11427,9 +11432,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.44",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-      "integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw=="
+      "version": "1.4.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.47.tgz",
+      "integrity": "sha512-ZHc8i3/cgeCRK/vC7W2htAG6JqUmOUgDNn/f9yY9J8UjfLjwzwOVEt4MWmgJAdvmxyrsR5KIFA/6+kUHGY0eUA=="
     },
     "node_modules/elegant-spinner": {
       "version": "1.0.1",
@@ -12284,9 +12289,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -13033,9 +13038,9 @@
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -20508,9 +20513,9 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.5.tgz",
-      "integrity": "sha512-YQEMMMCX3PYOWtUAQu8Fmz5/sH09s17eyQnDubwaAo8sWmnRTT1og96EFv1vL59l4nWfmtF3L91pqkuheVqRlA==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
+      "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
       "dev": true,
       "engines": {
         "node": ">= 10"
@@ -21117,9 +21122,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.1.32",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz",
-      "integrity": "sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -21255,15 +21260,23 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch/node_modules/tr46": {
@@ -22124,9 +22137,9 @@
       }
     },
     "node_modules/ow/node_modules/@sindresorhus/is": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
-      "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.3.0.tgz",
+      "integrity": "sha512-wwOvh0eO3PiTEivGJWiZ+b946SlMSb4pe+y+Ur/4S87cwo09pYi+FWHHnbrM3W9W7cBYKDqQXcrFYjYUCOJUEQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -24555,28 +24568,19 @@
       }
     },
     "node_modules/react-transition-group": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-      "integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
       "dev": true,
       "dependencies": {
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/react-transition-group/node_modules/dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/reactcss": {
@@ -24588,20 +24592,35 @@
       }
     },
     "node_modules/reactstrap": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-      "integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.0.1.tgz",
+      "integrity": "sha512-89VOv7SRlAlpS7RwXhzOQkSWkuhBR8LBsPGfNHifNL3WhtNP9y1sBdTcTYyH1ee2QtI8zRdwD0T5I/blHiwemg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "@popperjs/core": "^2.6.0",
         "classnames": "^2.2.3",
         "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^3.0.0"
+        "react-popper": "^2.2.4",
+        "react-transition-group": "^4.4.2"
       },
       "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/reactstrap/node_modules/react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "dev": true,
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/read-pkg": {
@@ -24860,9 +24879,9 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -27704,9 +27723,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -28790,9 +28809,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -30842,9 +30861,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -31114,9 +31133,9 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
-      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
+      "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -34069,9 +34088,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+          "version": "14.18.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+          "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
           "dev": true
         },
         "babel-plugin-polyfill-corejs3": {
@@ -34421,9 +34440,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+          "version": "14.18.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+          "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
           "dev": true
         },
         "ansi-styles": {
@@ -34601,9 +34620,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+          "version": "14.18.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+          "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
           "dev": true
         },
         "ansi-styles": {
@@ -34721,9 +34740,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+          "version": "14.18.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
+          "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A==",
           "dev": true
         },
         "ansi-styles": {
@@ -35541,9 +35560,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.9.tgz",
+      "integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -37070,30 +37089,30 @@
       "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
-      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
+      "integrity": "sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==",
       "requires": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "@babel/helper-define-polyfill-provider": "^0.3.1",
         "semver": "^6.1.1"
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.0.tgz",
-      "integrity": "sha512-Hcrgnmkf+4JTj73GbK3bBhlVPiLL47owUAnoJIf69Hakl3q+KfodbDXiZWGMM7iqCZTxCG3Z2VRfPNYES4rXqQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.1.tgz",
+      "integrity": "sha512-TihqEe4sQcb/QcPJvxe94/9RZuLQuF1+To4WqQcRvc+3J3gLCPIPgDKzGLG6zmQLfH3nn25heRuDNkS2KR4I8A==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "@babel/helper-define-polyfill-provider": "^0.3.1",
         "core-js-compat": "^3.20.0"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
-      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz",
+      "integrity": "sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.3.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.1"
       }
     },
     "babel-plugin-react-docgen": {
@@ -37372,9 +37391,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "requires": {}
     },
     "boxen": {
@@ -37817,9 +37836,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001299",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw=="
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -37911,9 +37930,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -38564,15 +38583,15 @@
       }
     },
     "core-js": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-      "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+      "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.2.tgz",
-      "integrity": "sha512-qZEzVQ+5Qh6cROaTPFLNS4lkvQ6mBzE3R6A6EEpssj7Zr2egMHgsy4XapdifqJDGC9CBiNv7s+ejI96rLNQFdg==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.3.tgz",
+      "integrity": "sha512-c8M5h0IkNZ+I92QhIpuSijOxGAcj3lgpsWdkCqmUTZNwidujF4r3pi6x1DCN+Vcs5qTS2XWWMfWSuCqyupX8gw==",
       "requires": {
         "browserslist": "^4.19.1",
         "semver": "7.0.0"
@@ -38586,9 +38605,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.2.tgz",
-      "integrity": "sha512-CmWHvSKn2vNL6p6StNp1EmMIfVY/pqn3JLAjfZQ8WZGPOlGoO92EkX9/Mk81i6GxvoPXjUqEQnpM3rJ5QxxIOg==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.3.tgz",
+      "integrity": "sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==",
       "dev": true
     },
     "core-util-is": {
@@ -39610,9 +39629,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.44",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-      "integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw=="
+      "version": "1.4.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.47.tgz",
+      "integrity": "sha512-ZHc8i3/cgeCRK/vC7W2htAG6JqUmOUgDNn/f9yY9J8UjfLjwzwOVEt4MWmgJAdvmxyrsR5KIFA/6+kUHGY0eUA=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -40388,9 +40407,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true
     },
     "espree": {
@@ -40856,9 +40875,9 @@
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -46529,9 +46548,9 @@
       "dev": true
     },
     "markdown-to-jsx": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.5.tgz",
-      "integrity": "sha512-YQEMMMCX3PYOWtUAQu8Fmz5/sH09s17eyQnDubwaAo8sWmnRTT1og96EFv1vL59l4nWfmtF3L91pqkuheVqRlA==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
+      "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
       "dev": true,
       "requires": {}
     },
@@ -47025,9 +47044,9 @@
       }
     },
     "nanoid": {
-      "version": "3.1.32",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz",
-      "integrity": "sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true
     },
     "nanomatch": {
@@ -47136,9 +47155,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -47812,9 +47831,9 @@
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
-          "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.3.0.tgz",
+          "integrity": "sha512-wwOvh0eO3PiTEivGJWiZ+b946SlMSb4pe+y+Ur/4S87cwo09pYi+FWHHnbrM3W9W7cBYKDqQXcrFYjYUCOJUEQ==",
           "dev": true
         }
       }
@@ -49688,26 +49707,15 @@
       }
     },
     "react-transition-group": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-      "integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
       "dev": true,
       "requires": {
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "dependencies": {
-        "dom-helpers": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        }
+        "prop-types": "^15.6.2"
       }
     },
     "reactcss": {
@@ -49719,16 +49727,29 @@
       }
     },
     "reactstrap": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-      "integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.0.1.tgz",
+      "integrity": "sha512-89VOv7SRlAlpS7RwXhzOQkSWkuhBR8LBsPGfNHifNL3WhtNP9y1sBdTcTYyH1ee2QtI8zRdwD0T5I/blHiwemg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
+        "@popperjs/core": "^2.6.0",
         "classnames": "^2.2.3",
         "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^3.0.0"
+        "react-popper": "^2.2.4",
+        "react-transition-group": "^4.4.2"
+      },
+      "dependencies": {
+        "react-popper": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+          "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+          "dev": true,
+          "requires": {
+            "react-fast-compare": "^3.0.1",
+            "warning": "^4.0.2"
+          }
+        }
       }
     },
     "read-pkg": {
@@ -49937,9 +49958,9 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -52178,9 +52199,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -52990,9 +53011,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {
@@ -54644,9 +54665,9 @@
       }
     },
     "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@tippyjs/react": "4.2.6",
-    "bootstrap": "4.6.1",
+    "bootstrap": "5.1.3",
     "moment": "2.29.1",
     "overlayscrollbars": "1.13.1",
     "overlayscrollbars-react": "0.2.3",
@@ -65,7 +65,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",
-    "reactstrap": "^8.10.1"
+    "reactstrap": "^9.0.1"
   },
   "devDependencies": {
     "@42.nl/jarb-final-form": "2.0.4",
@@ -119,7 +119,7 @@
     "react-query": "3.34.8",
     "react-router-dom": "6.2.1",
     "react-test-renderer": "17.0.2",
-    "reactstrap": "8.10.1",
+    "reactstrap": "9.0.1",
     "rollup": "2.64.0",
     "rollup-plugin-auto-external": "2.0.0",
     "rollup-plugin-copy": "3.4.0",
@@ -131,7 +131,7 @@
     "style-loader": "2.0.0",
     "ts-jest": "27.1.2",
     "ts-loader": "9.2.6",
-    "typescript": "4.5.4"
+    "typescript": "4.5.5"
   },
   "jest": {
     "rootDir": "src",

--- a/src/core/Button/Button.scss
+++ b/src/core/Button/Button.scss
@@ -5,7 +5,7 @@
     overflow: hidden;
 
     @each $color, $value in $theme-colors {
-      &.btn-#{$color} {
+      &.btn-#{"" + $color} {
         &:hover,
         &:active:hover {
           background-color: darken($value, 6%);
@@ -36,7 +36,7 @@
   }
 
   @each $color, $value in $theme-colors {
-    &.#{$color} {
+    &.#{"" + $color} {
       .spinner {
         stroke: $value;
       }

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -145,14 +145,14 @@ export default function Button({
       <Spinner
         size={getSpinnerSize(size)}
         color={outline ? '' : 'white'}
-        className={iconPosition === 'left' ? 'mr-2' : 'ml-2'}
+        className={iconPosition === 'left' ? 'me-2' : 'ms-2'}
       />
     ) : icon ? (
       <Icon
         icon={icon}
         className={classNames(
           'button-icon',
-          iconPosition === 'left' ? 'mr-2' : 'ml-2'
+          iconPosition === 'left' ? 'me-2' : 'ms-2'
         )}
       />
     ) : null;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Component: Button ui button normal inProgress is true 1`] = `
     >
       Save
       <Spinner
-        className="ml-2"
+        className="ms-2"
         color="white"
         size={16}
       />
@@ -147,7 +147,7 @@ exports[`Component: Button ui button outline inProgress is true 1`] = `
       className="d-flex justify-content-center align-items-center"
     >
       <Spinner
-        className="mr-2"
+        className="me-2"
         color=""
         size={16}
       />
@@ -212,7 +212,7 @@ exports[`Component: Button ui button with icon normal inProgress is false 1`] = 
       className="d-flex justify-content-center align-items-center"
     >
       <Icon
-        className="button-icon mr-2"
+        className="button-icon me-2"
         icon="save"
       />
       Save
@@ -237,7 +237,7 @@ exports[`Component: Button ui button with icon normal inProgress is true 1`] = `
       className="d-flex justify-content-center align-items-center"
     >
       <Spinner
-        className="mr-2"
+        className="me-2"
         color="white"
         size={16}
       />
@@ -263,7 +263,7 @@ exports[`Component: Button ui button with icon normal with icon on the right 1`]
     >
       Save
       <Icon
-        className="button-icon ml-2"
+        className="button-icon ms-2"
         icon="save"
       />
     </div>
@@ -287,7 +287,7 @@ exports[`Component: Button ui button with icon outline inProgress is false 1`] =
       className="d-flex justify-content-center align-items-center"
     >
       <Icon
-        className="button-icon mr-2"
+        className="button-icon me-2"
         icon="save"
       />
       Save
@@ -313,7 +313,7 @@ exports[`Component: Button ui button with icon outline inProgress is true 1`] = 
       className="d-flex justify-content-center align-items-center"
     >
       <Spinner
-        className="mr-2"
+        className="me-2"
         color=""
         size={16}
       />

--- a/src/core/FlashMessage/FlashMessage.scss
+++ b/src/core/FlashMessage/FlashMessage.scss
@@ -2,23 +2,16 @@
   position: relative;
   margin-top: 1rem;
   
-  .close {
-    position: relative;
-    left: 74px;
-    top: -13px;
-    cursor: pointer;
-
-    &:focus {
-      outline: 0;
-    }
+  .btn-close:focus {
+    outline: 0;
   }
 
   .alert {
     @each $color, $value in $theme-colors {
-      &.alert-#{$color} {
+      &.alert-#{"" + $color} {
         background: $value;
         border-color: $value;
-        @include color-yiq($value);
+        color: color-contrast($value);
       }
     }
   }

--- a/src/core/Loading/Loading.tsx
+++ b/src/core/Loading/Loading.tsx
@@ -37,7 +37,7 @@ export default function Loading({ children, className, text = {} }: Props) {
   return (
     <div className={classes}>
       <Spinner className="align-self-center" color="black" size={16} />
-      <span className="ml-1">
+      <span className="ms-1">
         {children
           ? children
           : t({

--- a/src/core/Loading/__snapshots__/Loading.test.tsx.snap
+++ b/src/core/Loading/__snapshots__/Loading.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Component: Loading ui with children: Component: Loading => ui => with c
     size={16}
   />
   <span
-    className="ml-1"
+    className="ms-1"
   >
     We are 
     <b>
@@ -31,7 +31,7 @@ exports[`Component: Loading ui without children: Component: Loading => ui => wit
     size={16}
   />
   <span
-    className="ml-1"
+    className="ms-1"
   >
     Loading...
   </span>

--- a/src/core/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/__snapshots__/Modal.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`Component: Modal ui sans sticky footer: Component: Modal => ui => sans 
   zIndex={1050}
 >
   <ModalHeader
-    charCode={215}
     closeAriaLabel="Close"
     tag="h5"
     toggle={[Function]}
@@ -108,7 +107,6 @@ exports[`Component: Modal ui with header and footer: Component: Modal => ui => w
   zIndex={1050}
 >
   <ModalHeader
-    charCode={215}
     closeAriaLabel="Close"
     tag="h5"
     toggle={[Function]}
@@ -185,7 +183,6 @@ exports[`Component: Modal ui without footer: Component: Modal => ui => without f
   zIndex={1050}
 >
   <ModalHeader
-    charCode={215}
     closeAriaLabel="Close"
     tag="h5"
     toggle={[Function]}

--- a/src/core/NavigationItem/NavigationItem.tsx
+++ b/src/core/NavigationItem/NavigationItem.tsx
@@ -72,7 +72,7 @@ export default function NavigationItem({
   return (
     <NavItem className={classNames('navigation-item', className)}>
       <NavLink to={to} exact={exact} tag={RRNavLink} activeClassName="active">
-        <Icon icon={icon} className="mr-3 align-bottom" />
+        <Icon icon={icon} className="me-3 align-bottom" />
         {text}
       </NavLink>
     </NavItem>

--- a/src/core/NavigationItem/__snapshots__/NavigationItem.test.tsx.snap
+++ b/src/core/NavigationItem/__snapshots__/NavigationItem.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Component: NavigationItem ui 1`] = `
     to="/dashboard"
   >
     <Icon
-      className="mr-3 align-bottom"
+      className="me-3 align-bottom"
       icon="dashboard"
     />
     Dashboard

--- a/src/core/OpenClose/OpenClose.stories.tsx
+++ b/src/core/OpenClose/OpenClose.stories.tsx
@@ -11,7 +11,7 @@ storiesOf('core/OpenClose', module).add('basic', () => {
   return (
     <Card body>
       <div className="d-flex align-items-center justify-content-start">
-        <Button onClick={() => setIsOpen(!isOpen)} className="mr-3">
+        <Button onClick={() => setIsOpen(!isOpen)} className="me-3">
           Toggle
         </Button>
         <OpenClose open={isOpen} />

--- a/src/core/OpenCloseModal/OpenCloseModal.tsx
+++ b/src/core/OpenCloseModal/OpenCloseModal.tsx
@@ -150,7 +150,7 @@ export function OpenCloseModal(props: Props) {
         onSave ? (
           <>
             <Button
-              className="ml-1"
+              className="ms-1"
               color="secondary"
               icon={cancelIcon}
               onClick={() => onClose()}
@@ -162,7 +162,7 @@ export function OpenCloseModal(props: Props) {
               })}
             </Button>
             <SubmitButton
-              className="ml-1"
+              className="ms-1"
               inProgress={!!inProgress}
               icon={saveIcon}
               onClick={() => onSave()}

--- a/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
+++ b/src/core/OpenCloseModal/__snapshots__/OpenCloseModal.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseM
   footer={
     <React.Fragment>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -13,7 +13,7 @@ exports[`Component: OpenCloseModal ui custom button texts: Component: OpenCloseM
         Stop please
       </Button>
       <SubmitButton
-        className="ml-1"
+        className="ms-1"
         icon="save"
         inProgress={false}
         onClick={[Function]}
@@ -47,7 +47,7 @@ exports[`Component: OpenCloseModal ui in progress: Component: OpenCloseModal => 
   footer={
     <React.Fragment>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -55,7 +55,7 @@ exports[`Component: OpenCloseModal ui in progress: Component: OpenCloseModal => 
         Cancel
       </Button>
       <SubmitButton
-        className="ml-1"
+        className="ms-1"
         icon="save"
         inProgress={true}
         onClick={[Function]}
@@ -89,7 +89,7 @@ exports[`Component: OpenCloseModal ui sans sticky footer: Component: OpenCloseMo
   footer={
     <React.Fragment>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -97,7 +97,7 @@ exports[`Component: OpenCloseModal ui sans sticky footer: Component: OpenCloseMo
         Cancel
       </Button>
       <SubmitButton
-        className="ml-1"
+        className="ms-1"
         icon="save"
         inProgress={false}
         onClick={[Function]}
@@ -131,7 +131,7 @@ exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => u
   footer={
     <React.Fragment>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -139,7 +139,7 @@ exports[`Component: OpenCloseModal ui with label: Component: OpenCloseModal => u
         Cancel
       </Button>
       <SubmitButton
-        className="ml-1"
+        className="ms-1"
         icon="save"
         inProgress={false}
         onClick={[Function]}
@@ -195,7 +195,7 @@ exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal =
   footer={
     <React.Fragment>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`Component: OpenCloseModal ui without label: Component: OpenCloseModal =
         Cancel
       </Button>
       <SubmitButton
-        className="ml-1"
+        className="ms-1"
         icon="save"
         inProgress={false}
         onClick={[Function]}

--- a/src/core/Pager/Pager.tsx
+++ b/src/core/Pager/Pager.tsx
@@ -67,7 +67,7 @@ export default function Pager<T>({
   return (
     <div className={classNames('pager', className)}>
       <Button
-        className="mr-1"
+        className="me-1"
         outline
         icon="arrow_back"
         disabled={first}

--- a/src/core/Pager/__snapshots__/Pager.test.tsx.snap
+++ b/src/core/Pager/__snapshots__/Pager.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Component: Pager ui first: Component: Pager => first 1`] = `
   className="pager"
 >
   <Button
-    className="mr-1"
+    className="me-1"
     disabled={true}
     icon="arrow_back"
     onClick={[Function]}
@@ -31,7 +31,7 @@ exports[`Component: Pager ui last: Component: Pager => last 1`] = `
   className="pager"
 >
   <Button
-    className="mr-1"
+    className="me-1"
     disabled={false}
     icon="arrow_back"
     onClick={[Function]}
@@ -57,7 +57,7 @@ exports[`Component: Pager ui normal: Component: Pager => normal 1`] = `
   className="pager"
 >
   <Button
-    className="mr-1"
+    className="me-1"
     disabled={false}
     icon="arrow_back"
     onClick={[Function]}

--- a/src/core/ProgressStepper/ProgressStepper.scss
+++ b/src/core/ProgressStepper/ProgressStepper.scss
@@ -25,7 +25,7 @@ $progress-stepper-icons: (
     }
 
     @each $color, $value in $theme-colors {
-      &.#{$color} {
+      &.#{"" + $color} {
         .step-circle {
           background-color: $value;
 

--- a/src/core/ProgressStepper/ProgressStepperExample.stories.tsx
+++ b/src/core/ProgressStepper/ProgressStepperExample.stories.tsx
@@ -46,7 +46,7 @@ storiesOf('core/ProgressStepper', module)
       <>
         <div className="text-center">
           <ProgressStepper<Step>
-            className="ml-auto"
+            className="ms-auto"
             steps={steps}
             onClick={(step) => setCurrent(step)}
             isStepClickable={(step) => {
@@ -75,7 +75,7 @@ storiesOf('core/ProgressStepper', module)
             }}
           />
         </div>
-        <div className="ml-2">
+        <div className="ms-2">
           <h1>Form: {current}</h1>
 
           <button className="btn btn-primary" onClick={onSubmit}>

--- a/src/core/SearchInput/SearchInput.stories.tsx
+++ b/src/core/SearchInput/SearchInput.stories.tsx
@@ -97,7 +97,7 @@ storiesOf('core/SearchInput', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Search</span>
-              <Tooltip className="ml-1" content="Search the following fields">
+              <Tooltip className="ms-1" content="Search the following fields">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/core/SearchInput/SearchInput.tsx
+++ b/src/core/SearchInput/SearchInput.tsx
@@ -4,7 +4,6 @@ import {
   FormGroup,
   Input,
   InputGroup,
-  InputGroupAddon,
   InputProps,
   Label
 } from 'reactstrap';
@@ -12,6 +11,7 @@ import {
 import { Icon } from '../Icon';
 import { BootstrapSize } from '../types';
 import { useId } from '../../hooks/useId/useId';
+import { AddonIcon } from '../../form/addons/AddonIcon/AddonIcon';
 
 export type SearchInputApi = {
   /**
@@ -22,8 +22,7 @@ export type SearchInputApi = {
   setValue: (value: string) => void;
 };
 
-type ModifiedInputProps = Omit<
-  InputProps,
+type ModifiedInputProps = Omit<InputProps,
   // We are going to override onChange so it sends out strings.
   | 'onChange'
   // We want to remove the value because we use defaultValue,
@@ -39,8 +38,7 @@ type ModifiedInputProps = Omit<
   | 'children'
   // We are going to override some properties to be able to provide docs.
   | 'placeholder'
-  | 'className'
->;
+  | 'className'>;
 
 export type Props = ModifiedInputProps & {
   /**
@@ -160,7 +158,7 @@ export default function SearchInput(props: Props) {
   // When the onChange changes update the handleChange
   useEffect(() => {
     handleChange.current = lodashDebounce(onChange, debounce, debounceSettings);
-  }, [onChange, debounce, debounceSettings]);
+  }, [ onChange, debounce, debounceSettings ]);
 
   function handleKeyUp(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === 'Enter') {
@@ -198,9 +196,7 @@ export default function SearchInput(props: Props) {
     if (showIcon) {
       return (
         <InputGroup className={className} size={size}>
-          <InputGroupAddon addonType="prepend">
-            <Icon icon="search" />
-          </InputGroupAddon>
+          <AddonIcon icon="search" />
           <Input {...inputProps} />
         </InputGroup>
       );

--- a/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -8,14 +8,9 @@ exports[`Component: SearchInput ui with icon 1`] = `
     className=""
     tag="div"
   >
-    <InputGroupAddon
-      addonType="prepend"
-      tag="div"
-    >
-      <Icon
-        icon="search"
-      />
-    </InputGroupAddon>
+    <AddonIcon
+      icon="search"
+    />
     <Input
       defaultValue=""
       id="1"
@@ -41,14 +36,9 @@ exports[`Component: SearchInput ui with icon when undefined 1`] = `
     className=""
     tag="div"
   >
-    <InputGroupAddon
-      addonType="prepend"
-      tag="div"
-    >
-      <Icon
-        icon="search"
-      />
-    </InputGroupAddon>
+    <AddonIcon
+      icon="search"
+    />
     <Input
       defaultValue=""
       id="2"
@@ -80,6 +70,7 @@ exports[`Component: SearchInput ui with label 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -120,6 +111,7 @@ exports[`Component: SearchInput ui with label and children 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -148,14 +140,9 @@ exports[`Component: SearchInput ui with value 1`] = `
     className=""
     tag="div"
   >
-    <InputGroupAddon
-      addonType="prepend"
-      tag="div"
-    >
-      <Icon
-        icon="search"
-      />
-    </InputGroupAddon>
+    <AddonIcon
+      icon="search"
+    />
     <Input
       defaultValue=""
       id="4"
@@ -183,14 +170,9 @@ exports[`Component: SearchInput ui without clear button 1`] = `
     className=""
     tag="div"
   >
-    <InputGroupAddon
-      addonType="prepend"
-      tag="div"
-    >
-      <Icon
-        icon="search"
-      />
-    </InputGroupAddon>
+    <AddonIcon
+      icon="search"
+    />
     <Input
       defaultValue=""
       id="5"

--- a/src/core/Tabs/Tab/Tab.tsx
+++ b/src/core/Tabs/Tab/Tab.tsx
@@ -88,7 +88,7 @@ export function Tab({
       <NavLink active={active} onClick={onClick} disabled={disabled}>
         <div className="d-flex p-2 justify-content-center">
           {icon ? (
-            <Icon icon={icon} color={iconColor} className="mr-1" />
+            <Icon icon={icon} color={iconColor} className="me-1" />
           ) : null}
           {label}
         </div>

--- a/src/core/Tabs/Tab/__snapshots__/Tab.test.tsx.snap
+++ b/src/core/Tabs/Tab/__snapshots__/Tab.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Component: Tab ui with icon: Component: Tab => ui => with icon 1`] = `
       className="d-flex p-2 justify-content-center"
     >
       <Icon
-        className="mr-1"
+        className="me-1"
         icon="close"
       />
       test

--- a/src/core/Tag/Tag.scss
+++ b/src/core/Tag/Tag.scss
@@ -1,5 +1,5 @@
 .tag {
-  @extend .badge, .badge-pill, .badge-primary;
+  @extend .badge, .rounded-pill, .bg-primary;
 
   display: inline-block;
   margin-right: 0.1875rem;

--- a/src/core/TextButton/TextButton.tsx
+++ b/src/core/TextButton/TextButton.tsx
@@ -26,7 +26,7 @@ export default function TextButton({ onClick, children, className }: Props) {
   return (
     <u
       role="button"
-      className={`align-self-center clickable font-weight-lighter ${className ??
+      className={`align-self-center clickable fw-lighter ${className ??
         ''}`}
       onClick={onClick}
     >

--- a/src/core/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/src/core/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`component: TextButton ui standard 1`] = `
 <u
-  className="align-self-center clickable font-weight-lighter "
+  className="align-self-center clickable fw-lighter "
   onClick={[MockFunction]}
   role="button"
 >
@@ -12,7 +12,7 @@ exports[`component: TextButton ui standard 1`] = `
 
 exports[`component: TextButton ui with custom classname 1`] = `
 <u
-  className="align-self-center clickable font-weight-lighter yolo"
+  className="align-self-center clickable fw-lighter yolo"
   onClick={[MockFunction]}
   role="button"
 >

--- a/src/core/Toggle/Toggle.scss
+++ b/src/core/Toggle/Toggle.scss
@@ -1,6 +1,6 @@
 .toggle-container {
   @each $color, $value in $theme-colors {
-    &.toggle-#{$color} {
+    &.toggle-#{"" + $color} {
       input[type='checkbox'] {
         &:checked {
           &::after {

--- a/src/core/Toggle/Toggle.tsx
+++ b/src/core/Toggle/Toggle.tsx
@@ -64,7 +64,7 @@ export default function Toggle({
   return (
     <span className={toggleClasses}>
       {label ? (
-        <span className="toggle-label mr-2" onClick={() => onChange(!value)}>
+        <span className="toggle-label me-2" onClick={() => onChange(!value)}>
           {label}
         </span>
       ) : null}

--- a/src/core/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Component: Toggle ui with custom label: Component: Toggle => ui => with
   className="toggle-container toggle-primary"
 >
   <span
-    className="toggle-label mr-2"
+    className="toggle-label me-2"
     onClick={[Function]}
   >
     <Tooltip
@@ -29,7 +29,7 @@ exports[`Component: Toggle ui with text label: Component: Toggle => ui => with t
   className="toggle-container toggle-primary"
 >
   <span
-    className="toggle-label mr-2"
+    className="toggle-label me-2"
     onClick={[Function]}
   >
     test

--- a/src/core/lists/AttributeList/__snapshots__/AttributeList.test.tsx.snap
+++ b/src/core/lists/AttributeList/__snapshots__/AttributeList.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Component: AttributeList ui 1`] = `
 <ListGroup
   flush={true}
   horizontal={false}
+  numbered={false}
   tag="ul"
 >
   <AttributeView

--- a/src/form/Checkbox/Checkbox.stories.tsx
+++ b/src/form/Checkbox/Checkbox.stories.tsx
@@ -33,7 +33,7 @@ storiesOf('Form/Checkbox', module)
 
         {isSClass ? (
           <Alert color="success" className="d-flex">
-            <Icon icon="warning" className="mr-1" /> This hero is of the highest
+            <Icon icon="warning" className="me-1" /> This hero is of the highest
             caliber
           </Alert>
         ) : null}
@@ -56,7 +56,7 @@ storiesOf('Form/Checkbox', module)
 
         {isSClass ? (
           <Alert color="success" className="d-flex">
-            <Icon icon="warning" className="mr-1" /> This hero is of the highest
+            <Icon icon="warning" className="me-1" /> This hero is of the highest
             caliber
           </Alert>
         ) : null}
@@ -77,7 +77,7 @@ storiesOf('Form/Checkbox', module)
 
         {isSClass ? (
           <Alert color="success" className="d-flex">
-            <Icon icon="warning" className="mr-1" /> This hero is of the highest
+            <Icon icon="warning" className="me-1" /> This hero is of the highest
             caliber
           </Alert>
         ) : null}
@@ -95,7 +95,7 @@ storiesOf('Form/Checkbox', module)
             <div className="d-flex justify-content-between">
               <span>Is S class hero</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="An S class hero is a hero of the highest caliber"
               >
                 <Icon icon="info" />
@@ -109,7 +109,7 @@ storiesOf('Form/Checkbox', module)
 
         {isSClass ? (
           <Alert color="success" className="d-flex">
-            <Icon icon="warning" className="mr-1" /> This hero is of the highest
+            <Icon icon="warning" className="me-1" /> This hero is of the highest
             caliber
           </Alert>
         ) : null}

--- a/src/form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Component: Checkbox ui with placeholder: Component: Checkbox => ui => w
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -59,6 +60,7 @@ exports[`Component: Checkbox ui without placeholder: Component: Checkbox => ui =
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.stories.tsx
@@ -171,7 +171,7 @@ storiesOf('Form/CheckboxMultipleSelect', module)
         <p>
           Limit to northern provinces
           <Toggle
-            className="ml-2"
+            className="ms-2"
             color="primary"
             value={limitToNorthern}
             onChange={() => setLimitToNorthern(!limitToNorthern)}
@@ -355,7 +355,7 @@ storiesOf('Form/CheckboxMultipleSelect', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Friends</span>
-              <Tooltip className="ml-1" content="Provinces are nice to have">
+              <Tooltip className="ms-1" content="Provinces are nice to have">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
+++ b/src/form/CheckboxMultipleSelect/CheckboxMultipleSelect.tsx
@@ -174,7 +174,7 @@ export default function CheckboxMultipleSelect<T>(props: Props<T>) {
         <div className="d-flex flex-wrap">
           {chunks.map((options, index) => {
             return (
-              <div className="pr-3" key={index} style={{ flexBasis: '300px' }}>
+              <div className="pe-3" key={index} style={{ flexBasis: '300px' }}>
                 {renderOptions({ options, horizontal: false })}
               </div>
             );

--- a/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
+++ b/src/form/CheckboxMultipleSelect/__snapshots__/CheckboxMultipleSelect.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -43,6 +44,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -73,6 +75,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -103,6 +106,7 @@ exports[`Component: CheckboxMultipleSelect ui horizontal: Component: CheckboxMul
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -136,6 +140,7 @@ exports[`Component: CheckboxMultipleSelect ui loading: Component: CheckboxMultip
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -170,6 +175,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -186,7 +192,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
     className="d-flex flex-wrap"
   >
     <div
-      className="pr-3"
+      className="pe-3"
       key="0"
       style={
         Object {
@@ -210,6 +216,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -240,6 +247,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -270,6 +278,7 @@ exports[`Component: CheckboxMultipleSelect ui with value: Component: CheckboxMul
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -306,7 +315,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
     className="d-flex flex-wrap"
   >
     <div
-      className="pr-3"
+      className="pe-3"
       key="0"
       style={
         Object {
@@ -330,6 +339,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -360,6 +370,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -390,6 +401,7 @@ exports[`Component: CheckboxMultipleSelect ui without label: Component: Checkbox
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -425,6 +437,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -434,7 +447,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
     className="d-flex flex-wrap"
   >
     <div
-      className="pr-3"
+      className="pe-3"
       key="0"
       style={
         Object {
@@ -458,6 +471,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -488,6 +502,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
@@ -518,6 +533,7 @@ exports[`Component: CheckboxMultipleSelect ui without placeholder: Component: Ch
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >

--- a/src/form/ColorPicker/ColorPicker.stories.tsx
+++ b/src/form/ColorPicker/ColorPicker.stories.tsx
@@ -72,7 +72,7 @@ storiesOf('Form/ColorPicker', module)
               <div className="d-flex justify-content-between">
                 <span>Color</span>
                 <Tooltip
-                  className="ml-1"
+                  className="ms-1"
                   content="Use the color picker to select a color"
                 >
                   <Icon icon="info" />

--- a/src/form/ColorPicker/ColorPicker.tsx
+++ b/src/form/ColorPicker/ColorPicker.tsx
@@ -138,7 +138,7 @@ export default function ColorPicker(props: Props) {
       <div className="d-flex">
         {value ? (
           <div className="d-flex justify-content-between">
-            <div className="border p-1 mr-3">
+            <div className="border p-1 me-3">
               <div
                 id="color-picker-value"
                 className="h-100"
@@ -148,7 +148,7 @@ export default function ColorPicker(props: Props) {
             {canClear ? (
               <TextButton
                 onClick={() => onColorSelected(undefined)}
-                className="mr-3"
+                className="me-3"
               >
                 {t({
                   key: 'ColorPicker.CLEAR',
@@ -170,7 +170,7 @@ export default function ColorPicker(props: Props) {
                 setIsOpen(!isOpen);
               }}
             >
-              {icon ? <Icon icon={icon} className="mr-2 align-bottom" /> : null}
+              {icon ? <Icon icon={icon} className="me-2 align-bottom" /> : null}
               {placeholder}
             </Button>
           }

--- a/src/form/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/src/form/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: ColorPicker ui with selected value 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -28,7 +29,7 @@ exports[`Component: ColorPicker ui with selected value 1`] = `
       className="d-flex justify-content-between"
     >
       <div
-        className="border p-1 mr-3"
+        className="border p-1 me-3"
       >
         <div
           className="h-100"
@@ -42,7 +43,7 @@ exports[`Component: ColorPicker ui with selected value 1`] = `
         />
       </div>
       <TextButton
-        className="mr-3"
+        className="me-3"
         onClick={[Function]}
       >
         Clear
@@ -134,6 +135,7 @@ exports[`Component: ColorPicker ui without selected value 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/DateTimeInput/DateTimeInput.scss
+++ b/src/form/DateTimeInput/DateTimeInput.scss
@@ -5,7 +5,7 @@
   }
 
   &.with-modal > .rdt {
-    .input-group-append .material-icons {
+    .input-group .material-icons:last-child {
       margin-right: 0;
     }
 

--- a/src/form/DateTimeInput/DateTimeInput.stories.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.stories.tsx
@@ -102,7 +102,7 @@ storiesOf('Form/DateTimeInput', module)
             <>
               <span>Date of birth</span>
               <Tooltip
-                className="position-relative ml-1"
+                className="position-relative ms-1"
                 style={{ top: 5 }}
                 content="This is the date you where born on"
               >
@@ -405,7 +405,7 @@ storiesOf('Form/DateTimeInput', module)
                   <SubmitButton
                     onClick={() => handleSubmit()}
                     inProgress={submitting}
-                    className="float-right"
+                    className="float-end"
                   >
                     Submit
                   </SubmitButton>
@@ -521,7 +521,7 @@ storiesOf('Form/DateTimeInput', module)
                   <SubmitButton
                     onClick={() => handleSubmit()}
                     inProgress={submitting}
-                    className="float-right"
+                    className="float-end"
                   >
                     Submit
                   </SubmitButton>

--- a/src/form/DateTimeInput/DateTimeInput.tsx
+++ b/src/form/DateTimeInput/DateTimeInput.tsx
@@ -247,7 +247,7 @@ export function maskedInputGroup(props: unknown, onClick: () => void) {
     <InputGroup>
       <MaskedInput {...props} render={reactStrapInput} />
       <AddonButton onClick={onClick}>
-        <Icon icon="calendar_today" />
+        <Icon icon="calendar_today" className="d-block" />
       </AddonButton>
     </InputGroup>
   );

--- a/src/form/DateTimeInput/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/src/form/DateTimeInput/__snapshots__/DateTimeInput.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Component: DateTimeInput ui InputGroup: Component: DateTimeInput => ui 
     onClick={[Function]}
   >
     <Icon
+      className="d-block"
       icon="calendar_today"
     />
   </AddonButton>
@@ -44,6 +45,7 @@ exports[`Component: DateTimeInput ui with date picker in modal: Component: DateT
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -132,6 +134,7 @@ exports[`Component: DateTimeInput ui with date picker in modal: Component: DateT
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -230,6 +233,7 @@ exports[`Component: DateTimeInput ui with format error: Component: DateTimeInput
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -317,6 +321,7 @@ exports[`Component: DateTimeInput ui with label: Component: DateTimeInput => ui 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/FileInput/FileInput.scss
+++ b/src/form/FileInput/FileInput.scss
@@ -5,7 +5,7 @@
       cursor: pointer;
     }
   }
-  &.form-group input[type=file] {
+  input[type=file] {
     opacity: 0;
     position: absolute;
     top: 0;

--- a/src/form/FileInput/FileInput.stories.tsx
+++ b/src/form/FileInput/FileInput.stories.tsx
@@ -55,7 +55,7 @@ storiesOf('Form/FileInput', module)
             <div className="d-flex justify-content-between">
               <span>Upload a file here</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 style={{ zIndex: 101 }}
                 content="The file should be a plain text file"
               >

--- a/src/form/FileInput/FileInput.tsx
+++ b/src/form/FileInput/FileInput.tsx
@@ -94,7 +94,7 @@ export default class FileInput extends Component<Props> {
             color={value || valid === false ? 'danger' : 'primary'}
             onClick={noop}
           >
-            <Icon icon={value ? 'delete' : 'cloud_upload'} />
+            <Icon icon={value ? 'delete' : 'cloud_upload'} className="d-block" />
           </AddonButton>
         </InputGroup>
 

--- a/src/form/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/src/form/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: FileInput ui empty value: Component: FileInput => ui => empt
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -44,6 +45,7 @@ exports[`Component: FileInput ui empty value: Component: FileInput => ui => empt
       position="right"
     >
       <Icon
+        className="d-block"
         icon="cloud_upload"
       />
     </AddonButton>
@@ -68,6 +70,7 @@ exports[`Component: FileInput ui with value: Component: FileInput => ui => with 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -95,6 +98,7 @@ exports[`Component: FileInput ui with value: Component: FileInput => ui => with 
       position="right"
     >
       <Icon
+        className="d-block"
         icon="delete"
       />
     </AddonButton>
@@ -132,6 +136,7 @@ exports[`Component: FileInput ui without label: Component: FileInput => ui => wi
       position="right"
     >
       <Icon
+        className="d-block"
         icon="cloud_upload"
       />
     </AddonButton>
@@ -156,6 +161,7 @@ exports[`Component: FileInput ui without placeholder: Component: FileInput => ui
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -183,6 +189,7 @@ exports[`Component: FileInput ui without placeholder: Component: FileInput => ui
       position="right"
     >
       <Icon
+        className="d-block"
         icon="cloud_upload"
       />
     </AddonButton>

--- a/src/form/FormExample.stories.tsx
+++ b/src/form/FormExample.stories.tsx
@@ -161,7 +161,7 @@ export function TotalForm({
               <InfoTooltip
                 tooltip="The 'Key' represents a part of the entity which can only be
                 created once on create but not on edit."
-                className="ml-2"
+                className="ms-2"
               />
             </>
           }

--- a/src/form/IconPicker/IconPicker.stories.tsx
+++ b/src/form/IconPicker/IconPicker.stories.tsx
@@ -53,7 +53,7 @@ storiesOf('Form/IconPicker', module)
               <div className="d-flex justify-content-between">
                 <span>Icon</span>
                 <Tooltip
-                  className="ml-1"
+                  className="ms-1"
                   content="The icon will be used as an avatar"
                 >
                   <Icon icon="info" />

--- a/src/form/IconPicker/IconPicker.tsx
+++ b/src/form/IconPicker/IconPicker.tsx
@@ -117,13 +117,13 @@ export default function IconPicker(props: Props) {
               <div className="d-flex justify-content-between">
                 <Icon
                   id="icon-picker-value"
-                  className="pt-2 mr-3"
+                  className="pt-2 me-3"
                   icon={value}
                 />
                 {canClear ? (
                   <TextButton
                     onClick={() => onIconSelected(undefined)}
-                    className="mr-3"
+                    className="me-3"
                   >
                     {t({
                       key: 'IconPicker.CLEAR',
@@ -150,7 +150,7 @@ export default function IconPicker(props: Props) {
                   }}
                 >
                   {icon ? (
-                    <Icon icon={icon} className="mr-2 align-bottom" />
+                    <Icon icon={icon} className="me-2 align-bottom" />
                   ) : null}
                   {placeholder}
                 </Button>

--- a/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
+++ b/src/form/IconPicker/__snapshots__/IconPicker.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component: IconPicker ui no results 1`] = `
 <div
-  className="icon-picker form-group"
+  className="icon-picker mb-3"
   color="success"
 >
   <Label
@@ -14,6 +14,7 @@ exports[`Component: IconPicker ui no results 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -92,7 +93,7 @@ exports[`Component: IconPicker ui no results 1`] = `
 
 exports[`Component: IconPicker ui with selected value 1`] = `
 <div
-  className="icon-picker form-group"
+  className="icon-picker mb-3"
   color="success"
 >
   <Label
@@ -104,6 +105,7 @@ exports[`Component: IconPicker ui with selected value 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -116,12 +118,12 @@ exports[`Component: IconPicker ui with selected value 1`] = `
       className="d-flex justify-content-between"
     >
       <Icon
-        className="pt-2 mr-3"
+        className="pt-2 me-3"
         icon="3d_rotation"
         id="icon-picker-value"
       />
       <TextButton
-        className="mr-3"
+        className="me-3"
         onClick={[Function]}
       >
         Clear
@@ -805,7 +807,7 @@ exports[`Component: IconPicker ui with selected value 1`] = `
 
 exports[`Component: IconPicker ui without label 1`] = `
 <div
-  className="icon-picker form-group"
+  className="icon-picker mb-3"
   color="success"
 >
   <div
@@ -1489,7 +1491,7 @@ exports[`Component: IconPicker ui without label 1`] = `
 
 exports[`Component: IconPicker ui without selected value 1`] = `
 <div
-  className="icon-picker form-group"
+  className="icon-picker mb-3"
   color="success"
 >
   <Label
@@ -1501,6 +1503,7 @@ exports[`Component: IconPicker ui without selected value 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/ImageUpload/ImageUpload.scss
+++ b/src/form/ImageUpload/ImageUpload.scss
@@ -6,7 +6,7 @@
       cursor: pointer;
     }
   }
-  &.form-group input[type='file'] {
+  input[type='file'] {
     opacity: 0;
     position: absolute;
     top: 0;

--- a/src/form/ImageUpload/ImageUpload.stories.tsx
+++ b/src/form/ImageUpload/ImageUpload.stories.tsx
@@ -63,7 +63,7 @@ storiesOf('Form/ImageUpload', module)
             <div className="d-flex justify-content-between">
               <span>Profile photo</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 style={{ zIndex: 101 }}
                 content="You can edit the photo after you've selected it"
               >

--- a/src/form/ImageUpload/ImageUpload.tsx
+++ b/src/form/ImageUpload/ImageUpload.tsx
@@ -371,7 +371,7 @@ export default class ImageUpload extends Component<Props, State> {
           })}
         </Button>
         <Button
-          className="ml-1"
+          className="ms-1"
           onClick={() => this.resetFileInput()}
           color="danger"
           icon="delete"
@@ -399,14 +399,14 @@ export default class ImageUpload extends Component<Props, State> {
         />
 
         <Button
-          className="ml-1 mt-2"
+          className="ms-1 mt-2"
           onClick={() => this.rotateRight()}
           color="secondary"
           icon="rotate_right"
         />
 
         <Button
-          className="ml-3"
+          className="ms-3"
           onClick={() => this.resetFileInput()}
           color="secondary"
           icon="cancel"
@@ -419,7 +419,7 @@ export default class ImageUpload extends Component<Props, State> {
         </Button>
 
         <Button
-          className="ml-1"
+          className="ms-1"
           onClick={() => this.onCrop()}
           color="primary"
           icon="done"

--- a/src/form/ImageUpload/__snapshots__/ImageUpload.test.tsx.snap
+++ b/src/form/ImageUpload/__snapshots__/ImageUpload.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Component: ImageUpload ui edit as circle: Component: ImageUpload => ui 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -68,13 +69,13 @@ exports[`Component: ImageUpload ui edit as circle: Component: ImageUpload => ui 
         onClick={[Function]}
       />
       <Button
-        className="ml-1 mt-2"
+        className="ms-1 mt-2"
         color="secondary"
         icon="rotate_right"
         onClick={[Function]}
       />
       <Button
-        className="ml-3"
+        className="ms-3"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -82,7 +83,7 @@ exports[`Component: ImageUpload ui edit as circle: Component: ImageUpload => ui 
         Cancel
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="primary"
         icon="done"
         onClick={[Function]}
@@ -112,6 +113,7 @@ exports[`Component: ImageUpload ui edit as rect: Component: ImageUpload => ui =>
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -163,13 +165,13 @@ exports[`Component: ImageUpload ui edit as rect: Component: ImageUpload => ui =>
         onClick={[Function]}
       />
       <Button
-        className="ml-1 mt-2"
+        className="ms-1 mt-2"
         color="secondary"
         icon="rotate_right"
         onClick={[Function]}
       />
       <Button
-        className="ml-3"
+        className="ms-3"
         color="secondary"
         icon="cancel"
         onClick={[Function]}
@@ -177,7 +179,7 @@ exports[`Component: ImageUpload ui edit as rect: Component: ImageUpload => ui =>
         CANCEL
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="primary"
         icon="done"
         onClick={[Function]}
@@ -207,6 +209,7 @@ exports[`Component: ImageUpload ui file-selected as circle: Component: ImageUplo
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -238,7 +241,7 @@ exports[`Component: ImageUpload ui file-selected as circle: Component: ImageUplo
         CHANGE
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="danger"
         icon="delete"
         onClick={[Function]}
@@ -284,7 +287,7 @@ exports[`Component: ImageUpload ui file-selected as rect without label: Componen
         Change
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="danger"
         icon="delete"
         onClick={[Function]}
@@ -314,6 +317,7 @@ exports[`Component: ImageUpload ui file-selected as rect: Component: ImageUpload
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -345,7 +349,7 @@ exports[`Component: ImageUpload ui file-selected as rect: Component: ImageUpload
         Change
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="danger"
         icon="delete"
         onClick={[Function]}
@@ -375,6 +379,7 @@ exports[`Component: ImageUpload ui no-file: Component: ImageUpload => ui => no-f
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >

--- a/src/form/Input/Input.stories.tsx
+++ b/src/form/Input/Input.stories.tsx
@@ -115,7 +115,7 @@ storiesOf('Form/Input', module)
             <div className="d-flex justify-content-between">
               <span>First name</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="Your first name is on your birth certificate"
               >
                 <Icon icon="info" />

--- a/src/form/Input/Input.test.tsx
+++ b/src/form/Input/Input.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import Input, { reactStrapInput, InputMask } from './Input';
+import Input, { reactStrapInput, InputMask, InputType } from './Input';
 
-import { InputType } from 'reactstrap/lib/Input';
 import { Addon } from '../addons/Addon/Addon';
 
 const mask: InputMask = [

--- a/src/form/Input/Input.tsx
+++ b/src/form/Input/Input.tsx
@@ -1,13 +1,40 @@
 import React, { ChangeEvent } from 'react';
 import RTMaskedInput from 'react-text-mask';
 import { FormGroup, Input as RSInput, InputGroup, Label } from 'reactstrap';
-import { InputType } from 'reactstrap/lib/Input';
 import withJarb from '../withJarb/withJarb';
 
 export type InputMask = (string | RegExp)[];
 
 import { FieldCompatible } from '../types';
 import { useId } from '../../hooks/useId/useId';
+
+export type InputType =
+  | 'text'
+  | 'email'
+  | 'select'
+  | 'file'
+  | 'radio'
+  | 'checkbox'
+  | 'switch'
+  | 'textarea'
+  | 'button'
+  | 'reset'
+  | 'submit'
+  | 'date'
+  | 'datetime-local'
+  | 'hidden'
+  | 'image'
+  | 'month'
+  | 'number'
+  | 'range'
+  | 'search'
+  | 'tel'
+  | 'url'
+  | 'week'
+  | 'password'
+  | 'datetime'
+  | 'time'
+  | 'color';
 
 export type Props = FieldCompatible<string, string> & {
   /**

--- a/src/form/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/form/Input/__snapshots__/Input.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: Input ui addon default: Component: Input => addon position d
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -57,6 +58,7 @@ exports[`Component: Input ui addon left: Component: Input => addon position left
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -100,6 +102,7 @@ exports[`Component: Input ui addon right: Component: Input => addon position rig
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -143,6 +146,7 @@ exports[`Component: Input ui defaults to text: Component: Input => ui => default
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -178,6 +182,7 @@ exports[`Component: Input ui is invalid: Component: Input => is invalid 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -214,6 +219,7 @@ exports[`Component: Input ui is valid: Component: Input => is valid 1`] = `
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -249,6 +255,7 @@ exports[`Component: Input ui type email: Component: Input => ui => type email 1`
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -284,6 +291,7 @@ exports[`Component: Input ui with mask: Component: Input => ui => with mask 1`] 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -358,6 +366,7 @@ exports[`Component: Input ui without placeholder: Component: Input => ui => with
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/ModalPicker/ModalPicker.tsx
+++ b/src/form/ModalPicker/ModalPicker.tsx
@@ -213,7 +213,7 @@ export default function ModalPicker<T>(props: Props<T>) {
 
         <div>
           <Button
-            className="ml-1"
+            className="ms-1"
             color="secondary"
             onClick={() => closeModal()}
           >
@@ -224,7 +224,7 @@ export default function ModalPicker<T>(props: Props<T>) {
             })}
           </Button>
           <Button
-            className="ml-1"
+            className="ms-1"
             color="primary"
             onClick={() => modalSaved()}
             disabled={!!!selected}

--- a/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
+++ b/src/form/ModalPicker/ModalPickerOpener/ModalPickerOpener.tsx
@@ -82,8 +82,8 @@ export function ModalPickerOpener<T>(props: Props<T>) {
   });
 
   const buttonClassName = classNames('flex-grow-0', 'flex-shrink-0', {
-    'mr-3': hasValue && alignButton === 'left',
-    'ml-3': hasValue && alignButton !== 'left'
+    'me-3': hasValue && alignButton === 'left',
+    'ms-3': hasValue && alignButton !== 'left'
   });
 
   // @ts-expect-error Accept that DisplayValues is sometimes an array and sometimes not
@@ -94,7 +94,7 @@ export function ModalPickerOpener<T>(props: Props<T>) {
       {displayValue}
 
       {hasValue && onClear ? (
-        <TextButton onClick={onClear} className="ml-3">
+        <TextButton onClick={onClear} className="ms-3">
           {t({
             overrideText: text.clear,
             key: 'ModalPickerOpener.CLEAR',
@@ -104,7 +104,7 @@ export function ModalPickerOpener<T>(props: Props<T>) {
       ) : null}
 
       <Button color="primary" onClick={openModal} className={buttonClassName}>
-        {icon ? <Icon icon={icon} className="mr-2 align-bottom" /> : null}
+        {icon ? <Icon icon={icon} className="me-2 align-bottom" /> : null}
         {label}
       </Button>
     </div>

--- a/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
+++ b/src/form/ModalPicker/ModalPickerOpener/__snapshots__/ModalPickerOpener.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`Component: ModalPickerOpener ui button aligned left with values: Compon
     ADMIN@42.NL
   </span>
   <TextButton
-    className="ml-3"
+    className="ms-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 mr-3"
+    className="flex-grow-0 flex-shrink-0 me-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -47,13 +47,13 @@ exports[`Component: ModalPickerOpener ui button aligned right with values: Compo
     ADMIN@42.NL
   </span>
   <TextButton
-    className="ml-3"
+    className="ms-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 ml-3"
+    className="flex-grow-0 flex-shrink-0 ms-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -86,13 +86,13 @@ exports[`Component: ModalPickerOpener ui tooltip: Component: ModalPickerOpener =
     ADMIN@42.NL
   </span>
   <TextButton
-    className="ml-3"
+    className="ms-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 ml-3"
+    className="flex-grow-0 flex-shrink-0 ms-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"
@@ -110,13 +110,13 @@ exports[`Component: ModalPickerOpener ui with values: Component: ModalPickerOpen
     ADMIN@42.NL
   </span>
   <TextButton
-    className="ml-3"
+    className="ms-3"
     onClick={[MockFunction]}
   >
     Clear
   </TextButton>
   <Button
-    className="flex-grow-0 flex-shrink-0 ml-3"
+    className="flex-grow-0 flex-shrink-0 ms-3"
     color="primary"
     onClick={[MockFunction]}
     tag="button"

--- a/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
+++ b/src/form/ModalPicker/__snapshots__/ModalPicker.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
   zIndex={1050}
 >
   <ModalHeader
-    charCode={215}
     closeAriaLabel="Close"
     tag="h5"
     toggle={[Function]}
@@ -51,6 +50,7 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -63,6 +63,7 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -84,6 +85,7 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -96,6 +98,7 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -170,7 +173,7 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
     </Button>
     <div>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         onClick={[Function]}
         tag="button"
@@ -178,7 +181,7 @@ exports[`Component: ModalPicker ui with addButton and search: Component: ModalPi
         Cancel
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="primary"
         disabled={false}
         onClick={[Function]}
@@ -222,7 +225,6 @@ exports[`Component: ModalPicker ui without addButton and search: Component: Moda
   zIndex={1050}
 >
   <ModalHeader
-    charCode={215}
     closeAriaLabel="Close"
     tag="h5"
     toggle={[Function]}
@@ -243,6 +245,7 @@ exports[`Component: ModalPicker ui without addButton and search: Component: Moda
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -255,6 +258,7 @@ exports[`Component: ModalPicker ui without addButton and search: Component: Moda
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -323,7 +327,7 @@ exports[`Component: ModalPicker ui without addButton and search: Component: Moda
     <div />
     <div>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="secondary"
         onClick={[Function]}
         tag="button"
@@ -331,7 +335,7 @@ exports[`Component: ModalPicker ui without addButton and search: Component: Moda
         Cancel
       </Button>
       <Button
-        className="ml-1"
+        className="ms-1"
         color="primary"
         disabled={false}
         onClick={[Function]}

--- a/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
+++ b/src/form/ModalPicker/multiple/ModalPickerMultiple.stories.tsx
@@ -211,7 +211,7 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
         <p>
           Limit to northern provinces
           <Toggle
-            className="ml-2"
+            className="ms-2"
             color="primary"
             value={limitToNorthern}
             onChange={() => setLimitToNorthern(!limitToNorthern)}
@@ -253,7 +253,7 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
         <p>
           Limit to northern provinces
           <Toggle
-            className="ml-2"
+            className="ms-2"
             color="primary"
             value={limitToNorthern}
             onChange={() => setLimitToNorthern(!limitToNorthern)}
@@ -490,7 +490,7 @@ storiesOf('Form/ModalPicker/ModalPickerMultiple', module)
             <div className="d-flex justify-content-between">
               <span>Friends</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="It is nice to have lots of friends"
               >
                 <Icon icon="info" />

--- a/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
+++ b/src/form/ModalPicker/multiple/__snapshots__/ModalPickerMultiple.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -115,6 +116,7 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -127,6 +129,7 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -152,6 +155,7 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -179,6 +183,7 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -206,6 +211,7 @@ exports[`Component: ModalPickerMultiple ui renderValue should be able to use cus
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -256,6 +262,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -356,6 +363,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -368,6 +376,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -393,6 +402,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -420,6 +430,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -447,6 +458,7 @@ exports[`Component: ModalPickerMultiple ui should render button left: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -479,6 +491,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -579,6 +592,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -591,6 +605,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -616,6 +631,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -643,6 +659,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -670,6 +687,7 @@ exports[`Component: ModalPickerMultiple ui should render button right with value
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -702,6 +720,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -788,6 +807,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -800,6 +820,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -825,6 +846,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -852,6 +874,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -879,6 +902,7 @@ exports[`Component: ModalPickerMultiple ui should render button right without va
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1005,6 +1029,7 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -1017,6 +1042,7 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1042,6 +1068,7 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1069,6 +1096,7 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1096,6 +1124,7 @@ exports[`Component: ModalPickerMultiple ui should render properly without label:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1128,6 +1157,7 @@ exports[`Component: ModalPickerMultiple ui should render the options with the co
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -1262,6 +1292,7 @@ exports[`Component: ModalPickerMultiple ui should render the options with the co
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -1274,6 +1305,7 @@ exports[`Component: ModalPickerMultiple ui should render the options with the co
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1304,6 +1336,7 @@ exports[`Component: ModalPickerMultiple ui should render the options with the co
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1331,6 +1364,7 @@ exports[`Component: ModalPickerMultiple ui should render the options with the co
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1358,6 +1392,7 @@ exports[`Component: ModalPickerMultiple ui should render the options with the co
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1390,6 +1425,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -1499,6 +1535,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -1511,6 +1548,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1536,6 +1574,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1563,6 +1602,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1590,6 +1630,7 @@ exports[`Component: ModalPickerMultiple ui should render: Component: ModalPicker
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >

--- a/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
+++ b/src/form/ModalPicker/single/ModalPickerSingle.stories.tsx
@@ -396,7 +396,7 @@ storiesOf('Form/ModalPicker/ModalPickerSingle', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Subject</span>
-              <Tooltip className="ml-1" content="The province you live in">
+              <Tooltip className="ms-1" content="The province you live in">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
+++ b/src/form/ModalPicker/single/__snapshots__/ModalPickerSingle.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: ModalPickerSingle ui renderValue should be able to use custo
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -112,6 +113,7 @@ exports[`Component: ModalPickerSingle ui renderValue should be able to use custo
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -139,6 +141,7 @@ exports[`Component: ModalPickerSingle ui renderValue should be able to use custo
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -166,6 +169,7 @@ exports[`Component: ModalPickerSingle ui renderValue should be able to use custo
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -216,6 +220,7 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -313,6 +318,7 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -340,6 +346,7 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -367,6 +374,7 @@ exports[`Component: ModalPickerSingle ui should render button left: Component: M
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -399,6 +407,7 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -496,6 +505,7 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -523,6 +533,7 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -550,6 +561,7 @@ exports[`Component: ModalPickerSingle ui should render button right with value: 
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -582,6 +594,7 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -667,6 +680,7 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -694,6 +708,7 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -721,6 +736,7 @@ exports[`Component: ModalPickerSingle ui should render button right without valu
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -834,6 +850,7 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -861,6 +878,7 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -888,6 +906,7 @@ exports[`Component: ModalPickerSingle ui should render without label: Component:
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -920,6 +939,7 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -1016,6 +1036,7 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1043,6 +1064,7 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >
@@ -1070,6 +1092,7 @@ exports[`Component: ModalPickerSingle ui should render: Component: ModalPickerSi
             "md",
             "lg",
             "xl",
+            "xxl",
           ]
         }
       >

--- a/src/form/NewPasswordInput/NewPasswordInput.stories.tsx
+++ b/src/form/NewPasswordInput/NewPasswordInput.stories.tsx
@@ -81,7 +81,7 @@ storiesOf('Form/NewPasswordInput', module)
             <div className="d-flex justify-content-between">
               <span>Password</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="Your password should be secret"
               >
                 <Icon icon="info" />

--- a/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
+++ b/src/form/NewPasswordInput/PasswordStrength/PasswordStrength.tsx
@@ -62,7 +62,7 @@ export default function PasswordStrength(props: Props) {
                 icon={isCompliant ? 'check_circle' : 'cancel'}
                 color={isCompliant ? 'success' : 'danger'}
                 size={16}
-                className="align-bottom mt-1 mb-1 mr-3"
+                className="align-bottom mt-1 mb-1 me-3"
               />
               <div>{t(labelForRule(rule, minimumLength))}</div>
             </div>

--- a/src/form/NewPasswordInput/PasswordStrength/__snapshots__/PasswordStrength.test.tsx.snap
+++ b/src/form/NewPasswordInput/PasswordStrength/__snapshots__/PasswordStrength.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Component: PasswordStrength ui default: Component: PasswordStrength => 
       key="lowercase"
     >
       <Icon
-        className="align-bottom mt-1 mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 me-3"
         color="danger"
         icon="cancel"
         size={16}
@@ -34,7 +34,7 @@ exports[`Component: PasswordStrength ui default: Component: PasswordStrength => 
       key="minimumLength"
     >
       <Icon
-        className="align-bottom mt-1 mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 me-3"
         color="danger"
         icon="cancel"
         size={16}
@@ -57,7 +57,7 @@ exports[`Component: PasswordStrength ui without meter: Component: PasswordStreng
       key="lowercase"
     >
       <Icon
-        className="align-bottom mt-1 mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 me-3"
         color="danger"
         icon="cancel"
         size={16}
@@ -71,7 +71,7 @@ exports[`Component: PasswordStrength ui without meter: Component: PasswordStreng
       key="minimumLength"
     >
       <Icon
-        className="align-bottom mt-1 mb-1 mr-3"
+        className="align-bottom mt-1 mb-1 me-3"
         color="danger"
         icon="cancel"
         size={16}

--- a/src/form/PlainTextFormControl/__snapshots__/PlainTextFormControl.test.tsx.snap
+++ b/src/form/PlainTextFormControl/__snapshots__/PlainTextFormControl.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Component: PlainTextFormControl ui default: Component: PlainTextFormCon
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/RadioGroup/RadioGroup.stories.tsx
+++ b/src/form/RadioGroup/RadioGroup.stories.tsx
@@ -200,7 +200,7 @@ storiesOf('Form/RadioGroup', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Subject</span>
-              <Tooltip className="ml-1" content="The province you live in">
+              <Tooltip className="ms-1" content="The province you live in">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/form/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -61,6 +62,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -91,6 +93,7 @@ exports[`Component: RadioGroup ui horizontal: Component: RadioGroup => ui => hor
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -162,6 +165,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -192,6 +196,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -222,6 +227,7 @@ exports[`Component: RadioGroup ui with value: Component: RadioGroup => ui => wit
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -268,6 +274,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -298,6 +305,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -328,6 +336,7 @@ exports[`Component: RadioGroup ui without label: Component: RadioGroup => ui => 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -370,6 +379,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -400,6 +410,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >
@@ -430,6 +441,7 @@ exports[`Component: RadioGroup ui without placeholder: Component: RadioGroup => 
           "md",
           "lg",
           "xl",
+          "xxl",
         ]
       }
     >

--- a/src/form/Select/Select.stories.tsx
+++ b/src/form/Select/Select.stories.tsx
@@ -200,7 +200,7 @@ storiesOf('Form/Select', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Subject</span>
-              <Tooltip className="ml-1" content="The province you live in">
+              <Tooltip className="ms-1" content="The province you live in">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FormGroup, Input as RSInput, Label } from 'reactstrap';
-import { InputType } from 'reactstrap/lib/Input';
 
 import withJarb from '../withJarb/withJarb';
 import { t } from '../../utilities/translation/translation';
@@ -14,6 +13,7 @@ import Loading from '../../core/Loading/Loading';
 import { useId } from '../../hooks/useId/useId';
 import { FieldCompatible } from '../types';
 import { alwaysTrue } from '../utils';
+import { InputType } from '../Input/Input';
 
 export type Text = {
   /**

--- a/src/form/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/form/Select/__snapshots__/Select.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Component: Select ui loading: Component: Select => ui => loading 1`] = 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -44,6 +45,7 @@ exports[`Component: Select ui with value: Component: Select => ui => with value 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -146,6 +148,7 @@ exports[`Component: Select ui without placeholder: Component: Select => ui => wi
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/TextEditor/TextEditor.stories.tsx
+++ b/src/form/TextEditor/TextEditor.stories.tsx
@@ -74,7 +74,7 @@ storiesOf('Form/TextEditor', module)
             <div className="d-flex justify-content-between">
               <span>Description</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="Be sure to secure against XSS attacks"
               >
                 <Icon icon="info" />
@@ -144,7 +144,7 @@ storiesOf('Form/TextEditor', module)
           }
 
           const span = document.createElement('span');
-          span.className = 'd-inline-block mr-3';
+          span.className = 'd-inline-block me-3';
           span.innerText = 'Insert placeholder';
           label.insertBefore(span, label.firstChild);
         });

--- a/src/form/TextEditor/__snapshots__/TextEditor.test.tsx.snap
+++ b/src/form/TextEditor/__snapshots__/TextEditor.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`Component: TextEditor ui with value: Component: textEditor => ui => wit
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -148,6 +149,7 @@ exports[`Component: TextEditor ui without placeholder: Component: textEditor => 
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/Textarea/Textarea.stories.tsx
+++ b/src/form/Textarea/Textarea.stories.tsx
@@ -50,7 +50,7 @@ storiesOf('Form/Textarea', module)
             <div className="d-flex justify-content-between">
               <span>Description</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="The description is shown inside a tooltip"
               >
                 <Icon icon="info" />

--- a/src/form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: Textarea ui with value: Component: textarea => ui => with va
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -69,6 +70,7 @@ exports[`Component: Textarea ui without placeholder: Component: textarea => ui =
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
+++ b/src/form/Typeahead/multiple/TypeaheadMultiple.stories.tsx
@@ -168,7 +168,7 @@ storiesOf('Form/Typeahead/JarbTypeaheadMultiple', module)
         <p>
           Limit to northern provinces
           <Toggle
-            className="ml-2"
+            className="ms-2"
             color="primary"
             value={limitToNorthern}
             onChange={() => setLimitToNorthern(!limitToNorthern)}
@@ -225,7 +225,7 @@ storiesOf('Form/Typeahead/JarbTypeaheadMultiple', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Friends</span>
-              <Tooltip className="ml-1" content="Provinces are nice to have">
+              <Tooltip className="ms-1" content="Provinces are nice to have">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
+++ b/src/form/Typeahead/multiple/__snapshots__/TypeaheadMultiple.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Component: TypeaheadMultiple ui async with a custom pageSize of 2 optio
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -106,6 +107,7 @@ exports[`Component: TypeaheadMultiple ui async with the default pageSize of 10 o
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -201,6 +203,7 @@ exports[`Component: TypeaheadMultiple ui with a custom pagination text: Componen
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -290,6 +293,7 @@ exports[`Component: TypeaheadMultiple ui with the default pagination text: Compo
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -379,6 +383,7 @@ exports[`Component: TypeaheadMultiple ui with value: Component: TypeaheadMultipl
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -569,6 +574,7 @@ exports[`Component: TypeaheadMultiple ui without placeholder: Component: Typeahe
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
+++ b/src/form/Typeahead/single/TypeaheadSingle.stories.tsx
@@ -197,7 +197,7 @@ storiesOf('Form/Typeahead/JarbTypeaheadSingle', module)
           label={
             <div className="d-flex justify-content-between">
               <span>Subject</span>
-              <Tooltip className="ml-1" content="The province you live in">
+              <Tooltip className="ms-1" content="The province you live in">
                 <Icon icon="info" />
               </Tooltip>
             </div>

--- a/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
+++ b/src/form/Typeahead/single/__snapshots__/TypeaheadSingle.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Component: TypeaheadSingle ui async with a custom pageSize of 2 options
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -95,6 +96,7 @@ exports[`Component: TypeaheadSingle ui async with the default pageSize of 10 opt
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -188,6 +190,7 @@ exports[`Component: TypeaheadSingle ui with a custom pagination text: Component:
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -275,6 +278,7 @@ exports[`Component: TypeaheadSingle ui with the default pagination text: Compone
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -362,6 +366,7 @@ exports[`Component: TypeaheadSingle ui with value: Component: TypeaheadSingle =>
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >
@@ -552,6 +557,7 @@ exports[`Component: TypeaheadSingle ui without placeholder: Component: Typeahead
         "md",
         "lg",
         "xl",
+        "xxl",
       ]
     }
   >

--- a/src/form/ValuePicker/ValuePicker.stories.tsx
+++ b/src/form/ValuePicker/ValuePicker.stories.tsx
@@ -168,7 +168,7 @@ storiesOf('Form/ValuePicker/multiple', module)
             <div className="d-flex justify-content-between">
               <span>Best friend</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="Don't be jealous of your best friends wife"
               >
                 <Icon icon="info" />
@@ -295,10 +295,10 @@ storiesOf('Form/ValuePicker/single', module)
         />
 
         <p>Use these buttons to trigger a morph</p>
-        <Button className="mr-1" onClick={() => setSize('small')}>
+        <Button className="me-1" onClick={() => setSize('small')}>
           Small
         </Button>
-        <Button className="mr-1" onClick={() => setSize('medium')}>
+        <Button className="me-1" onClick={() => setSize('medium')}>
           Medium
         </Button>
         <Button onClick={() => setSize('large')}>Large</Button>
@@ -328,10 +328,10 @@ storiesOf('Form/ValuePicker/single', module)
         />
 
         <p>Use these buttons to trigger a morph</p>
-        <Button className="mr-1" onClick={() => setSize('small')}>
+        <Button className="me-1" onClick={() => setSize('small')}>
           Small
         </Button>
-        <Button className="mr-1" onClick={() => setSize('medium')}>
+        <Button className="me-1" onClick={() => setSize('medium')}>
           Medium
         </Button>
         <Button onClick={() => setSize('large')}>Large</Button>
@@ -359,10 +359,10 @@ storiesOf('Form/ValuePicker/single', module)
         />
 
         <p>Use these buttons to trigger a morph</p>
-        <Button className="mr-1" onClick={() => setSize('small')}>
+        <Button className="me-1" onClick={() => setSize('small')}>
           Small
         </Button>
-        <Button className="mr-1" onClick={() => setSize('medium')}>
+        <Button className="me-1" onClick={() => setSize('medium')}>
           Medium
         </Button>
         <Button onClick={() => setSize('large')}>Large</Button>
@@ -385,7 +385,7 @@ storiesOf('Form/ValuePicker/single', module)
             <div className="d-flex justify-content-between">
               <span>Best friend</span>
               <Tooltip
-                className="ml-1"
+                className="ms-1"
                 content="Don't be jealous of your best friends wife"
               >
                 <Icon icon="info" />
@@ -401,10 +401,10 @@ storiesOf('Form/ValuePicker/single', module)
         />
 
         <p>Use these buttons to trigger a morph</p>
-        <Button className="mr-1" onClick={() => setSize('small')}>
+        <Button className="me-1" onClick={() => setSize('small')}>
           Small
         </Button>
-        <Button className="mr-1" onClick={() => setSize('medium')}>
+        <Button className="me-1" onClick={() => setSize('medium')}>
           Medium
         </Button>
         <Button onClick={() => setSize('large')}>Large</Button>
@@ -457,7 +457,7 @@ storiesOf('Form/ValuePicker/single', module)
         />
 
         <p>Use these buttons to trigger a morph</p>
-        <Button className="mr-1" onClick={() => setSize('small')}>
+        <Button className="me-1" onClick={() => setSize('small')}>
           Small
         </Button>
         <Button onClick={() => setSize('large')}>Large</Button>
@@ -491,10 +491,10 @@ storiesOf('Form/ValuePicker/single', module)
           }}
         />
         <p>Use these buttons to trigger a morph</p>
-        <Button className="mr-1" onClick={() => setSize('small')}>
+        <Button className="me-1" onClick={() => setSize('small')}>
           Small
         </Button>
-        <Button className="mr-1" onClick={() => setSize('medium')}>
+        <Button className="me-1" onClick={() => setSize('medium')}>
           Medium
         </Button>
         <Button onClick={() => setSize('large')}>Large</Button>

--- a/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
+++ b/src/form/ValuePicker/__snapshots__/ValuePicker.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
       tag="div"
     >
       <div
-        className="form-group"
+        className="mb-3"
       >
         <Label
           for="bestFriend"
@@ -99,11 +99,12 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
           <label
-            className=""
+            className="form-label"
             htmlFor="bestFriend"
           >
             Best friend
@@ -120,7 +121,7 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
           className="d-flex flex-wrap"
         >
           <div
-            className="pr-3"
+            className="pe-3"
             key="0"
             style={
               Object {
@@ -147,11 +148,12 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                       "md",
                       "lg",
                       "xl",
+                      "xxl",
                     ]
                   }
                 >
                   <label
-                    className="form-check-label"
+                    className="form-check-label form-label"
                   >
                     <Input
                       checked={false}
@@ -194,11 +196,12 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                       "md",
                       "lg",
                       "xl",
+                      "xxl",
                     ]
                   }
                 >
                   <label
-                    className="form-check-label"
+                    className="form-check-label form-label"
                   >
                     <Input
                       checked={false}
@@ -241,11 +244,12 @@ exports[`Component: ValuePicker multiple when CheckboxMultipleSelect should rend
                       "md",
                       "lg",
                       "xl",
+                      "xxl",
                     ]
                   }
                 >
                   <label
-                    className="form-check-label"
+                    className="form-check-label form-label"
                   >
                     <Input
                       checked={false}
@@ -364,7 +368,7 @@ exports[`Component: ValuePicker multiple when ModalPickerMultiple should render 
       tag="div"
     >
       <div
-        className="form-group"
+        className="mb-3"
       >
         <Label
           for="bestFriend"
@@ -376,11 +380,12 @@ exports[`Component: ValuePicker multiple when ModalPickerMultiple should render 
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
           <label
-            className=""
+            className="form-label"
             htmlFor="bestFriend"
           >
             Best friend
@@ -412,11 +417,11 @@ exports[`Component: ValuePicker multiple when ModalPickerMultiple should render 
                 type="button"
               >
                 <Icon
-                  className="mr-2 align-bottom"
+                  className="me-2 align-bottom"
                   icon="face"
                 >
                   <i
-                    className="icon mr-2 align-bottom material-icons"
+                    className="icon me-2 align-bottom material-icons"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -672,7 +677,7 @@ exports[`Component: ValuePicker single when ModalPickerSingle should render a \`
       tag="div"
     >
       <div
-        className="form-group"
+        className="mb-3"
       >
         <Label
           for="bestFriend"
@@ -684,11 +689,12 @@ exports[`Component: ValuePicker single when ModalPickerSingle should render a \`
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
           <label
-            className=""
+            className="form-label"
             htmlFor="bestFriend"
           >
             Best friend
@@ -720,11 +726,11 @@ exports[`Component: ValuePicker single when ModalPickerSingle should render a \`
                 type="button"
               >
                 <Icon
-                  className="mr-2 align-bottom"
+                  className="me-2 align-bottom"
                   icon="face"
                 >
                   <i
-                    className="icon mr-2 align-bottom material-icons"
+                    className="icon me-2 align-bottom material-icons"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -917,7 +923,7 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
       tag="fieldset"
     >
       <fieldset
-        className="radio-group  form-group"
+        className="radio-group  mb-3"
       >
         <legend>
           Best friend
@@ -948,11 +954,12 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
                   "md",
                   "lg",
                   "xl",
+                  "xxl",
                 ]
               }
             >
               <label
-                className="form-check-label"
+                className="form-check-label form-label"
               >
                 <Input
                   checked={false}
@@ -995,11 +1002,12 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
                   "md",
                   "lg",
                   "xl",
+                  "xxl",
                 ]
               }
             >
               <label
-                className="form-check-label"
+                className="form-check-label form-label"
               >
                 <Input
                   checked={false}
@@ -1042,11 +1050,12 @@ exports[`Component: ValuePicker single when RadioGroup should render a \`RadioGr
                   "md",
                   "lg",
                   "xl",
+                  "xxl",
                 ]
               }
             >
               <label
-                className="form-check-label"
+                className="form-check-label form-label"
               >
                 <Input
                   checked={false}
@@ -1163,7 +1172,7 @@ exports[`Component: ValuePicker single when Select should render a \`Select\` co
       tag="div"
     >
       <div
-        className="form-group"
+        className="mb-3"
       >
         <Label
           for="bestFriend"
@@ -1175,11 +1184,12 @@ exports[`Component: ValuePicker single when Select should render a \`Select\` co
               "md",
               "lg",
               "xl",
+              "xxl",
             ]
           }
         >
           <label
-            className=""
+            className="form-label"
             htmlFor="bestFriend"
           >
             Best friend
@@ -1194,7 +1204,7 @@ exports[`Component: ValuePicker single when Select should render a \`Select\` co
           type="select"
         >
           <select
-            className="showing-placeholder form-control"
+            className="showing-placeholder form-select"
             id="bestFriend"
             onBlur={[MockFunction]}
             onChange={[Function]}

--- a/src/form/addons/Addon/Addon.test.tsx
+++ b/src/form/addons/Addon/Addon.test.tsx
@@ -17,27 +17,4 @@ describe('Component: Addon', () => {
 
     expect(toJson(addon)).toMatchSnapshot('Component: Addon');
   });
-
-  describe('position behavior', () => {
-    it('should use addonType "append" when right', () => {
-      const { addon } = setup({ position: 'right' });
-
-      // @ts-expect-error Test mock
-      expect(addon.find('InputGroupAddon').props().addonType).toBe('append');
-    });
-
-    it('should use addonType "prepend" when no position is given', () => {
-      const { addon } = setup({ position: undefined });
-
-      // @ts-expect-error Test mock
-      expect(addon.find('InputGroupAddon').props().addonType).toBe('prepend');
-    });
-
-    it('should use addonType "prepend" when left', () => {
-      const { addon } = setup({ position: 'left' });
-
-      // @ts-expect-error Test mock
-      expect(addon.find('InputGroupAddon').props().addonType).toBe('prepend');
-    });
-  });
 });

--- a/src/form/addons/Addon/Addon.tsx
+++ b/src/form/addons/Addon/Addon.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import { InputGroupAddon } from 'reactstrap';
 
 export type AddonPosition = 'left' | 'right';
 
@@ -16,12 +15,6 @@ export type Props = {
    * Defaults to 'left'
    */
   position?: AddonPosition;
-
-  /**
-   * Optional extra CSS class you want to add to the component.
-   * Useful for styling the component.
-   */
-  className?: string;
 };
 
 /**
@@ -32,12 +25,10 @@ export type Props = {
  * is using an addon with the value of "km" to show that the input's
  * unit is a kilometer.
  */
-export function Addon({ children, position = 'left', className }: Props) {
-  const addonType = position === 'left' ? 'prepend' : 'append';
-
+export function Addon({ children }: Props) {
   return (
-    <InputGroupAddon className={className} addonType={addonType}>
+    <>
       {children}
-    </InputGroupAddon>
+    </>
   );
 }

--- a/src/form/addons/Addon/__snapshots__/Addon.test.tsx.snap
+++ b/src/form/addons/Addon/__snapshots__/Addon.test.tsx.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component: Addon ui: Component: Addon 1`] = `
-<InputGroupAddon
-  addonType="prepend"
-  tag="div"
->
+<Fragment>
   42
-</InputGroupAddon>
+</Fragment>
 `;

--- a/src/form/addons/AddonButton/AddonButton.tsx
+++ b/src/form/addons/AddonButton/AddonButton.tsx
@@ -24,6 +24,12 @@ export type Props = Omit<AddonProps, 'position'> & {
    * Callback for when the addon is clicked.
    */
   onClick: () => void;
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
 };
 
 /**
@@ -38,13 +44,14 @@ export function AddonButton({
   className
 }: Props) {
   return (
-    <Addon className={className} position={position}>
+    <Addon position={position}>
       <Button
         // Tabindex set to -1 to avoid tabbing through it
         tabIndex={-1}
         type="button"
         color={!color ? 'primary' : color}
         onClick={onClick}
+        className={className}
       >
         {children}
       </Button>

--- a/src/form/addons/AddonIcon/AddonIcon.tsx
+++ b/src/form/addons/AddonIcon/AddonIcon.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 import { Icon, IconType } from '../../..';
 
 import { Addon, Props as AddonProps } from '../Addon/Addon';
+import { InputGroupText } from 'reactstrap';
 
 export type Props = Omit<AddonProps, 'children'> & {
   icon: IconType;
+
+  /**
+   * Optional extra CSS class you want to add to the component.
+   * Useful for styling the component.
+   */
+  className?: string;
 };
 
 /**
@@ -13,8 +20,10 @@ export type Props = Omit<AddonProps, 'children'> & {
  */
 export function AddonIcon({ icon, className, position }: Props) {
   return (
-    <Addon className={className} position={position}>
-      <Icon icon={icon} />
+    <Addon position={position}>
+      <InputGroupText>
+        <Icon icon={icon} className={className} />
+      </InputGroupText>
     </Addon>
   );
 }

--- a/src/form/addons/AddonIcon/__snapshots__/AddonIcon.test.tsx.snap
+++ b/src/form/addons/AddonIcon/__snapshots__/AddonIcon.test.tsx.snap
@@ -2,11 +2,15 @@
 
 exports[`Component: AddonIcon ui: Component: AddonIcon 1`] = `
 <Addon
-  className="custom-class"
   position="right"
 >
-  <Icon
-    icon="360"
-  />
+  <InputGroupText
+    tag="span"
+  >
+    <Icon
+      className="custom-class"
+      icon="360"
+    />
+  </InputGroupText>
 </Addon>
 `;

--- a/src/form/story-utils.tsx
+++ b/src/form/story-utils.tsx
@@ -28,7 +28,7 @@ export function FinalForm({ children }: Props) {
                 <SubmitButton
                   onClick={() => handleSubmit()}
                   inProgress={submitting}
-                  className="float-right"
+                  className="float-end"
                 >
                   Submit
                 </SubmitButton>

--- a/src/hooks/useBootstrapSize/useBootstrapSize.test.tsx
+++ b/src/hooks/useBootstrapSize/useBootstrapSize.test.tsx
@@ -60,12 +60,26 @@ describe('useBootstrapSize', () => {
 
   it('should return xl and desktop true when window width more than 1200 pixels', () => {
     // noinspection JSConstantReassignment
-    global.innerWidth = 1400;
+    global.innerWidth = 1300;
 
     const { result } = renderHook(() => useBootstrapSize());
 
     expect(result.current).toEqual({
       bootstrapSize: 'xl',
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true
+    });
+  });
+
+  it('should return xxl and desktop true when window width more than 1400 pixels', () => {
+    // noinspection JSConstantReassignment
+    global.innerWidth = 1600;
+
+    const { result } = renderHook(() => useBootstrapSize());
+
+    expect(result.current).toEqual({
+      bootstrapSize: 'xxl',
       isMobile: false,
       isTablet: false,
       isDesktop: true

--- a/src/hooks/useBootstrapSize/useBootstrapSize.ts
+++ b/src/hooks/useBootstrapSize/useBootstrapSize.ts
@@ -6,8 +6,9 @@ import { useEffect, useState } from 'react';
  * md: for tablets (devices with resolutions ≥ 768px).
  * lg: for laptops (devices with resolutions ≥ 992px).
  * xl: for desktops (devices with resolutions ≥ 1200px)
+ * xxl: for larger desktops (devices with resolutions ≥ 1400px)
  */
-export type BootstrapSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type BootstrapSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
 export type BootstrapInfo = {
   bootstrapSize: BootstrapSize;
@@ -73,7 +74,7 @@ function isTablet(size: BootstrapSize) {
 }
 
 function isDesktop(size: BootstrapSize) {
-  return ['lg', 'xl'].includes(size);
+  return ['lg', 'xl', 'xxl'].includes(size);
 }
 
 function getBootstrapSize(width: number): BootstrapSize {
@@ -85,7 +86,9 @@ function getBootstrapSize(width: number): BootstrapSize {
     return 'md';
   } else if (width >= 992 && width < 1200) {
     return 'lg';
-  } else {
+  } else if (width >= 1200 && width < 1400) {
     return 'xl';
+  } else {
+    return 'xxl';
   }
 }

--- a/src/styling/_bootstrap.scss
+++ b/src/styling/_bootstrap.scss
@@ -1,1 +1,31 @@
 @import '~bootstrap/scss/bootstrap';
+
+.b-t {
+  border-top: 1px solid rgba($body-color, 0.13);
+}
+.b-b {
+  border-bottom: 1px solid rgba($body-color, 0.13);
+}
+.b-l {
+  border-left: 1px solid rgba($body-color, 0.13);
+}
+.b-r {
+  border-right: 1px solid rgba($body-color, 0.13);
+}
+.b-all {
+  border: 1px solid rgba($body-color, 0.13);
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.not-clickable {
+  cursor: default !important;
+}
+
+@each $color, $value in $theme-colors {
+  .btn-#{"" + $color} {
+    color: white;
+  }
+}

--- a/src/styling/_form.scss
+++ b/src/styling/_form.scss
@@ -113,18 +113,9 @@ select.showing-placeholder {
   color: $input-placeholder-color;
 }
 
-.input-group {
-  &-append,
-  &-prepend {
-    i {
-      @extend .input-group-text;
-    }
-
-    .btn > i.material-icons {
-      border: 0;
-      background: none;
-      color: #fff;
-      padding: 0;
-    }
-  }
+.input-group .btn > i.material-icons {
+  border: 0;
+  background: none;
+  color: #fff;
+  padding: 0;
 }

--- a/src/styling/_mixins.scss
+++ b/src/styling/_mixins.scss
@@ -1,38 +1,4 @@
-.b-t {
-  border-top: 1px solid rgba($body-color, 0.13);
-}
-.b-b {
-  border-bottom: 1px solid rgba($body-color, 0.13);
-}
-.b-l {
-  border-left: 1px solid rgba($body-color, 0.13);
-}
-.b-r {
-  border-right: 1px solid rgba($body-color, 0.13);
-}
-.b-all {
-  border: 1px solid rgba($body-color, 0.13);
-}
-
-.clickable {
-  cursor: pointer;
-}
-
-.not-clickable {
-  cursor: default !important;
-}
-
-$theme-colors: (
-  primary: map-get($theme-colors, primary),
-  secondary: $gray-600,
-  success: map-get($theme-colors, success),
-  info: map-get($theme-colors, info),
-  warning: map-get($theme-colors, warning),
-  danger: map-get($theme-colors, danger),
-  light: $gray-200,
-  dark: $gray-800,
-  white: white
-);
+@use "sass:math";
 
 /// Stroke font-character
 /// @param  {Integer} $stroke - Stroke width
@@ -54,19 +20,4 @@ $theme-colors: (
 /// @return {Style}           - text-shadow
 @mixin stroke($stroke, $color) {
   text-shadow: stroke($stroke, $color);
-}
-
-// Color contrast
-@mixin color-yiq($color) {
-  $r: red($color);
-  $g: green($color);
-  $b: blue($color);
-
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
-
-  @if ($yiq >= 150) {
-    color: darken($color, 40%);
-  } @else {
-    color: lighten($color, 40%);
-  }
 }

--- a/src/styling/_variables.scss
+++ b/src/styling/_variables.scss
@@ -26,30 +26,30 @@ $teal: #5bc0de !default;
 $cyan: #17a2b8 !default;
 
 $colors: (
-  blue: $blue,
-  indigo: $indigo,
-  purple: $purple,
-  pink: $pink,
-  red: $red,
-  orange: $orange,
-  yellow: $yellow,
-  green: $green,
-  teal: $teal,
-  cyan: $cyan,
-  white: $white,
-  gray: $gray-600,
-  gray-dark: $gray-800
+  "blue": $blue,
+  "indigo": $indigo,
+  "purple": $purple,
+  "pink": $pink,
+  "red": $red,
+  "orange": $orange,
+  "yellow": $yellow,
+  "green": $green,
+  "teal": $teal,
+  "cyan": $cyan,
+  "white": $white,
+  "gray": $gray-600,
+  "gray-dark": $gray-800
 ) !default;
 
 $theme-colors: (
-  primary: $blue,
-  secondary: $gray-500,
-  success: $green,
-  info: $cyan,
-  warning: $yellow,
-  danger: $red,
-  light: $gray-100,
-  dark: $gray-800
+  "primary": $blue,
+  "secondary": $gray-600,
+  "success": $green,
+  "info": $cyan,
+  "warning": $yellow,
+  "danger": $red,
+  "light": $gray-200,
+  "dark": $gray-800
 ) !default;
 
 $body-bg: #f4f6f8 !default;
@@ -59,3 +59,4 @@ $font-family-sans-serif: -apple-system, system-ui, BlinkMacSystemFont,
   'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif !default;
 
 $input-placeholder-color: $gray-500 !default;
+$input-bg: white;

--- a/src/table/EpicTable/EpicTable.scss
+++ b/src/table/EpicTable/EpicTable.scss
@@ -38,7 +38,7 @@
 
   &-header {
     background-color: map-get($theme-colors, primary);
-    color: color-yiq(map-get($theme-colors, primary));
+    color: white;
     font-weight: bold;
     flex-grow: 1;
 
@@ -56,10 +56,6 @@
 
     select.form-control {
       padding: 0 0.2rem;
-    }
-
-    .form-group {
-      margin-bottom: 0;
     }
   }
 
@@ -93,4 +89,8 @@
 
 .user-select-none {
   user-select: none;
+}
+
+.epic-table-form-cell .mb-3 {
+  margin-bottom: 0 !important;
 }

--- a/src/table/EpicTable/EpicTable.stories.tsx
+++ b/src/table/EpicTable/EpicTable.stories.tsx
@@ -1014,21 +1014,21 @@ storiesOf('table/EpicTable', module)
     return (
       <Card body>
         <div className="d-flex mb-2">
-          <Button className="mr-1" onClick={() => setMode('loading')}>
+          <Button className="me-1" onClick={() => setMode('loading')}>
             Loading
           </Button>
-          <Button className="mr-1" onClick={() => setMode('empty')}>
+          <Button className="me-1" onClick={() => setMode('empty')}>
             Empty
           </Button>
-          <Button className="mr-1" onClick={() => setMode('error')}>
+          <Button className="me-1" onClick={() => setMode('error')}>
             Error
           </Button>
-          <Button className="mr-1" onClick={() => setMode('no-results')}>
+          <Button className="me-1" onClick={() => setMode('no-results')}>
             No results
           </Button>
 
           <Button
-            className="d-inline-block float-right"
+            className="d-inline-block float-end"
             icon="details"
             onClick={() => setDetail(true)}
           >

--- a/src/table/EpicTable/cells/EpicForm/EpicForm.scss
+++ b/src/table/EpicTable/cells/EpicForm/EpicForm.scss
@@ -12,11 +12,6 @@
     display: flex;
   }
 
-  .form-group {
-    margin: 0;
-    width: 100%;
-  }
-
   &--odd {
     .epic-table-form-cell {
       // Must be transparent otherwise the shadow of the left / right

--- a/src/table/EpicTable/cells/EpicFormCell/EpicFormCell.tsx
+++ b/src/table/EpicTable/cells/EpicFormCell/EpicFormCell.tsx
@@ -24,7 +24,7 @@ type Props = {
 export function EpicFormCell({ children, width, height }: Props) {
   return (
     <div
-      className={'epic-table-form-cell border-bottom py-1 pr-1'}
+      className={'epic-table-form-cell border-bottom py-1 pe-1'}
       style={{
         minWidth: width,
         width,

--- a/src/table/EpicTable/cells/EpicFormCell/__snapshots__/EpicFormCell.test.tsx.snap
+++ b/src/table/EpicTable/cells/EpicFormCell/__snapshots__/EpicFormCell.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component: EpicFormCell ui 1`] = `
 <div
-  className="epic-table-form-cell border-bottom py-1 pr-1"
+  className="epic-table-form-cell border-bottom py-1 pe-1"
   style={
     Object {
       "height": 48,

--- a/src/table/EpicTable/widgets/EpicDetail/EpicDetail.tsx
+++ b/src/table/EpicTable/widgets/EpicDetail/EpicDetail.tsx
@@ -35,7 +35,7 @@ type Props = {
  */
 export function EpicDetail({ children, onClose, text = {} }: Props) {
   return (
-    <div className="bg-white h-100 border-top border-right border-bottom py-1 shadow">
+    <div className="bg-white h-100 border-top border-end border-bottom py-1 shadow">
       <div className="d-flex align-items-center border-bottom">
         <Icon className="text-muted py-2 px-1" onClick={onClose} icon="close" />
         <span className="text-muted">

--- a/src/table/EpicTable/widgets/EpicDetail/__snapshots__/EpicDetail.test.tsx.snap
+++ b/src/table/EpicTable/widgets/EpicDetail/__snapshots__/EpicDetail.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component: EpicDetail ui 1`] = `
 <div
-  className="bg-white h-100 border-top border-right border-bottom py-1 shadow"
+  className="bg-white h-100 border-top border-end border-bottom py-1 shadow"
 >
   <div
     className="d-flex align-items-center border-bottom"

--- a/src/table/EpicTable/widgets/EpicSelection/EpicSelection.tsx
+++ b/src/table/EpicTable/widgets/EpicSelection/EpicSelection.tsx
@@ -28,7 +28,7 @@ export function EpicSelection({ children, checked, onChange }: Props) {
     <Label className="d-flex m-0 align-items-center">
       <Input
         type="checkbox"
-        className="m-0 ml-1 mr-2 d-inline-block position-static"
+        className="m-0 ms-1 me-2 d-inline-block position-static"
         checked={checked}
         onChange={() => onChange(!checked)}
       />

--- a/src/table/EpicTable/widgets/EpicSelection/__snapshots__/EpicSelection.test.tsx.snap
+++ b/src/table/EpicTable/widgets/EpicSelection/__snapshots__/EpicSelection.test.tsx.snap
@@ -11,12 +11,13 @@ exports[`Component: EpicSelection ui is checked 1`] = `
       "md",
       "lg",
       "xl",
+      "xxl",
     ]
   }
 >
   <Input
     checked={true}
-    className="m-0 ml-1 mr-2 d-inline-block position-static"
+    className="m-0 ms-1 me-2 d-inline-block position-static"
     onChange={[Function]}
     type="checkbox"
   />
@@ -34,12 +35,13 @@ exports[`Component: EpicSelection ui is not checked 1`] = `
       "md",
       "lg",
       "xl",
+      "xxl",
     ]
   }
 >
   <Input
     checked={false}
-    className="m-0 ml-1 mr-2 d-inline-block position-static"
+    className="m-0 ms-1 me-2 d-inline-block position-static"
     onChange={[Function]}
     type="checkbox"
   />

--- a/src/table/EpicTable/widgets/EpicSort/EpicSort.tsx
+++ b/src/table/EpicTable/widgets/EpicSort/EpicSort.tsx
@@ -29,7 +29,7 @@ export type Props = {
 export function EpicSort({ direction, onChange }: Props) {
   return (
     <Icon
-      className="pr-1"
+      className="pe-1"
       onClick={() => onChange(nextDirection(direction))}
       icon={iconForDirection(direction)}
     />

--- a/src/table/EpicTable/widgets/EpicSort/__snapshots__/EpicSort.test.tsx.snap
+++ b/src/table/EpicTable/widgets/EpicSort/__snapshots__/EpicSort.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component: EpicSort ui is ASC 1`] = `
 <Icon
-  className="pr-1"
+  className="pe-1"
   icon="arrow_drop_up"
   onClick={[Function]}
 />
@@ -10,7 +10,7 @@ exports[`Component: EpicSort ui is ASC 1`] = `
 
 exports[`Component: EpicSort ui is DESC 1`] = `
 <Icon
-  className="pr-1"
+  className="pe-1"
   icon="arrow_drop_down"
   onClick={[Function]}
 />
@@ -18,7 +18,7 @@ exports[`Component: EpicSort ui is DESC 1`] = `
 
 exports[`Component: EpicSort ui is NONE 1`] = `
 <Icon
-  className="pr-1"
+  className="pe-1"
   icon="sort"
   onClick={[Function]}
 />

--- a/src/table/FormTable/FormTable.stories.tsx
+++ b/src/table/FormTable/FormTable.stories.tsx
@@ -178,7 +178,7 @@ storiesOf('table/FormTable', module)
                       formId={'personForm' + person.id}
                       type="submit"
                       icon="save"
-                      className="mr-1"
+                      className="me-1"
                       color={dirtyPersons[person.id] ? 'primary' : 'secondary'}
                     >
                       Save
@@ -189,7 +189,7 @@ storiesOf('table/FormTable', module)
                         type="reset"
                         icon="restore"
                         color="secondary"
-                        className="mr-1"
+                        className="me-1"
                       >
                         Reset
                       </FormButton>
@@ -344,6 +344,7 @@ storiesOf('table/FormTable', module)
                     labelForOption={(option) => option.name}
                     errorMode="tooltip"
                     alignButton="right"
+                    className="mw-100"
                   />
                 </EpicFormCell>
 
@@ -381,7 +382,7 @@ storiesOf('table/FormTable', module)
                   <JarbRadioGroup
                     id={`sex-${person.id}`}
                     name="sex"
-                    className="ml-1"
+                    className="ms-1"
                     options={['male', 'female']}
                     labelForOption={(option) => option}
                     horizontal={true}
@@ -564,7 +565,7 @@ storiesOf('table/FormTable', module)
                           formId={'personForm' + person.id}
                           type="submit"
                           icon="save"
-                          className="mr-1"
+                          className="me-1"
                           color={dirty ? 'primary' : 'secondary'}
                         >
                           Save
@@ -574,7 +575,7 @@ storiesOf('table/FormTable', module)
                         type="button"
                         icon="cancel"
                         color="secondary"
-                        className="mr-1"
+                        className="me-1"
                         onClick={() => setEditingPerson(undefined)}
                       >
                         Cancel
@@ -763,7 +764,7 @@ storiesOf('table/FormTable', module)
                     <JarbRadioGroup
                       id={`sex-${person.id}`}
                       name="sex"
-                      className="ml-1"
+                      className="ms-1"
                       options={['male', 'female']}
                       labelForOption={(option) => option}
                       horizontal={true}
@@ -788,7 +789,7 @@ storiesOf('table/FormTable', module)
                           onConfirm={() => setEditingPerson(person)}
                           icon="edit"
                           color="primary"
-                          className="mr-1"
+                          className="me-1"
                           dialogText={`All progress on ${editingPerson.firstName} will be lost. Are you sure you want to edit ${person.firstName}?`}
                         >
                           Edit
@@ -798,7 +799,7 @@ storiesOf('table/FormTable', module)
                           onClick={() => setEditingPerson(person)}
                           icon="edit"
                           color="primary"
-                          className="mr-1"
+                          className="me-1"
                         >
                           Edit
                         </Button>
@@ -1209,7 +1210,7 @@ storiesOf('table/FormTable', module)
                   <JarbRadioGroup
                     id={`sex-${person.id}`}
                     name="sex"
-                    className="ml-1"
+                    className="ms-1"
                     options={['male', 'female']}
                     labelForOption={(option) => option}
                     horizontal={true}
@@ -1425,7 +1426,7 @@ storiesOf('table/FormTable', module)
 
           <Button
             onClick={paste}
-            className="ml-2"
+            className="ms-2"
             icon="assignment"
             inProgress={processingPaste}
           >
@@ -1498,7 +1499,7 @@ storiesOf('table/FormTable', module)
                       formId={'personForm' + person.id}
                       type="submit"
                       icon="save"
-                      className="mr-1"
+                      className="me-1"
                       color={dirtyPersons[person.id] ? 'primary' : 'secondary'}
                     >
                       Save
@@ -1509,7 +1510,7 @@ storiesOf('table/FormTable', module)
                         type="reset"
                         icon="restore"
                         color="secondary"
-                        className="mr-1"
+                        className="me-1"
                       >
                         Reset
                       </FormButton>
@@ -1701,7 +1702,7 @@ storiesOf('table/FormTable', module)
                   <JarbRadioGroup
                     id={`sex-${person.id}`}
                     name="sex"
-                    className="ml-1"
+                    className="ms-1"
                     options={['male', 'female']}
                     labelForOption={(option) => option}
                     horizontal={true}


### PR DESCRIPTION
Reactstrap recently released a new version that supports bootstrap v5+,
so we should be able to support bootstrap 5 from now on.

Upgraded boostrap and reactstrap dependencies.
Replaced classes as described in the Bootstrap migration guide.

Closes #618