### PR TITLE
improvement: ConfirmButton disabled property

### DIFF
--- a/src/core/ConfirmButton/ConfirmButton.tsx
+++ b/src/core/ConfirmButton/ConfirmButton.tsx
@@ -63,6 +63,7 @@ export function ConfirmButton({
   color = 'danger',
   onConfirm,
   inProgress,
+  disabled,
   text = {},
   className
 }: Props) {
@@ -86,7 +87,8 @@ export function ConfirmButton({
     icon,
     children,
     fullWidth,
-    size
+    size,
+    disabled
   };
 
   return (


### PR DESCRIPTION
The ConfirmButton allows a disabled property as it is an extension to
the Button component, but it doesn't pass the property to the Button.

Changed ConfirmButton to pass disabled property to Button.

Closes #658