### PR TITLE
fix: async stories no query client error

### DIFF
--- a/src/core/AsyncContent/AsyncContent.stories.tsx
+++ b/src/core/AsyncContent/AsyncContent.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import AsyncContent from './AsyncContent';
-import { useQuery } from 'react-query';
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 import { action } from '@storybook/addon-actions';
 import { ContentState, Button } from '../..';
 
@@ -26,8 +26,23 @@ function loadingData() {
   return new Promise(() => undefined);
 }
 
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      cacheTime: 0
+    }
+  },
+});
+
 storiesOf('core/async/AsyncContent', module)
   .addParameters({ component: AsyncContent })
+  .addDecorator((Story) => (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  ))
   .add('when loaded', () => {
     const state = useQuery('data', loadData);
 

--- a/src/core/AsyncList/AsyncList.stories.tsx
+++ b/src/core/AsyncList/AsyncList.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { useQuery } from 'react-query';
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 import { Button, Card, ListGroup, ListGroupItem } from 'reactstrap';
 
 import AsyncList from './AsyncList';
@@ -38,8 +38,23 @@ function loadingData(): Promise<User[]> {
   return new Promise(() => undefined);
 }
 
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      cacheTime: 0
+    }
+  }
+});
+
 storiesOf('core/Async/AsyncList', module)
   .addParameters({ component: AsyncList })
+  .addDecorator((Story) => (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  ))
   .add('when loaded', () => {
     const state = useQuery('data', loadData);
 

--- a/src/core/AsyncPage/AsyncPage.stories.tsx
+++ b/src/core/AsyncPage/AsyncPage.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { useQuery } from 'react-query';
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 import { Button, Card, ListGroup, ListGroupItem } from 'reactstrap';
 import { emptyPage, Page } from '@42.nl/spring-connect';
 
@@ -39,8 +39,23 @@ function loadingData(): Promise<Page<User>> {
   return new Promise(() => undefined);
 }
 
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      cacheTime: 0
+    }
+  }
+});
+
 storiesOf('core/async/AsyncPage', module)
   .addParameters({ component: AsyncPage })
+  .addDecorator((Story) => (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  ))
   .add('when loaded', () => {
     const state = useQuery('data', loadData);
 


### PR DESCRIPTION
In the storybook, in all AsyncContent, AsyncList and AsyncPage stories,
an error is displayed: No QueryClient set, use QueryClientProvider to
set one.

Added decorator to wrap async stories in QueryClientProvider.

Closes #624