### PR TITLE
improvement: expose ModalPicker

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -98,6 +98,7 @@ describe('index', () => {
         "Loading": [Function],
         "LoadingPage": [Function],
         "Modal": [Function],
+        "ModalPicker": [Function],
         "ModalPickerMultiple": [Function],
         "ModalPickerSingle": [Function],
         "MoreOrLess": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export { ModalPickerSingle, JarbModalPickerSingle, FieldModalPickerSingle } from
 export type { ModalPickerSingleRenderValue } from './form/ModalPicker/single/ModalPickerSingle';
 export { ModalPickerMultiple, JarbModalPickerMultiple, FieldModalPickerMultiple } from './form/ModalPicker/multiple/ModalPickerMultiple';
 export type { ModalPickerMultipleRenderValues } from './form/ModalPicker/multiple/ModalPickerMultiple';
+export { ModalPicker } from './form/ModalPicker/ModalPicker';
 export type {
   ModalPickerAddButtonCallback,
   ModalPickerAddButtonOptions,


### PR DESCRIPTION
It might be useful to expose ModalPicker to allow developers to build
their own ModalPicker variant with more flexibility.

Exposed ModalPicker.

Closes #626