### PR TITLE
improvement: codecov only once in workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,12 +4,11 @@ on: [ push ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 18.x, 20.x ]
+        node-version: [ 16.x, 18.x, 20.x ]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +21,9 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-${{ matrix.node-version }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-node-
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup timezone
         uses: zcong1993/setup-timezone@v1.1.2
         with:
@@ -35,6 +36,22 @@ jobs:
       - run: npm run storybook:build
         env:
           CI: true
+      - uses: actions/upload-artifact@v3
+        if: matrix.node-version == '20.x'
+        with:
+          path: ./coverage
+          name: code-coverage
+
+  codecov:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: code-coverage
+          path: ./coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Currently, we upload the code coverage to codecov on every build, so at this moment 4 times for 4 node versions. We should only check code coverage once.

Separated upload to codecov into its own job using artifact that's only built once in build job.