### PR TITLE
Updated script for POSIX compliance

### DIFF
--- a/scripts/dev-publish.sh
+++ b/scripts/dev-publish.sh
@@ -1,17 +1,15 @@
 #!/bin/sh
 
-read -p "Have you updated the package version (y/n)? " answer
-case ${answer:0:1} in
-y | Y) ;;
-
-*)
+printf -- "Have you updated the package version (y/n)? "
+read -r answer
+case $(echo "$answer" | cut -c1-1) in y | Y) ;;*)
     echo "Please do so according to https://semver.org/"
     exit 1
     ;;
 esac
 
 # Check if docker exists
-if [[ "$(docker -v 2>/dev/null)" == "" ]]; then
+if [ "$(docker -v 2>/dev/null)" = "" ]; then
     printf -- 'You dont seem to have Docker installed.\n'
     printf -- 'Get it: https://www.docker.com/community-edition\n'
     printf -- 'Exiting with code 127...\n'
@@ -26,16 +24,16 @@ if [ "$(docker ps -q -f name=verdaccio)" ]; then
     printf -- '\033[32m SUCCESS: Pulled down Verdaccio instance \033[0m\n'
 fi
 
-printf -- '\033[37m Starting verdaccio... \033[0m\n'
+printf -- '\033[37m Starting Verdaccio... \033[0m\n'
 docker run -d -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio:4.2.1 >/dev/null 2>&1
 docker start verdaccio 2>&1
-until $(curl --output /dev/null --silent --head --fail http://localhost:4873); do
+until curl --output /dev/null --silent --head --fail http://localhost:4873; do
     printf '.'
     sleep 1
 done
 printf -- '\033[32m SUCCESS: Verdaccio is now running \033[0m\n'
 
-printf -- '\033[37m Creating verdaccio user... \033[0m\n'
+printf -- '\033[37m Creating Verdaccio user... \033[0m\n'
 /usr/bin/expect <<EOD
         spawn npm adduser --registry http://localhost:4873
         expect {
@@ -45,25 +43,25 @@ printf -- '\033[37m Creating verdaccio user... \033[0m\n'
         }
 EOD
 
-printf -- '\033[32m SUCCESS: verdaccio user created \033[0m\n'
+printf -- '\033[32m SUCCESS: Verdaccio user created \033[0m\n'
 
 
 # Compile version
 printf -- '\033[37m Attempting to compile \033[0m\n'
 npm run compile
-printf -- '\033[32m SUCCESS: Succesfully compiled \033[0m\n'
+printf -- '\033[32m SUCCESS: Successfully compiled \033[0m\n'
 
 # Cleanup
 printf -- '\033[37m Cleaning up build artifacts... \033[0m\n'
 git checkout stats.html
 git checkout .size-snapshot.json
-printf -- '\033[32m SUCCESS: Succesfully cleaned up build artifacts \033[0m\n'
+printf -- '\033[32m SUCCESS: Successfully cleaned up build artifacts \033[0m\n'
 
 # Publish packages
-printf -- '\033[37m Attempting to publish to verdaccio... \033[0m\n'
+printf -- '\033[37m Attempting to publish to Verdaccio... \033[0m\n'
 npm publish --registry http://localhost:4873
-printf -- '\033[32m SUCCESS: Succesfully published packages \033[0m\n'
+printf -- '\033[32m SUCCESS: Successfully published packages \033[0m\n'
 
 # Provide instructions
 version=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
-printf -- '\033[32m Now go to your test project set the version of "@42.nl/ui" to "%s" then run "npm install --registry http://localhost:4873" \033[0m\n' $version
+printf -- '\033[32m Now go to your test project set the version of "@42.nl/ui" to "%s" then run "npm install --registry http://localhost:4873" \033[0m\n' "$version"


### PR DESCRIPTION
- read-call updated to use -r flag. Removed -p flag.
- Removed string-indexing in case.
- Removed double-bracket syntax.
- Removed $() from until-statement.

Note that almost all of these changes can be discarded by using #!/bin/bash or similar.