### PR TITLE
improvement: add total elements counter to Pagination

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -216,7 +216,8 @@ Here is a JSON notation containing all keys and default translations:
     "SEARCH_LABEL": "Start typing to search"
   },
   "Pagination": {
-    "PAGE_SIZE_DROPDOWN_LABEL": "Select page size"
+    "PAGE_SIZE_DROPDOWN_LABEL": "Select page size",
+    "TOTAL_ELEMENTS": "{{totalElements}} records found"
   }
 }
 ```

--- a/src/core/EpicPagination/EpicPagination.scss
+++ b/src/core/EpicPagination/EpicPagination.scss
@@ -28,11 +28,6 @@
       color: var(--bs-body-color);
     }
 
-    .total-elements {
-      border: var(--bs-pagination-border-width) solid transparent;
-      padding: var(--bs-pagination-padding-y) var(--bs-pagination-padding-x);
-    }
-
     .scale-to-page-size-1000 {
       font-size: small;
     }
@@ -40,5 +35,10 @@
     .scale-to-page-size-10000 {
       font-size: x-small;
     }
+  }
+
+  .total-elements {
+    border: var(--bs-pagination-border-width) solid transparent;
+    padding: var(--bs-pagination-padding-y) var(--bs-pagination-padding-x);
   }
 }

--- a/src/core/EpicPagination/EpicPagination.stories.tsx
+++ b/src/core/EpicPagination/EpicPagination.stories.tsx
@@ -47,6 +47,21 @@ storiesOf('core/EpicPagination', module)
       </div>
     );
   })
+  .add('without total elements', () => {
+    const [pageNumber, setPageNumber] = useState(5);
+
+    const page = pageOf(range(1, 100), pageNumber, 10);
+
+    return (
+      <div className="d-flex justify-content-center">
+        <EpicPagination
+          page={page}
+          onChange={setPageNumber}
+          showTotalElements={false}
+        />
+      </div>
+    );
+  })
   .add('with changeable page size', () => {
     const [pageNumber, setPageNumber] = useState(5);
     const [pageSize, setPageSize] = useState(10);

--- a/src/core/EpicPagination/EpicPagination.test.tsx
+++ b/src/core/EpicPagination/EpicPagination.test.tsx
@@ -13,6 +13,7 @@ describe('Component: EpicPagination', () => {
     totalElements = 100,
     size = 10,
     showPreviousAndNextButtons,
+    showTotalElements,
     hasPageSizeDropdown,
     allowedPageSizes
   }: {
@@ -21,6 +22,7 @@ describe('Component: EpicPagination', () => {
     totalElements?: number;
     size?: number;
     showPreviousAndNextButtons?: boolean;
+    showTotalElements?: boolean;
     hasPageSizeDropdown?: boolean;
     allowedPageSizes?: number[];
   }) {
@@ -42,6 +44,7 @@ describe('Component: EpicPagination', () => {
       page,
       onChange: onChangeSpy,
       showPreviousAndNextButtons,
+      showTotalElements,
       onPageSizeChange: hasPageSizeDropdown ? pageSizeChangeSpy : undefined,
       allowedPageSizes
     };
@@ -116,6 +119,16 @@ describe('Component: EpicPagination', () => {
     test('without page size dropdown', () => {
       setup({ hasPageSizeDropdown: false });
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+
+    test('with total elements', () => {
+      setup({ totalElements: 20, showTotalElements: true });
+      expect(screen.queryByText('20 records found')).toBeInTheDocument();
+    });
+
+    test('without total elements', () => {
+      setup({ totalElements: 20, showTotalElements: false });
+      expect(screen.queryByText('20 records found')).not.toBeInTheDocument();
     });
 
     test('with custom allowed page sizes', () => {

--- a/src/core/EpicPagination/EpicPagination.tsx
+++ b/src/core/EpicPagination/EpicPagination.tsx
@@ -14,6 +14,7 @@ import { t } from '../../utilities/translation/translation';
 
 type Text = {
   pageSizeDropdownLabel?: string;
+  totalElements?: string;
 };
 
 type Props<T> = {
@@ -47,6 +48,13 @@ type Props<T> = {
   showPreviousAndNextButtons?: boolean;
 
   /**
+   * Whether to show the total number of elements.
+   *
+   * Defaults to `true`
+   */
+  showTotalElements?: boolean;
+
+  /**
    * Optional extra CSS class you want to add to the component.
    * Useful for styling the component.
    */
@@ -71,6 +79,7 @@ export function EpicPagination<T>({
   allowedPageSizes = [5, 10, 20, 50, 100],
   className,
   showPreviousAndNextButtons = true,
+  showTotalElements = true,
   text = {}
 }: Props<T>) {
   const {
@@ -145,12 +154,17 @@ export function EpicPagination<T>({
             </PaginationItem>
           </>
         ) : null}
-        <PaginationItem disabled={true}>
-          <div className="total-elements">
-            {page.totalElements} records found
-          </div>
-        </PaginationItem>
       </RPagination>
+      {showTotalElements ? (
+        <div className="ms-3 mt-2 mt-sm-0 pagination__total-elements">
+          {t({
+            key: 'Pagination.TOTAL_ELEMENTS',
+            data: { totalElements },
+            fallback: `${totalElements} records found`,
+            overrideText: text.totalElements
+          })}
+        </div>
+      ) : null}
       {onPageSizeChange && allowedPageSizes ? (
         <Select<number>
           onChange={onPageSizeChange}

--- a/src/core/EpicPagination/__snapshots__/EpicPagination.test.tsx.snap
+++ b/src/core/EpicPagination/__snapshots__/EpicPagination.test.tsx.snap
@@ -109,18 +109,13 @@ exports[`Component: EpicPagination ui middle 1`] = `
             </i>
           </button>
         </li>
