### PR TITLE
improvement: testing custom hooks

### DIFF
--- a/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.test.ts
+++ b/src/form/NewPasswordInput/PasswordStrength/useMeterWidth/useMeterWidth.test.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useMeterWidth } from './useMeterWidth';
+import { renderHook } from '@testing-library/react';
 
 describe('Hook: useMeterWidth', () => {
   it('should set meter width based on rules', () => {
@@ -9,7 +10,7 @@ describe('Hook: useMeterWidth', () => {
     const setMeterWidthSpy = jest.fn();
     jest.spyOn(React, 'useState').mockReturnValue([ 0, setMeterWidthSpy ]);
 
-    useMeterWidth({ lowercase: true });
+    renderHook(() => useMeterWidth({ lowercase: true }));
 
     expect(setMeterWidthSpy).toBeCalledTimes(1);
     expect(setMeterWidthSpy).toBeCalledWith(100);

--- a/src/hooks/useHover/useHover.test.tsx
+++ b/src/hooks/useHover/useHover.test.tsx
@@ -1,11 +1,12 @@
 import { useHover } from './useHover';
 import React from 'react';
+import { renderHook } from '@testing-library/react';
 
 describe('useHover', () => {
   it('should set hover to true when onMouseEnter is called', () => {
     const setHoverSpy = jest.fn();
     jest.spyOn(React, 'useState').mockReturnValue([ false, setHoverSpy ]);
-    const [ , { onMouseEnter } ] = useHover();
+    const { result: { current: [ , { onMouseEnter } ] } } = renderHook(() => useHover());
     onMouseEnter();
     expect(setHoverSpy).toBeCalledTimes(1);
     expect(setHoverSpy).toBeCalledWith(true);
@@ -14,7 +15,7 @@ describe('useHover', () => {
   it('should set hover to false when onMouseLeave is called', () => {
     const setHoverSpy = jest.fn();
     jest.spyOn(React, 'useState').mockReturnValue([ true, setHoverSpy ]);
-    const [ , { onMouseLeave } ] = useHover();
+    const { result: { current: [ , { onMouseLeave } ] } } = renderHook(() => useHover());
     onMouseLeave();
     expect(setHoverSpy).toBeCalledTimes(1);
     expect(setHoverSpy).toBeCalledWith(false);


### PR DESCRIPTION
Hooks should always be tested using renderHook.

Added renderHook to useHover and useMeterWidth testing.