-        <li
-          class="page-item disabled"
-        >
-          <div
-            class="total-elements"
-          >
-            100
-             records found
-          </div>
-        </li>
       </ul>
     </nav>
+    <div
+      class="ms-3 mt-2 mt-sm-0 pagination__total-elements"
+    >
+      100 records found
+    </div>
   </div>
 </div>
 `;

--- a/src/core/Pagination/Pagination.scss
+++ b/src/core/Pagination/Pagination.scss
@@ -21,9 +21,17 @@
   }
 }
 
-.pagination__select-size .form-select {
-  border-color: #dee2e6;
-  min-width: 77px;
-  padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
+.pagination__total-elements {
+  padding: 0.5rem;
+}
+
+.pagination__select-size {
+  margin-bottom: 0 !important;
+
+  .form-select {
+    border-color: #dee2e6;
+    min-width: 77px;
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+  }
 }

--- a/src/core/Pagination/Pagination.stories.tsx
+++ b/src/core/Pagination/Pagination.stories.tsx
@@ -12,14 +12,17 @@ storiesOf('core/Pagination', module)
   .addDecorator((Story) => (
     <>
       <Alert color="warning" className="mb-4">
-        <p>To be able to use Pagination, you have to add @42.nl/spring-connect and lodash to your dependencies:</p>
+        <p>
+          To be able to use Pagination, you have to add @42.nl/spring-connect
+          and lodash to your dependencies:
+        </p>
         <code>npm install --save @42.nl/spring-connect lodash</code>
       </Alert>
       <Story />
     </>
   ))
   .add('default', () => {
-    const [ pageNumber, setPageNumber ] = useState(5);
+    const [pageNumber, setPageNumber] = useState(5);
 
     const page = pageOf(range(1, 100), pageNumber, 10);
 
@@ -30,7 +33,7 @@ storiesOf('core/Pagination', module)
     );
   })
   .add('without previous and next', () => {
-    const [ pageNumber, setPageNumber ] = useState(5);
+    const [pageNumber, setPageNumber] = useState(5);
 
     const page = pageOf(range(1, 100), pageNumber, 10);
 
@@ -44,9 +47,24 @@ storiesOf('core/Pagination', module)
       </div>
     );
   })
+  .add('without total elements', () => {
+    const [pageNumber, setPageNumber] = useState(5);
+
+    const page = pageOf(range(1, 100), pageNumber, 10);
+
+    return (
+      <div className="d-flex justify-content-center">
+        <Pagination
+          page={page}
+          onChange={setPageNumber}
+          showTotalElements={false}
+        />
+      </div>
+    );
+  })
   .add('with changeable page size', () => {
-    const [ pageNumber, setPageNumber ] = useState(5);
-    const [ pageSize, setPageSize ] = useState(10);
+    const [pageNumber, setPageNumber] = useState(5);
+    const [pageSize, setPageSize] = useState(10);
 
     const page = pageOf(range(1, 200), pageNumber, pageSize);
 
@@ -64,8 +82,8 @@ storiesOf('core/Pagination', module)
     );
   })
   .add('with allowed page sizes', () => {
-    const [ pageNumber, setPageNumber ] = useState(5);
-    const [ pageSize, setPageSize ] = useState(8);
+    const [pageNumber, setPageNumber] = useState(5);
+    const [pageSize, setPageSize] = useState(8);
 
     const page = pageOf(range(1, 200), pageNumber, pageSize);
 
@@ -78,7 +96,7 @@ storiesOf('core/Pagination', module)
             setPageSize(size);
             setPageNumber(1);
           }}
-          allowedPageSizes={[ 2, 4, 8, 16, 32 ]}
+          allowedPageSizes={[2, 4, 8, 16, 32]}
         />
       </div>
     );

--- a/src/core/Pagination/Pagination.test.tsx
+++ b/src/core/Pagination/Pagination.test.tsx
@@ -13,6 +13,7 @@ describe('Component: Pagination', () => {
     totalElements = 100,
     size = 10,
     showPreviousAndNextButtons,
+    showTotalElements,
     hasPageSizeDropdown,
     allowedPageSizes
   }: {
@@ -21,6 +22,7 @@ describe('Component: Pagination', () => {
     totalElements?: number;
     size?: number;
     showPreviousAndNextButtons?: boolean;
+    showTotalElements?: boolean;
     hasPageSizeDropdown?: boolean;
     allowedPageSizes?: number[];
   }) {
@@ -42,13 +44,12 @@ describe('Component: Pagination', () => {
       page,
       onChange: onChangeSpy,
       showPreviousAndNextButtons,
+      showTotalElements,
       onPageSizeChange: hasPageSizeDropdown ? pageSizeChangeSpy : undefined,
       allowedPageSizes
     };
 
-    const { container } = render(
-      <Pagination {...props} />
-    );
+    const { container } = render(<Pagination {...props} />);
 
     return { container, onChangeSpy, pageSizeChangeSpy };
   }
@@ -84,13 +85,27 @@ describe('Component: Pagination', () => {
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
     });
 
+    test('with total elements', () => {
+      setup({ totalElements: 20, showTotalElements: true });
+      expect(screen.queryByText('20 records found')).toBeInTheDocument();
+    });
+
+    test('without total elements', () => {
+      setup({ totalElements: 20, showTotalElements: false });
+      expect(screen.queryByText('20 records found')).not.toBeInTheDocument();
+    });
+
     test('with custom allowed page sizes', () => {
-      setup({ hasPageSizeDropdown: true, size: 3, allowedPageSizes: [ 3, 6 ] });
+      setup({ hasPageSizeDropdown: true, size: 3, allowedPageSizes: [3, 6] });
       expect(screen.queryAllByRole('option').length).toBe(2);
       expect(screen.queryByRole('option', { name: '3' })).toBeInTheDocument();
       expect(screen.queryByRole('option', { name: '6' })).toBeInTheDocument();
-      expect(screen.queryByRole('option', { name: '5' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('option', { name: '10' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', { name: '5' })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', { name: '10' })
+      ).not.toBeInTheDocument();
     });
 
     test('without previous and next buttons', () => {
@@ -107,23 +122,35 @@ describe('Component: Pagination', () => {
 
     it('should disable the previous button when on the first page', () => {
       setup({ number: 1, totalPages: 3 });
-      expect(screen.getByText('arrow_back').parentNode?.parentNode).toHaveClass('disabled');
+      expect(screen.getByText('arrow_back').parentNode?.parentNode).toHaveClass(
+        'disabled'
+      );
     });
 
     it('should disable the next button when on the last page', () => {
       setup({ number: 3, totalPages: 3 });
-      expect(screen.getByText('arrow_forward').parentNode?.parentNode).toHaveClass('disabled');
+      expect(
+        screen.getByText('arrow_forward').parentNode?.parentNode
+      ).toHaveClass('disabled');
     });
 
     it('should return null when onPageSizeChange is defined but the total number of elements does not exceed the minimum page size', () => {
-      const { container } = setup({ hasPageSizeDropdown: true, totalElements: 5, totalPages: 1 });
+      const { container } = setup({
+        hasPageSizeDropdown: true,
+        totalElements: 5,
+        totalPages: 1
+      });
       expect(container.firstChild).toBeNull();
     });
   });
 
   describe('events', () => {
     it('should call onChange when pagination links are clicked', () => {
-      const { onChangeSpy } = setup({ number: 5, totalPages: 10, showPreviousAndNextButtons: false });
+      const { onChangeSpy } = setup({
+        number: 5,
+        totalPages: 10,
+        showPreviousAndNextButtons: false
+      });
 
       fireEvent.click(screen.getByText('1'));
 
@@ -179,41 +206,41 @@ describe('Component: Pagination', () => {
 
 describe('pages', () => {
   test('exact middle', () => {
-    expect(pagesFor(5, 10)).toEqual([ 1, '...', 4, 5, 6, '...', 10 ]);
+    expect(pagesFor(5, 10)).toEqual([1, '...', 4, 5, 6, '...', 10]);
   });
 
   test('almost middle', () => {
-    expect(pagesFor(5, 10)).toEqual([ 1, '...', 4, 5, 6, '...', 10 ]);
-    expect(pagesFor(6, 10)).toEqual([ 1, '...', 5, 6, 7, '...', 10 ]);
+    expect(pagesFor(5, 10)).toEqual([1, '...', 4, 5, 6, '...', 10]);
+    expect(pagesFor(6, 10)).toEqual([1, '...', 5, 6, 7, '...', 10]);
   });
 
   test('absolute left', () => {
-    expect(pagesFor(1, 10)).toEqual([ 1, 2, 3, '...', 8, 9, 10 ]);
+    expect(pagesFor(1, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
   });
 
   test('almost left', () => {
-    expect(pagesFor(2, 10)).toEqual([ 1, 2, 3, '...', 8, 9, 10 ]);
-    expect(pagesFor(3, 10)).toEqual([ 1, 2, 3, 4, '...', 9, 10 ]);
-    expect(pagesFor(4, 10)).toEqual([ 1, 2, 3, 4, 5, '...', 10 ]);
+    expect(pagesFor(2, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
+    expect(pagesFor(3, 10)).toEqual([1, 2, 3, 4, '...', 9, 10]);
+    expect(pagesFor(4, 10)).toEqual([1, 2, 3, 4, 5, '...', 10]);
   });
 
   test('almost right', () => {
-    expect(pagesFor(7, 10)).toEqual([ 1, '...', 6, 7, 8, 9, 10 ]);
-    expect(pagesFor(8, 10)).toEqual([ 1, 2, '...', 7, 8, 9, 10 ]);
-    expect(pagesFor(9, 10)).toEqual([ 1, 2, 3, '...', 8, 9, 10 ]);
+    expect(pagesFor(7, 10)).toEqual([1, '...', 6, 7, 8, 9, 10]);
+    expect(pagesFor(8, 10)).toEqual([1, 2, '...', 7, 8, 9, 10]);
+    expect(pagesFor(9, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
   });
 
   test('absolute right', () => {
-    expect(pagesFor(10, 10)).toEqual([ 1, 2, 3, '...', 8, 9, 10 ]);
+    expect(pagesFor(10, 10)).toEqual([1, 2, 3, '...', 8, 9, 10]);
   });
 
   test('shortage', () => {
-    expect(pagesFor(1, 3)).toEqual([ 1, 2, 3 ]);
-    expect(pagesFor(3, 3)).toEqual([ 1, 2, 3 ]);
-    expect(pagesFor(1, 7)).toEqual([ 1, 2, 3, 4, 5, 6, 7 ]);
-    expect(pagesFor(4, 7)).toEqual([ 1, 2, 3, 4, 5, 6, 7 ]);
-    expect(pagesFor(7, 7)).toEqual([ 1, 2, 3, 4, 5, 6, 7 ]);
-    expect(pagesFor(1, 8)).toEqual([ 1, 2, 3, '...', 6, 7, 8 ]);
-    expect(pagesFor(8, 8)).toEqual([ 1, 2, 3, '...', 6, 7, 8 ]);
+    expect(pagesFor(1, 3)).toEqual([1, 2, 3]);
+    expect(pagesFor(3, 3)).toEqual([1, 2, 3]);
+    expect(pagesFor(1, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pagesFor(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pagesFor(7, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pagesFor(1, 8)).toEqual([1, 2, 3, '...', 6, 7, 8]);
+    expect(pagesFor(8, 8)).toEqual([1, 2, 3, '...', 6, 7, 8]);
   });
 });

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Page } from '@42.nl/spring-connect';
 
-import { Pagination as RPagination, PaginationItem, PaginationLink } from 'reactstrap';
+import {
+  Pagination as RPagination,
+  PaginationItem,
+  PaginationLink
+} from 'reactstrap';
 
 import { Icon } from '../Icon';
 import { range } from 'lodash';
@@ -10,6 +14,7 @@ import { t } from '../../utilities/translation/translation';
 
 type Text = {
   pageSizeDropdownLabel?: string;
+  totalElements?: string;
 };
 
 type Props<T> = {
@@ -43,6 +48,13 @@ type Props<T> = {
   showPreviousAndNextButtons?: boolean;
 
   /**
+   * Whether to show the total number of elements.
+   *
+   * Defaults to `true`
+   */
+  showTotalElements?: boolean;
+
+  /**
    * Optional extra CSS class you want to add to the component.
    * Useful for styling the component.
    */
@@ -64,16 +76,29 @@ export function Pagination<T>({
   page,
   onChange,
   onPageSizeChange,
-  allowedPageSizes = [ 5, 10, 20, 50, 100 ],
+  allowedPageSizes = [5, 10, 20, 50, 100],
   className,
   showPreviousAndNextButtons = true,
+  showTotalElements = true,
   text = {}
 }: Props<T>) {
-  const { first, last, totalPages, totalElements, size, number: current } = page;
+  const {
+    first,
+    last,
+    totalPages,
+    totalElements,
+    size,
+    number: current
+  } = page;
   const content = pagesFor(current, totalPages);
 
   // Don't bother to render if there is nothing to paginate.
-  if (first && last && (!onPageSizeChange || allowedPageSizes && allowedPageSizes[0] >= totalElements)) {
+  if (
+    first &&
+    last &&
+    (!onPageSizeChange ||
+      (allowedPageSizes && allowedPageSizes[0] >= totalElements))
+  ) {
     return null;
   }
 
@@ -108,6 +133,16 @@ export function Pagination<T>({
           </PaginationItem>
         ) : null}
       </RPagination>
+      {showTotalElements ? (
+        <div className="ms-3 mt-2 mt-sm-0 pagination__total-elements">
+          {t({
+            key: 'Pagination.TOTAL_ELEMENTS',
+            data: { totalElements },
+            fallback: `${totalElements} records found`,
+            overrideText: text.totalElements
+          })}
+        </div>
+      ) : null}
       {onPageSizeChange && allowedPageSizes ? (
         <Select<number>
           onChange={onPageSizeChange}
@@ -146,9 +181,12 @@ export function pagesFor(
     // 1 2 3 {4} 5 ... 31
 
     const tillEllipsis = range(1, Math.max(4, currentPage + 2));
-    const fromEllipsis = range(totalPages - (5 - tillEllipsis.length), totalPages + 1);
+    const fromEllipsis = range(
+      totalPages - (5 - tillEllipsis.length),
+      totalPages + 1
+    );
 
-    return [ ...tillEllipsis, ellipsis, ...fromEllipsis ];
+    return [...tillEllipsis, ellipsis, ...fromEllipsis];
   }
 
   if (currentPage > totalPages - 4) {
@@ -156,11 +194,20 @@ export function pagesFor(
     // till
     // 1 2 3 ... 29 30 {31}
 
-    const fromEllipsis = range(Math.min(totalPages - 2, currentPage - 1), totalPages + 1);
+    const fromEllipsis = range(
+      Math.min(totalPages - 2, currentPage - 1),
+      totalPages + 1
+    );
     const tillEllipsis = range(1, 7 - fromEllipsis.length);
 
-    return [ ...tillEllipsis, ellipsis, ...fromEllipsis ];
+    return [...tillEllipsis, ellipsis, ...fromEllipsis];
   }
 
-  return [ 1, ellipsis, ...range(currentPage - 1, currentPage + 2), ellipsis, totalPages ];
+  return [
+    1,
+    ellipsis,
+    ...range(currentPage - 1, currentPage + 2),
+    ellipsis,
+    totalPages
+  ];
 }

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -106,6 +106,11 @@ exports[`Component: Pagination ui first page 1`] = `
         </li>
       </ul>
     </nav>
+    <div
+      class="ms-3 mt-2 mt-sm-0 pagination__total-elements"
+    >
+      100 records found
+    </div>
   </div>
 </div>
 `;
@@ -216,6 +221,11 @@ exports[`Component: Pagination ui last page 1`] = `
         </li>
       </ul>
     </nav>
+    <div
+      class="ms-3 mt-2 mt-sm-0 pagination__total-elements"
+    >
+      100 records found
+    </div>
   </div>
 </div>
 `;
@@ -327,6 +337,11 @@ exports[`Component: Pagination ui middle 1`] = `
         </li>
       </ul>
     </nav>
+    <div
+      class="ms-3 mt-2 mt-sm-0 pagination__total-elements"
+    >
+      100 records found
+    </div>
   </div>
 </div>
 `;

--- a/src/form/ModalPicker/ModalPicker.tsx
+++ b/src/form/ModalPicker/ModalPicker.tsx
@@ -1,14 +1,29 @@
 import React from 'react';
 import { Page } from '@42.nl/spring-connect';
-import { Button, Col, Modal, ModalBody, ModalFooter, ModalHeader, Row } from 'reactstrap';
+import {
+  Button,
+  Col,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Row
+} from 'reactstrap';
 
 import { Pagination } from '../../core/Pagination/Pagination';
 import { t } from '../../utilities/translation/translation';
 import { SearchInput } from '../../core/SearchInput/SearchInput';
 import { ContentState } from '../../core/ContentState/ContentState';
 import { EmptyModal } from './EmptyModal';
-import { ModalPickerRenderOptions, ModalPickerRenderOptionsOption } from './types';
-import { FieldCompatibleWithPredeterminedOptions, IsOptionEnabled, isOptionSelected } from '../option';
+import {
+  ModalPickerRenderOptions,
+  ModalPickerRenderOptionsOption
+} from './types';
+import {
+  FieldCompatibleWithPredeterminedOptions,
+  IsOptionEnabled,
+  isOptionSelected
+} from '../option';
 
 export type Text = {
   placeholder?: string;
@@ -110,8 +125,10 @@ type Props<T> = {
   selected: T | T[];
 };
 
-export type RenderOptionsConfig<T> = Omit<FieldCompatibleWithPredeterminedOptions<T>,
-  'options' | 'reloadOptions' | 'isOptionEnabled'> & {
+export type RenderOptionsConfig<T> = Omit<
+  FieldCompatibleWithPredeterminedOptions<T>,
+  'options' | 'reloadOptions' | 'isOptionEnabled'
+> & {
   // It is always provided by the ModalPickerSingle and ModalPickerMultiple
   isOptionEnabled: IsOptionEnabled<T>;
 
@@ -186,7 +203,11 @@ export function ModalPicker<T>(props: Props<T>) {
 
       {shouldRenderPagination ? (
         <ModalFooter className="d-flex justify-content-center">
-          <Pagination page={page} onChange={(page) => pageChanged(page)} />
+          <Pagination
+            page={page}
+            onChange={(page) => pageChanged(page)}
+            showTotalElements={false}
+          />
         </ModalFooter>
       ) : null}
 


### PR DESCRIPTION
The EpicPagination displays the total number of elements. I would like to see that in the Pagination component as well.

Added total elements to Pagination component.
Changed total elements in EpicPagination to be translatable string. Added possibility to hide total elements in Pagination and EpicPagination.

Closes #687